### PR TITLE
Minor restructure

### DIFF
--- a/GUI/Commands/EditBatchCommand.py
+++ b/GUI/Commands/EditBatchCommand.py
@@ -4,7 +4,7 @@ from GUI.ProjectDataModel import ProjectDataModel
 from GUI.ViewModel.ViewModelUpdate import ModelUpdate
 from GUI.ViewModel.ViewModelUpdateSection import UpdateValue
 from PySubtitle.SubtitleBatch import SubtitleBatch
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 
 import logging
 from PySubtitle.Helpers.Localization import _
@@ -23,7 +23,7 @@ class EditBatchCommand(Command):
         if not self.datamodel or not self.datamodel.project:
             raise CommandError(_("No project data"), command=self)
 
-        subtitles : SubtitleFile = self.datamodel.project.subtitles
+        subtitles : Subtitles = self.datamodel.project.subtitles
         if not subtitles:
             raise CommandError(_("Unable to edit batch because datamodel is invalid"), command=self)
 
@@ -56,7 +56,7 @@ class EditBatchCommand(Command):
         if not self.undo_data:
             raise CommandError(_("No undo data available"), command=self)
 
-        subtitles : SubtitleFile = self.datamodel.project.subtitles
+        subtitles : Subtitles = self.datamodel.project.subtitles
 
         with subtitles.lock:
             batch : SubtitleBatch = subtitles.GetBatch(self.scene_number, self.batch_number)

--- a/GUI/Commands/EditLineCommand.py
+++ b/GUI/Commands/EditLineCommand.py
@@ -8,7 +8,7 @@ from GUI.ViewModel.ViewModelUpdate import ModelUpdate
 from PySubtitle.Helpers.Time import GetTimeDelta
 from PySubtitle.SubtitleBatch import SubtitleBatch
 from PySubtitle.SubtitleLine import SubtitleLine
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 
 from PySubtitle.SubtitleValidator import SubtitleValidator
 from PySubtitle.Helpers.Localization import _
@@ -26,7 +26,7 @@ class EditLineCommand(Command):
         if not self.datamodel or not self.datamodel.project:
             raise CommandError(_("No project data"), command=self)
 
-        subtitles : SubtitleFile = self.datamodel.project.subtitles
+        subtitles : Subtitles = self.datamodel.project.subtitles
         if not subtitles:
             raise CommandError(_("Unable to edit batch because datamodel is invalid"), command=self)
 
@@ -94,7 +94,7 @@ class EditLineCommand(Command):
         if not self.undo_data:
             raise CommandError(_("No undo data available"), command=self)
 
-        subtitles : SubtitleFile = self.datamodel.project.subtitles
+        subtitles : Subtitles = self.datamodel.project.subtitles
 
         with subtitles.lock:
             batch : SubtitleBatch|None = subtitles.GetBatchContainingLine(self.line_number)

--- a/GUI/Commands/EditSceneCommand.py
+++ b/GUI/Commands/EditSceneCommand.py
@@ -4,7 +4,7 @@ from GUI.Command import Command, CommandError
 from GUI.ProjectDataModel import ProjectDataModel
 from GUI.ViewModel.ViewModelUpdate import ModelUpdate
 from PySubtitle.Helpers.Localization import _
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleScene import SubtitleScene
 
 class EditSceneCommand(Command):
@@ -20,7 +20,7 @@ class EditSceneCommand(Command):
         if not self.datamodel or not self.datamodel.project:
             raise CommandError(_("No project data"), command=self)
 
-        subtitles : SubtitleFile = self.datamodel.project.subtitles
+        subtitles : Subtitles = self.datamodel.project.subtitles
         if not subtitles:
             raise CommandError("Unable to edit scene because datamodel is invalid", command=self)
 
@@ -51,7 +51,7 @@ class EditSceneCommand(Command):
         if not self.undo_data:
             raise CommandError(_("No undo data available"), command=self)
 
-        subtitles : SubtitleFile = self.datamodel.project.subtitles
+        subtitles : Subtitles = self.datamodel.project.subtitles
 
         with subtitles.lock:
             scene = subtitles.GetScene(self.scene_number)

--- a/GUI/Commands/LoadSubtitleFile.py
+++ b/GUI/Commands/LoadSubtitleFile.py
@@ -34,7 +34,7 @@ class LoadSubtitleFile(Command):
             # Write a backup if an existing project was loaded
             if self.write_backup and project.read_project:
                 logging.info(_("Saving backup copy of the project"))
-                project.WriteBackupFile()
+                project.SaveBackupFile()
 
             self.project = project
             self.datamodel = ProjectDataModel(project, self.options)

--- a/GUI/Commands/MergeLinesCommand.py
+++ b/GUI/Commands/MergeLinesCommand.py
@@ -2,7 +2,7 @@ from GUI.Command import Command, CommandError, UndoError
 from GUI.ProjectDataModel import ProjectDataModel
 from GUI.ViewModel.ViewModelUpdate import ModelUpdate
 from PySubtitle.SubtitleBatch import SubtitleBatch
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleProject import SubtitleProject
 from PySubtitle.Helpers.Localization import _
 
@@ -21,7 +21,7 @@ class MergeLinesCommand(Command):
         if not self.datamodel or not self.datamodel.project:
             raise CommandError(_("No project data"), command=self)
 
-        subtitles : SubtitleFile = self.datamodel.project.subtitles
+        subtitles : Subtitles = self.datamodel.project.subtitles
 
         if not subtitles:
             raise CommandError(_("No subtitles"), command=self)
@@ -78,7 +78,7 @@ class MergeLinesCommand(Command):
         if not self.undo_data:
             raise UndoError(_("No undo data available"), command=self)
 
-        subtitles : SubtitleFile = self.datamodel.project.subtitles
+        subtitles : Subtitles = self.datamodel.project.subtitles
 
         updates = {}
         for scene_number, batch_number, original_lines, translated_lines in self.undo_data:

--- a/GUI/Commands/MergeScenesCommand.py
+++ b/GUI/Commands/MergeScenesCommand.py
@@ -3,7 +3,7 @@ import logging
 from GUI.Command import Command, CommandError, UndoError
 from GUI.ProjectDataModel import ProjectDataModel
 from GUI.ViewModel.ViewModelUpdate import ModelUpdate
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.Helpers.Localization import _
 
 class MergeScenesCommand(Command):
