### PR TITLE
Parse Gemini response refusals

### DIFF
--- a/PySubtitle/Providers/Gemini/GeminiClient.py
+++ b/PySubtitle/Providers/Gemini/GeminiClient.py
@@ -210,7 +210,7 @@ class GeminiClient(TranslationClient):
                 probability = getattr(rating, 'probability', 'Unknown')
                 blocked = getattr(rating, 'blocked', False)
                 
-                rating_str = f"{category}={probability}"
+                rating_str = f"{getattr(category, 'name', str(category))}={getattr(probability, 'name', str(probability))}"
                 if blocked:
                     rating_str += " (BLOCKED)"
                 safety_info.append(rating_str)


### PR DESCRIPTION
Dig deeper into the reason when Gemini refuses to translate a block of subtitles, in particular flag censorship issues and suggest trying a different provider.

Pass the safety_settings argument, which was previously not being used, even though it doesn't seem to help with the PROHIBITED_CONTENT problem.