@@ -22,7 +22,7 @@ class MergeScenesCommand(Command):
         if not self.datamodel or not self.datamodel.project:
             raise CommandError(_("No project data"), command=self)
 
-        subtitles : SubtitleFile = self.datamodel.project.subtitles
+        subtitles : Subtitles = self.datamodel.project.subtitles
 
         if len(self.scene_numbers) < 2:
             raise CommandError(_("Cannot merge less than two scenes"), command=self)
@@ -54,7 +54,7 @@ class MergeScenesCommand(Command):
         if not self.datamodel or not self.datamodel.project:
             raise CommandError(_("No project data"), command=self)
 
-        subtitles : SubtitleFile = self.datamodel.project.subtitles
+        subtitles : Subtitles = self.datamodel.project.subtitles
 
         model_update : ModelUpdate =  self.AddModelUpdate()
 

--- a/GUI/Commands/ReparseTranslationsCommand.py
+++ b/GUI/Commands/ReparseTranslationsCommand.py
@@ -4,7 +4,7 @@ from GUI.ViewModel.ViewModelUpdate import ModelUpdate
 from GUI.ViewModel.ViewModelUpdateSection import BatchKey, LineKey, UpdateValue
 from PySubtitle.Options import Options
 from PySubtitle.SubtitleBatch import SubtitleBatch
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleProject import SubtitleProject
 from PySubtitle.SubtitleTranslator import SubtitleTranslator
 from PySubtitle.Helpers.Localization import _
@@ -33,7 +33,7 @@ class ReparseTranslationsCommand(Command):
             raise CommandError(_("No project data"), command=self)
 
         project : SubtitleProject = self.datamodel.project
-        subtitles : SubtitleFile = project.subtitles
+        subtitles : Subtitles = project.subtitles
         options : Options = self.datamodel.project_options
         translation_provider : TranslationProvider|None = self.datamodel.translation_provider
 
@@ -93,7 +93,7 @@ class ReparseTranslationsCommand(Command):
             raise CommandError(_("No project data"), command=self)
 
         project : SubtitleProject = self.datamodel.project
-        subtitles : SubtitleFile = project.subtitles
+        subtitles : Subtitles = project.subtitles
         options = self.datamodel.project_options
         validator = SubtitleValidator(options)
 

--- a/GUI/Commands/SaveProjectFile.py
+++ b/GUI/Commands/SaveProjectFile.py
@@ -20,7 +20,7 @@ class SaveProjectFile(Command):
 
         self.project.projectfile = self.project.GetProjectFilepath(self.filepath)
         self.project.subtitles.outputpath = GetOutputPath(self.project.projectfile, self.project.target_language)
-        self.project.WriteProjectFile()
+        self.project.SaveProjectFile()
 
         if self.project.subtitles.translated:
             self.project.SaveTranslation()

--- a/GUI/Commands/StartTranslationCommand.py
+++ b/GUI/Commands/StartTranslationCommand.py
@@ -6,7 +6,7 @@ from GUI.ProjectDataModel import ProjectDataModel
 from GUI.Commands.TranslateSceneCommand import TranslateSceneCommand
 from PySubtitle.Helpers.Localization import _
 
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleProject import SubtitleProject
 
 class StartTranslationCommand(Command):
@@ -23,7 +23,7 @@ class StartTranslationCommand(Command):
             raise CommandError(_("Nothing to translate"), command=self)
 
         project : SubtitleProject = self.datamodel.project
-        subtitles : SubtitleFile = project.subtitles
+        subtitles : Subtitles = project.subtitles
 
         if self.resume and subtitles.scenes and all(scene.all_translated for scene in subtitles.scenes):
             logging.info(_("All scenes are fully translated"))

--- a/GUI/Commands/SwapTextAndTranslations.py
+++ b/GUI/Commands/SwapTextAndTranslations.py
@@ -2,7 +2,7 @@ from GUI.Command import Command, CommandError
 from GUI.ProjectDataModel import ProjectDataModel
 from GUI.ViewModel.ViewModelUpdate import ModelUpdate
 from PySubtitle.Helpers.Localization import _
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleProject import SubtitleProject
 
 import logging
@@ -32,7 +32,7 @@ class SwapTextAndTranslations(Command):
             raise CommandError(_("No project data"), command=self)
 
         project : SubtitleProject = self.datamodel.project
-        subtitles : SubtitleFile = project.subtitles
+        subtitles : Subtitles = project.subtitles
         batch = subtitles.GetBatch(self.scene_number, self.batch_number)
 
         # Swap original and translated text (only in the viewmodel)

--- a/GUI/UnitTests/DataModelHelpers.py
+++ b/GUI/UnitTests/DataModelHelpers.py
@@ -3,7 +3,7 @@ from PySubtitle.Helpers.TestCases import AddTranslations, PrepareSubtitles
 from PySubtitle.Options import Options
 from PySubtitle.SettingsType import SettingsType
 from PySubtitle.SubtitleBatcher import SubtitleBatcher
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleProject import SubtitleProject
 
 
@@ -12,7 +12,7 @@ def CreateTestDataModel(test_data : dict, options : Options|None = None) -> Proj
     Creates a ProjectDataModel from test data.
     """
     options = options or Options()
-    file : SubtitleFile = PrepareSubtitles(test_data, 'original')
+    file : Subtitles = PrepareSubtitles(test_data, 'original')
     project = SubtitleProject(options)
     project.subtitles = file
     project.UpdateProjectSettings(options)
@@ -30,7 +30,7 @@ def CreateTestDataModelBatched(test_data : dict, options : Options|None = None, 
 
     options = options or datamodel.project_options
 
-    subtitles : SubtitleFile = datamodel.project.subtitles
+    subtitles : Subtitles = datamodel.project.subtitles
     batcher = SubtitleBatcher(options.GetSettings())
     subtitles.AutoBatch(batcher)
 

--- a/GUI/UnitTests/test_BatchCommands.py
+++ b/GUI/UnitTests/test_BatchCommands.py
@@ -4,7 +4,7 @@ from GUI.ProjectDataModel import ProjectDataModel
 from GUI.UnitTests.DataModelHelpers import CreateTestDataModel
 from PySubtitle.Helpers.TestCases import SubtitleTestCase
 from PySubtitle.Helpers.Tests import log_input_expected_result, log_test_name
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.UnitTests.TestData.chinese_dinner import chinese_dinner_data
 
 class BatchCommandTests(SubtitleTestCase):
@@ -28,13 +28,13 @@ class BatchCommandTests(SubtitleTestCase):
                 self.fail("Failed to create datamodel for test case")
                 continue
 
-            file : SubtitleFile = datamodel.project.subtitles
+            file : Subtitles = datamodel.project.subtitles
 
             with self.subTest("BatchSubtitlesCommand"):
                 self.BatchSubtitlesCommandTest(file, datamodel, test_case)
 
 
-    def BatchSubtitlesCommandTest(self, file : SubtitleFile, datamodel : ProjectDataModel, test_data : dict):
+    def BatchSubtitlesCommandTest(self, file : Subtitles, datamodel : ProjectDataModel, test_data : dict):
         if not datamodel.project or not datamodel.project.subtitles:
             self.fail("Failed to create datamodel for test case")
             return

--- a/GUI/UnitTests/test_DataModel.py
+++ b/GUI/UnitTests/test_DataModel.py
@@ -3,7 +3,7 @@ from GUI.UnitTests.DataModelHelpers import CreateTestDataModel
 from PySubtitle.Helpers.TestCases import SubtitleTestCase
 from PySubtitle.Helpers.Tests import log_input_expected_result, log_test_name
 from PySubtitle.Options import Options, SettingsType
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleProject import SubtitleProject
 from GUI.UnitTests.TestData.chinese_dinner import chinese_dinner_data
 
@@ -25,7 +25,7 @@ class DataModelTests(SubtitleTestCase):
         project = SubtitleProject(global_options)
         
         # Simulate loading a subtitle file with project settings
-        project_file = SubtitleFile()
+        project_file = Subtitles()
         original_subtitles = chinese_dinner_data.get_str('original')
         if original_subtitles is None:
             self.fail("Couldn't load subtitles")
@@ -140,7 +140,7 @@ class DataModelTests(SubtitleTestCase):
         
         # Create first project
         project1 = SubtitleProject(global_options)
-        project1_file = SubtitleFile()
+        project1_file = Subtitles()
         original_subtitles1 = chinese_dinner_data.get_str('original')
         if original_subtitles1 is None:
             self.fail("Couldn't load subtitles")
@@ -155,7 +155,7 @@ class DataModelTests(SubtitleTestCase):
         
         # Create second project
         project2 = SubtitleProject(global_options)
-        project2_file = SubtitleFile()
+        project2_file = Subtitles()
         original_subtitles2 = chinese_dinner_data.get_str('original')
         if original_subtitles2 is None:
             self.fail("Couldn't load subtitles")
@@ -235,7 +235,7 @@ class DataModelTests(SubtitleTestCase):
         
         # Create project with different provider settings
         project = SubtitleProject(global_options)
-        project_file = SubtitleFile()
+        project_file = Subtitles()
         original_subtitles3 = chinese_dinner_data.get_str('original')
         if original_subtitles3 is None:
             self.fail("Couldn't load subtitles")
@@ -288,7 +288,7 @@ class DataModelTests(SubtitleTestCase):
         
         datamodel.UpdateSettings(new_settings)
         
-        # All settings should be updated since there's no project to restore from
+        # All settings should be updated since there's no project to restore from (this is a bit of a nonsense test)
         max_threads_no_project = datamodel.project_options.get_int('max_threads')
         
         log_input_expected_result("Provider with no project", 'Dummy Claude', datamodel.project_options.provider)

--- a/GUI/UnitTests/test_DeleteLinesCommand.py
+++ b/GUI/UnitTests/test_DeleteLinesCommand.py
@@ -5,7 +5,7 @@ from GUI.ProjectDataModel import ProjectDataModel
 from GUI.UnitTests.DataModelHelpers import CreateTestDataModelBatched
 from PySubtitle.Helpers.TestCases import SubtitleTestCase
 from PySubtitle.Helpers.Tests import log_info, log_input_expected_result, log_test_name
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.UnitTests.TestData.chinese_dinner import chinese_dinner_data
 
 class DeleteLinesCommandTest(SubtitleTestCase):
@@ -53,7 +53,7 @@ class DeleteLinesCommandTest(SubtitleTestCase):
             self.fail("Failed to create test datamodel with subtitles")
             return
 
-        subtitles: SubtitleFile = datamodel.project.subtitles
+        subtitles: Subtitles = datamodel.project.subtitles
 
         for test_case in self.delete_lines_test_cases:
             scene_number, batch_number = test_case['batch_number']

--- a/GUI/UnitTests/test_EditCommands.py
+++ b/GUI/UnitTests/test_EditCommands.py
@@ -10,7 +10,7 @@ from GUI.ProjectDataModel import ProjectDataModel
 from GUI.UnitTests.DataModelHelpers import CreateTestDataModelBatched
 from PySubtitle.Helpers.TestCases import SubtitleTestCase
 from PySubtitle.Helpers.Tests import log_input_expected_result, log_test_name
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.UnitTests.TestData.chinese_dinner import chinese_dinner_data
 
 class EditCommandsTests(SubtitleTestCase):
@@ -62,7 +62,7 @@ class EditCommandsTests(SubtitleTestCase):
             assert datamodel.project is not None  # Type narrowing for PyLance
             self.assertIsNotNone(datamodel.project.subtitles)
             
-            subtitles: SubtitleFile = datamodel.project.subtitles
+            subtitles: Subtitles = datamodel.project.subtitles
             undo_stack: list[Command] = []
 
             for command_data in test_case['tests']:
@@ -98,7 +98,7 @@ class EditCommandsTests(SubtitleTestCase):
             reference_subtitles = reference_datamodel.project.subtitles
             self._assert_same_as_reference(subtitles, reference_subtitles)
 
-    def EditSceneCommandTest(self, subtitles: SubtitleFile, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> Command:
+    def EditSceneCommandTest(self, subtitles: Subtitles, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> Command:
         scene_number: int = test_data['scene_number']
 
         scene = subtitles.GetScene(scene_number)
@@ -131,7 +131,7 @@ class EditCommandsTests(SubtitleTestCase):
 
         return edit_scene_command
 
-    def EditBatchCommandTest(self, subtitles: SubtitleFile, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> Command:
+    def EditBatchCommandTest(self, subtitles: Subtitles, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> Command:
         scene_number, batch_number = test_data['batch_number']
 
         scene = subtitles.GetScene(scene_number)
@@ -168,7 +168,7 @@ class EditCommandsTests(SubtitleTestCase):
 
         return edit_batch_command
 
-    def EditLineCommandTest(self, subtitles: SubtitleFile, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> Command:
+    def EditLineCommandTest(self, subtitles: Subtitles, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> Command:
         line_number: int = test_data['line_number']
 
         batch = subtitles.GetBatchContainingLine(line_number)

--- a/GUI/UnitTests/test_MergeLinesCommand.py
+++ b/GUI/UnitTests/test_MergeLinesCommand.py
@@ -6,7 +6,7 @@ from GUI.Commands.MergeLinesCommand import MergeLinesCommand
 from GUI.UnitTests.DataModelHelpers import CreateTestDataModelBatched
 from PySubtitle.Helpers.TestCases import SubtitleTestCase
 from PySubtitle.Helpers.Tests import log_input_expected_result, log_test_name
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.UnitTests.TestData.chinese_dinner import chinese_dinner_data
 
 class MergeLinesCommandTest(SubtitleTestCase):
@@ -39,7 +39,7 @@ class MergeLinesCommandTest(SubtitleTestCase):
         assert datamodel.project is not None  # Type narrowing for PyLance
         self.assertIsNotNone(datamodel.project.subtitles)
         
-        subtitles: SubtitleFile = datamodel.project.subtitles
+        subtitles: Subtitles = datamodel.project.subtitles
         undo_stack: list[MergeLinesCommand] = []
 
         for test_case in self.merge_lines_test_cases:

--- a/GUI/UnitTests/test_MergeSplitCommands.py
+++ b/GUI/UnitTests/test_MergeSplitCommands.py
@@ -11,7 +11,7 @@ from GUI.ProjectDataModel import ProjectDataModel
 from GUI.UnitTests.DataModelHelpers import CreateTestDataModelBatched
 from PySubtitle.Helpers.TestCases import SubtitleTestCase
 from PySubtitle.Helpers.Tests import log_input_expected_result, log_test_name
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.UnitTests.TestData.chinese_dinner import chinese_dinner_data
 
 class MergeSplitCommandsTests(SubtitleTestCase):
@@ -129,7 +129,7 @@ class MergeSplitCommandsTests(SubtitleTestCase):
             assert datamodel.project is not None  # Type narrowing for PyLance
             self.assertIsNotNone(datamodel.project.subtitles)
             
-            subtitles: SubtitleFile = datamodel.project.subtitles
+            subtitles: Subtitles = datamodel.project.subtitles
 
             for command_data in test_case['tests']:
                 test: str = command_data['test']
@@ -151,7 +151,7 @@ class MergeSplitCommandsTests(SubtitleTestCase):
                     else:
                         self.fail(f"Unknown test type: {test}")
 
-    def MergeSceneCommandTest(self, file: SubtitleFile, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
+    def MergeSceneCommandTest(self, file: Subtitles, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
         merge_scene_numbers = test_data['scene_numbers']
 
         undo_expected_scene_count = len(file.scenes)
@@ -192,7 +192,7 @@ class MergeSplitCommandsTests(SubtitleTestCase):
         self.assertSequenceEqual([scene.linecount for scene in file.scenes], undo_expected_scene_linecounts)
         self.assertSequenceEqual([[batch.number for batch in scene.batches] for scene in file.scenes], undo_expected_scene_batches)
 
-    def MergeBatchesCommandTest(self, file: SubtitleFile, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
+    def MergeBatchesCommandTest(self, file: Subtitles, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
         scene_number = test_data['scene_number']
         batch_numbers = test_data['batch_numbers']
 
@@ -223,7 +223,7 @@ class MergeSplitCommandsTests(SubtitleTestCase):
         self.assertSequenceEqual([batch.number for batch in merge_scene.batches], undo_expected_batch_numbers)
         self.assertSequenceEqual([batch.size for batch in merge_scene.batches], undo_expected_batch_sizes)
 
-    def MergeScenesMergeBatchesCommandTest(self, file: SubtitleFile, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
+    def MergeScenesMergeBatchesCommandTest(self, file: Subtitles, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
         # Merge scenes, then merge batches in the merged scenes, then undo both
         merge_scene_numbers = test_data['scene_numbers']
         merge_batch_numbers = test_data['batch_numbers']
@@ -277,7 +277,7 @@ class MergeSplitCommandsTests(SubtitleTestCase):
         self.assertSequenceEqual([[batch.number for batch in scene.batches] for scene in file.scenes], undo_expected_scene_batches)
         self.assertSequenceEqual([[batch.size for batch in scene.batches] for scene in file.scenes], undo_expected_scene_batch_sizes)
 
-    def MergeSplitScenesCommandTest(self, file: SubtitleFile, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
+    def MergeSplitScenesCommandTest(self, file: Subtitles, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
         # Merge scenes, then split the merged scene, then undo both
         merge_scene_numbers = test_data['scene_numbers']
         split_scene_batch_number = test_data['split_scene_batch_number']
@@ -360,7 +360,7 @@ class MergeSplitCommandsTests(SubtitleTestCase):
         self.assertSequenceEqual([scene.linecount for scene in file.scenes], undo_merge_expected_scene_linecount)
         self.assertSequenceEqual([[batch.number for batch in scene.batches] for scene in file.scenes], undo_merge_expected_scene_batches)
 
-    def SplitBatchCommandTest(self, file: SubtitleFile, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
+    def SplitBatchCommandTest(self, file: Subtitles, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
         scene_number, batch_number = test_data['batch_number']
         split_line_number = test_data['split_line_number']
 
@@ -413,7 +413,7 @@ class MergeSplitCommandsTests(SubtitleTestCase):
             self.assertEqual(batch.originals[0].text, expected_original)
             self.assertEqual(batch.translated[0].text, expected_translated)
 
-    def AutoSplitBatchCommandTest(self, file: SubtitleFile, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
+    def AutoSplitBatchCommandTest(self, file: Subtitles, datamodel: ProjectDataModel, test_data: dict[str, Any]) -> None:
         scene_number, batch_number = test_data['batch_number']
         min_batch_size = test_data.get('min_batch_size', 1)
 

--- a/GUI/UnitTests/test_ReparseTranslationCommand.py
+++ b/GUI/UnitTests/test_ReparseTranslationCommand.py
@@ -5,7 +5,7 @@ from GUI.ProjectDataModel import ProjectDataModel
 from GUI.UnitTests.DataModelHelpers import CreateTestDataModelBatched
 from PySubtitle.Helpers.TestCases import SubtitleTestCase, AddResponsesFromMap
 from PySubtitle.Helpers.Tests import log_info, log_input_expected_result, log_test_name
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.UnitTests.TestData.chinese_dinner import chinese_dinner_data
 
 class ReparseTranslationsCommandTest(SubtitleTestCase):
@@ -60,7 +60,7 @@ class ReparseTranslationsCommandTest(SubtitleTestCase):
             if not test_project or not test_project.subtitles:
                 return
 
-            test_subtitles: SubtitleFile = test_project.subtitles
+            test_subtitles: Subtitles = test_project.subtitles
 
             # Add the translator responses to the test data model
             AddResponsesFromMap(test_subtitles, test_data)

--- a/GUI/UnitTests/test_StartTranslationCommand.py
+++ b/GUI/UnitTests/test_StartTranslationCommand.py
@@ -11,7 +11,7 @@ from GUI.ProjectDataModel import ProjectDataModel
 from GUI.Commands.StartTranslationCommand import StartTranslationCommand
 
 from PySubtitle.SubtitleBatch import SubtitleBatch
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.UnitTests.TestData.chinese_dinner import chinese_dinner_data
 
 test_cases = [
@@ -109,7 +109,7 @@ class StartTranslationCommandTests(SubtitleTestCase):
                 self.fail("Failed to create test datamodel")
                 return
 
-            subtitles : SubtitleFile = datamodel.project.subtitles
+            subtitles : Subtitles = datamodel.project.subtitles
 
             commands : list = case.get('commands') or []
 
@@ -167,14 +167,14 @@ class StartTranslationCommandTests(SubtitleTestCase):
 
         return commands
 
-    def _validate_translated_batches(self, subtitles : SubtitleFile, command_data : dict):
+    def _validate_translated_batches(self, subtitles : Subtitles, command_data : dict):
         expected_translated_batches = command_data.get('expected_translated_batches', [])
         for scene_number, batch_number in expected_translated_batches:
             batch : SubtitleBatch = subtitles.GetBatch(scene_number, batch_number)
             self.assertIsNotNone(batch)
             self.assertTrue(batch.any_translated)
 
-    def _validate_untranslated_batches(self, subtitles : SubtitleFile, command_data : dict):
+    def _validate_untranslated_batches(self, subtitles : Subtitles, command_data : dict):
         expected_untranslated_batches = command_data.get('expected_untranslated_batches', [])
         for scene_number, batch_number in expected_untranslated_batches:
             batch : SubtitleBatch = subtitles.GetBatch(scene_number, batch_number)

--- a/GUI/ViewModel/ViewModel.py
+++ b/GUI/ViewModel/ViewModel.py
@@ -12,7 +12,7 @@ from GUI.ViewModel.ViewModelError import ViewModelError
 
 from PySubtitle.Helpers.Time import TimedeltaToText
 from PySubtitle.Instructions import DEFAULT_TASK_TYPE
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleScene import SubtitleScene
 from PySubtitle.SubtitleBatch import SubtitleBatch
 from PySubtitle.SubtitleLine import SubtitleLine
@@ -80,8 +80,8 @@ class ProjectViewModel(QStandardItemModel):
             self.blockSignals(False)
             self.endResetModel()
 
-    def CreateModel(self, data : SubtitleFile):
-        if not isinstance(data, SubtitleFile):
+    def CreateModel(self, data : Subtitles):
+        if not isinstance(data, Subtitles):
             raise ValueError(_("Can only model subtitle files"))
 
         self.model = {}

--- a/GUI/Widgets/ProjectSettings.py
+++ b/GUI/Widgets/ProjectSettings.py
@@ -23,7 +23,7 @@ from PySubtitle.Options import Options
 from PySubtitle.Helpers.Parse import ParseNames
 from PySubtitle.SettingsType import SettingType, SettingsType
 from PySubtitle.Substitutions import Substitutions
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleProject import SubtitleProject
 from PySubtitle.TranslationProvider import TranslationProvider
 from PySubtitle.Helpers.Localization import _
@@ -333,7 +333,7 @@ class ProjectSettings(QGroupBox):
             try:
                 project_options = Options({"project": 'read'})
                 source : SubtitleProject = SubtitleProject(project_options)
-                subtitles : SubtitleFile|None = source.ReadProjectFile(file_name)
+                subtitles : Subtitles|None = source.ReadProjectFile(file_name)
                 if not subtitles:
                     raise ValueError("Invalid project file")
 

--- a/PySubtitle/Formats/demo_architecture.py
+++ b/PySubtitle/Formats/demo_architecture.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from datetime import timedelta
 from PySubtitle.SubtitleLine import SubtitleLine
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.Formats.SrtFileHandler import SrtFileHandler
 from PySubtitle.SubtitleFileHandler import SubtitleFileHandler
 from typing import Iterator, TextIO
@@ -115,7 +115,7 @@ def demo_format_agnostic_architecture():
     
     # 5. Show backward compatibility
     print("5. Backward Compatibility:")
-    sf = SubtitleFile()
+    sf = Subtitles()
     sf.LoadSubtitlesFromString(sample_srt)
     if sf.originals:
         print(f"   Loaded {len(sf.originals)} subtitles into SubtitleFile")

--- a/PySubtitle/Helpers/TestCases.py
+++ b/PySubtitle/Helpers/TestCases.py
@@ -10,7 +10,7 @@ from PySubtitle.SettingsType import SettingsType
 from PySubtitle.SubtitleBatch import SubtitleBatch
 from PySubtitle.SubtitleBatcher import SubtitleBatcher
 from PySubtitle.SubtitleError import TranslationError
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleLine import SubtitleLine
 from PySubtitle.SubtitleProject import SubtitleProject
 from PySubtitle.SubtitleScene import SubtitleScene
@@ -48,7 +48,7 @@ class SubtitleTestCase(unittest.TestCase):
 
         self.assertIn("Dummy Provider", self.options.provider_settings, "Dummy Provider settings should exist")
 
-    def _assert_same_as_reference(self, subtitles : SubtitleFile, reference_subtitles: SubtitleFile):
+    def _assert_same_as_reference(self, subtitles : Subtitles, reference_subtitles: Subtitles):
         """
         Assert that the current state of the subtitles is identical to the reference datamodel
         """
@@ -91,16 +91,16 @@ class SubtitleTestCase(unittest.TestCase):
         self.assertSequenceEqual([ line.end for line in batch.originals ], [ line.end for line in reference_batch.originals ])
 
 
-def PrepareSubtitles(subtitle_data : dict, key : str = 'original') -> SubtitleFile:
+def PrepareSubtitles(subtitle_data : dict, key : str = 'original') -> Subtitles:
     """
     Prepares a SubtitleFile object from subtitle data.
     """
-    subtitles : SubtitleFile = SubtitleFile()
+    subtitles : Subtitles = Subtitles()
     subtitles.LoadSubtitlesFromString(subtitle_data[key])
     subtitles.UpdateProjectSettings(SettingsType(subtitle_data))
     return subtitles
 
-def AddTranslations(subtitles : SubtitleFile, subtitle_data : dict, key : str = 'translated'):
+def AddTranslations(subtitles : Subtitles, subtitle_data : dict, key : str = 'translated'):
     """
     Adds translations to the subtitles.
     """
@@ -120,7 +120,7 @@ def AddTranslations(subtitles : SubtitleFile, subtitle_data : dict, key : str = 
                 translated = line.translated
                 line.translation = translated.text if translated else None
 
-def AddResponsesFromMap(subtitles : SubtitleFile, test_data : dict):
+def AddResponsesFromMap(subtitles : Subtitles, test_data : dict):
     """
     Add translator responses to the subtitles if test_data has a response map.
     """

--- a/PySubtitle/Helpers/Tests.py
+++ b/PySubtitle/Helpers/Tests.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any
 
 from PySubtitle.SettingsType import SettingsType
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 
 separator = "".center(60, "-")
 wide_separator = "".center(120, "-")
@@ -130,7 +130,7 @@ def RunTestOnAllSrtFiles(run_test, test_options: list[dict], directory_path: str
         logger.info(separator)
 
         try:
-            subtitles = SubtitleFile(filepath)
+            subtitles = Subtitles(filepath)
             subtitles.LoadSubtitles()
 
             for options in test_options:

--- a/PySubtitle/SubtitleSerialisation.py
+++ b/PySubtitle/SubtitleSerialisation.py
@@ -5,7 +5,7 @@ from PySubtitle.SettingsType import SettingsType
 from PySubtitle.SubtitleLine import SubtitleLine
 from PySubtitle.SubtitleBatch import SubtitleBatch
 from PySubtitle.SubtitleError import TranslationError
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleScene import SubtitleScene
 from PySubtitle.Translation import Translation
 from PySubtitle.TranslationPrompt import TranslationPrompt
@@ -39,7 +39,7 @@ class SubtitleEncoder(json.JSONEncoder):
         if obj is None:
             return None
 
-        if isinstance(obj, SubtitleFile):
+        if isinstance(obj, Subtitles):
             return {
                 "sourcepath": obj.sourcepath,
                 "outputpath": obj.outputpath,
@@ -112,10 +112,10 @@ def _object_hook(dct):
     # Reconstruct our custom types from JSON
     if '_class' in dct:
         class_name = dct.pop('_class')
-        if class_name == classname(SubtitleFile):
+        if class_name == classname(Subtitles) or class_name == "SubtitleFile":      # Backward compatibility
             sourcepath = dct.get('sourcepath')
             outpath = dct.get('outputpath') or dct.get('filename')
-            obj = SubtitleFile(sourcepath, outpath)
+            obj = Subtitles(sourcepath, outpath)
             obj.settings = dct.get('settings', {}) or dct.get('context', {})
             obj.scenes = dct.get('scenes', [])
             obj.UpdateProjectSettings(SettingsType()) # Force update for legacy files

--- a/PySubtitle/SubtitleSerialisation.py
+++ b/PySubtitle/SubtitleSerialisation.py
@@ -126,9 +126,9 @@ def _object_hook(dct):
         elif class_name == classname(SubtitleBatch):
             obj = SubtitleBatch(dct)
             return obj
-        elif class_name == classname(SubtitleLine) or class_name == "Subtitle": # TEMP backward compatibility
+        elif class_name == classname(SubtitleLine):
             return SubtitleLine(dct)
-        elif class_name == classname(Translation) or class_name == "GPTTranslation":
+        elif class_name == classname(Translation):
             content = dct.get('content') or {
                 'text' : dct.get('text'),
                 'finish_reason' : dct.get('finish_reason'),

--- a/PySubtitle/SubtitleSerialisation.py
+++ b/PySubtitle/SubtitleSerialisation.py
@@ -126,9 +126,9 @@ def _object_hook(dct):
         elif class_name == classname(SubtitleBatch):
             obj = SubtitleBatch(dct)
             return obj
-        elif class_name == classname(SubtitleLine):
+        elif class_name == classname(SubtitleLine) or class_name == "Subtitle": # TEMP backward compatibility
             return SubtitleLine(dct)
-        elif class_name == classname(Translation):
+        elif class_name == classname(Translation) or class_name == "GPTTranslation":
             content = dct.get('content') or {
                 'text' : dct.get('text'),
                 'finish_reason' : dct.get('finish_reason'),

--- a/PySubtitle/SubtitleSerialisation.py
+++ b/PySubtitle/SubtitleSerialisation.py
@@ -112,7 +112,7 @@ def _object_hook(dct):
     # Reconstruct our custom types from JSON
     if '_class' in dct:
         class_name = dct.pop('_class')
-        if class_name == classname(Subtitles) or class_name == "SubtitleFile":      # Backward compatibility
+        if class_name in {classname(Subtitles), "SubtitleFile"}:      # Backward compatibility
             sourcepath = dct.get('sourcepath')
             outpath = dct.get('outputpath') or dct.get('filename')
             obj = Subtitles(sourcepath, outpath)

--- a/PySubtitle/SubtitleTranslator.py
+++ b/PySubtitle/SubtitleTranslator.py
@@ -21,7 +21,7 @@ from PySubtitle.SubtitleBatch import SubtitleBatch
 
 from PySubtitle.SubtitleError import NoProviderError, NoTranslationError, ProviderError, SubtitleError, TranslationAbortedError, TranslationError, TranslationImpossibleError
 from PySubtitle.Helpers import FormatErrorMessages
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleScene import SubtitleScene, UnbatchScenes
 from PySubtitle.TranslationEvents import TranslationEvents
 from PySubtitle.TranslationPrompt import TranslationPrompt
@@ -94,7 +94,7 @@ class SubtitleTranslator:
         self.aborted = True
         self.client.AbortTranslation()
 
-    def TranslateSubtitles(self, subtitles : SubtitleFile):
+    def TranslateSubtitles(self, subtitles : Subtitles):
         """
         Translate a SubtitleFile
         """
@@ -156,7 +156,7 @@ class SubtitleTranslator:
         subtitles.originals = originals
         subtitles.translated = translations
 
-    def TranslateScene(self, subtitles : SubtitleFile, scene : SubtitleScene, batch_numbers = None, line_numbers = None):
+    def TranslateScene(self, subtitles : Subtitles, scene : SubtitleScene, batch_numbers = None, line_numbers = None):
         """
         Send a scene for translation
         """

--- a/PySubtitle/Subtitles.py
+++ b/PySubtitle/Subtitles.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from copy import deepcopy
-import json
 import os
 import logging
 import threading
@@ -27,9 +26,9 @@ from PySubtitle.Formats.SrtFileHandler import SrtFileHandler
 default_encoding = os.getenv('DEFAULT_ENCODING', 'utf-8')
 fallback_encoding = os.getenv('DEFAULT_ENCODING', 'iso-8859-1')
 
-class SubtitleFile:
+class Subtitles:
     """
-    High level class for manipulating subtitle files
+    High level class for manipulating subtitles
     """
     DEFAULT_PROJECT_SETTINGS : SettingsType = SettingsType({
         'provider': None,
@@ -286,21 +285,6 @@ class SubtitleFile:
 
         except SubtitleParseError as e:
             logging.error(_("Failed to parse SRT string: {}").format(str(e)))
-
-    def SaveProjectFile(self, projectfile: str, encoder_class: type|None = None) -> None:
-        """
-        Save the project settings to a JSON file
-        """
-        if encoder_class is None:
-            raise ValueError("No encoder provided")
-
-        projectfile = os.path.normpath(projectfile)
-        logging.info(_("Writing project data to {}").format(str(projectfile)))
-
-        with self.lock:
-            with open(projectfile, 'w', encoding=default_encoding) as f:
-                project_json = json.dumps(self, cls=encoder_class, ensure_ascii=False, indent=4) # type: ignore
-                f.write(project_json)
 
     def SaveOriginal(self, path: str|None = None) -> None:
         """
@@ -646,7 +630,9 @@ class SubtitleFile:
         return value if isinstance(value, str) else default
 
     def _update_compatibility(self, settings: SettingsType) -> None:
-        """ Update settings for compatibility with older versions """
+        """
+        Update settings for compatibility with older versions
+        """
         if not settings.get('description') and settings.get('synopsis'):
             settings['description'] = settings.get('synopsis')
 

--- a/PySubtitle/UnitTests/test_ChineseDinner.py
+++ b/PySubtitle/UnitTests/test_ChineseDinner.py
@@ -4,7 +4,7 @@ from PySubtitle.Helpers.TestCases import PrepareSubtitles, SubtitleTestCase
 from PySubtitle.Helpers.Tests import log_info, log_input_expected_result, log_test_name
 from PySubtitle.SubtitleBatch import SubtitleBatch
 from PySubtitle.SubtitleBatcher import SubtitleBatcher
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleLine import SubtitleLine
 from PySubtitle.SubtitleProject import SubtitleProject
 from PySubtitle.SubtitleScene import SubtitleScene
@@ -19,7 +19,7 @@ class ChineseDinnerTests(SubtitleTestCase):
     def test_ChineseDinner(self):
         log_test_name("Chinese Dinner Tests")
 
-        subtitles : SubtitleFile = SubtitleFile()
+        subtitles : Subtitles = Subtitles()
 
         with self.subTest("Load subtitles from string"):
             log_test_name("Load subtitles from string")
@@ -93,7 +93,7 @@ class ChineseDinnerTests(SubtitleTestCase):
         ]
         batch_containing_line = [(1, 1, 1), (10, 1,1), (32, 2, 1), (55, 2, 1), (63, 4, 1)]
 
-        subtitles : SubtitleFile = PrepareSubtitles(chinese_dinner_data)
+        subtitles : Subtitles = PrepareSubtitles(chinese_dinner_data)
 
         batcher = SubtitleBatcher(self.options)
         subtitles.AutoBatch(batcher)

--- a/PySubtitle/UnitTests/test_Translator.py
+++ b/PySubtitle/UnitTests/test_Translator.py
@@ -5,7 +5,7 @@ from PySubtitle.Helpers.TestCases import DummyProvider, PrepareSubtitles, Subtit
 from PySubtitle.Helpers.Tests import log_info, log_input_expected_result, log_test_name
 from PySubtitle.SubtitleBatch import SubtitleBatch
 from PySubtitle.SubtitleBatcher import SubtitleBatcher
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleScene import SubtitleScene
 from PySubtitle.SubtitleTranslator import SubtitleTranslator
 
@@ -27,8 +27,8 @@ class SubtitleTranslatorTests(SubtitleTestCase):
 
             provider = DummyProvider(data=data)
 
-            originals : SubtitleFile = PrepareSubtitles(data, 'original')
-            reference : SubtitleFile = PrepareSubtitles(data, 'translated')
+            originals : Subtitles = PrepareSubtitles(data, 'original')
+            reference : Subtitles = PrepareSubtitles(data, 'translated')
 
             self.assertEqual(originals.linecount, reference.linecount)
 
@@ -48,7 +48,7 @@ class SubtitleTranslatorTests(SubtitleTestCase):
 
             translator.TranslateSubtitles(originals)
 
-    def validate_batch(self, batch : SubtitleBatch, original : SubtitleFile, reference : SubtitleFile):
+    def validate_batch(self, batch : SubtitleBatch, original : Subtitles, reference : Subtitles):
         log_info(f"Validating scene {batch.scene} batch {batch.number}")
         log_info(f"Summary: {batch.summary}")
         self.assertIsNotNone(batch.summary)
@@ -77,7 +77,7 @@ class SubtitleTranslatorTests(SubtitleTestCase):
             self.assertEqual(original_batch.originals[i], batch.originals[i])
             self.assertEqual(reference_batch.originals[i], batch.translated[i])
 
-    def validate_scene(self, scene : SubtitleScene, original : SubtitleFile, reference : SubtitleFile):
+    def validate_scene(self, scene : SubtitleScene, original : Subtitles, reference : Subtitles):
         log_info(f"Validating scene {scene.number}")
         log_info(f"Summary: {scene.summary}")
         self.assertIsNotNone(scene.summary)
@@ -100,8 +100,8 @@ class SubtitleTranslatorTests(SubtitleTestCase):
 
             provider = DummyProvider(data=data)
 
-            originals : SubtitleFile = PrepareSubtitles(data, 'original')
-            reference : SubtitleFile = PrepareSubtitles(data, 'translated')
+            originals : Subtitles = PrepareSubtitles(data, 'original')
+            reference : Subtitles = PrepareSubtitles(data, 'translated')
 
             self.assertEqual(originals.linecount, reference.linecount)
 

--- a/Tests/batcher_test.py
+++ b/Tests/batcher_test.py
@@ -1,6 +1,6 @@
 import os
 from PySubtitle.SubtitleBatcher import SubtitleBatcher
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.Helpers.Tests import RunTestOnAllSrtFiles, separator
 
 def analyze_scenes(scenes):
@@ -25,7 +25,7 @@ def analyze_scenes(scenes):
 
     return num_scenes, num_batches_list, largest_batch_list, smallest_batch_list, average_batch_size_list
 
-def batcher_test(subtitles: SubtitleFile, logger, options):
+def batcher_test(subtitles: Subtitles, logger, options):
     if not subtitles.originals:
         raise Exception("No original subtitles to batch")
 

--- a/Tests/preprocessor_test.py
+++ b/Tests/preprocessor_test.py
@@ -1,10 +1,10 @@
 import os
 from PySubtitle.SettingsType import SettingsType
-from PySubtitle.SubtitleFile import SubtitleFile
+from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleProcessor import SubtitleProcessor
 from PySubtitle.Helpers.Tests import RunTestOnAllSrtFiles, separator
 
-def preprocess_test(subtitles: SubtitleFile, logger, options : SettingsType):
+def preprocess_test(subtitles: Subtitles, logger, options : SettingsType):
     if not subtitles.originals:
         raise Exception("No original subtitles to preprocess")
 

--- a/scripts/azure-subtrans.py
+++ b/scripts/azure-subtrans.py
@@ -48,7 +48,7 @@ try:
 
     if project.write_project:
         logging.info(f"Writing project data to {str(project.projectfile)}")
-        project.WriteProjectFile()
+        project.SaveProjectFile()
 
 except Exception as e:
     print("Error:", e)

--- a/scripts/bedrock-subtrans.py
+++ b/scripts/bedrock-subtrans.py
@@ -52,7 +52,7 @@ try:
 
     if project.write_project:
         logging.info(f"Writing project data to {str(project.projectfile)}")
-        project.WriteProjectFile()
+        project.SaveProjectFile()
 
 except Exception as e:
     logging.error(f"Error during subtitle translation: {e}")

--- a/scripts/claude-subtrans.py
+++ b/scripts/claude-subtrans.py
@@ -37,7 +37,7 @@ try:
 
     if project.write_project:
         logging.info(f"Writing project data to {str(project.projectfile)}")
-        project.WriteProjectFile()
+        project.SaveProjectFile()
 
 except Exception as e:
     print("Error:", e)

--- a/scripts/deepseek-subtrans.py
+++ b/scripts/deepseek-subtrans.py
@@ -42,7 +42,7 @@ try:
 
     if project.write_project:
         logging.info(f"Writing project data to {str(project.projectfile)}")
-        project.WriteProjectFile()
+        project.SaveProjectFile()
 
 except Exception as e:
     print("Error:", e)

--- a/scripts/gemini-subtrans.py
+++ b/scripts/gemini-subtrans.py
@@ -36,7 +36,7 @@ try:
 
     if project.write_project:
         logging.info(f"Writing project data to {str(project.projectfile)}")
-        project.WriteProjectFile()
+        project.SaveProjectFile()
 
 except Exception as e:
     print("Error:", e)

--- a/scripts/gpt-subtrans.py
+++ b/scripts/gpt-subtrans.py
@@ -47,7 +47,7 @@ try:
 
     if project.write_project:
         logging.info(f"Writing project data to {str(project.projectfile)}")
-        project.WriteProjectFile()
+        project.SaveProjectFile()
 
 except Exception as e:
     print("Error:", e)

--- a/scripts/llm-subtrans.py
+++ b/scripts/llm-subtrans.py
@@ -59,7 +59,7 @@ try:
 
     if project.write_project:
         logging.info(f"Writing project data to {str(project.projectfile)}")
-        project.WriteProjectFile()
+        project.SaveProjectFile()
 
 except Exception as e:
     print("Error:", e)

--- a/scripts/mistral-subtrans.py
+++ b/scripts/mistral-subtrans.py
@@ -42,7 +42,7 @@ try:
 
     if project.write_project:
         logging.info(f"Writing project data to {str(project.projectfile)}")
-        project.WriteProjectFile()
+        project.SaveProjectFile()
 
 except Exception as e:
     print("Error:", e)

--- a/scripts/subtrans_common.py
+++ b/scripts/subtrans_common.py
@@ -149,7 +149,7 @@ def CreateProject(options : Options, args: Namespace) -> SubtitleProject:
 
     if args.writebackup and project.read_project:
         logging.info("Saving backup copy of the project")
-        project.WriteBackupFile()
+        project.SaveBackupFile()
 
     project.UpdateProjectSettings(options)
 


### PR DESCRIPTION
Renamed SubtitleFile to Subtitles, to better indicate how it is used in the project.
Moved saving project files to SubtitleProject and renamed some methods for clarity.
There is more to do in future to better separate concerns, this is just groundwork to prepare for supporting multiple file formats.
Removed backward compatibility for some very old project files from the SubtitleDecoder class.