### PR TITLE
Add subtitle format conversion support with GUI options and tests

### DIFF
--- a/GUI/NewProjectSettings.py
+++ b/GUI/NewProjectSettings.py
@@ -17,6 +17,7 @@ from PySubtitle.SubtitleProcessor import SubtitleProcessor
 from PySubtitle.SubtitleProject import SubtitleProject
 from PySubtitle.SubtitleScene import SubtitleScene
 from PySubtitle.Helpers.Localization import _
+from PySubtitle.SubtitleFormatRegistry import SubtitleFormatRegistry
 
 if os.environ.get("DEBUG_MODE") == "1":
     try:
@@ -34,7 +35,8 @@ class NewProjectSettings(QDialog):
         'max_batch_size': (int, _("Most lines to send in each batch")),
         'preprocess_subtitles': (bool, _("Preprocess subtitles before batching")),
         'instruction_file': (str, _("Detailed instructions for the translator")),
-        'prompt': (str, _("High-level instructions for the translator"))
+        'prompt': (str, _("High-level instructions for the translator")),
+        'format': (str, _("Output subtitle format"))
     }
 
     def __init__(self, datamodel : ProjectDataModel, parent=None):
@@ -55,6 +57,10 @@ class NewProjectSettings(QDialog):
         available_models = datamodel.available_models
         self.OPTIONS['model'] = (available_models, self.OPTIONS['model'][1])
         self.settings['model'] = datamodel.selected_model
+
+        formats = SubtitleFormatRegistry.enumerate_formats()
+        self.OPTIONS['format'] = (formats, _("Output subtitle format"))
+        self.settings['format'] = self.settings.get('format', formats[0] if formats else None)
 
         instruction_files = GetInstructionsFiles()
         if instruction_files:

--- a/GUI/Widgets/ProjectSettings.py
+++ b/GUI/Widgets/ProjectSettings.py
@@ -19,6 +19,7 @@ from GUI.ProjectDataModel import ProjectDataModel
 
 from GUI.Widgets.Widgets import OptionsGrid, TextBoxEditor
 from PySubtitle.Helpers import GetValueName
+from PySubtitle.SubtitleFormatRegistry import SubtitleFormatRegistry
 from PySubtitle.Options import Options
 from PySubtitle.Helpers.Parse import ParseNames
 from PySubtitle.SettingsType import SettingType, SettingsType
@@ -42,6 +43,7 @@ class ProjectSettings(QGroupBox):
         self.action_handler : ProjectActions|None = action_handler
         self.provider_list = sorted(TranslationProvider.get_providers())
         self.model_list : list[str] = []
+        self.format_list : list[str] = SubtitleFormatRegistry.enumerate_formats()
         self.widgets : dict[str, QLineEdit|QCheckBox|QComboBox] = {}
         self.settings : SettingsType = SettingsType()
         self.current_provider : str|None = None
@@ -68,6 +70,7 @@ class ProjectSettings(QGroupBox):
             'substitution_mode': self._gettextvalue('substitution_mode'),
             'model': self._gettextvalue('model') if 'model' in self.widgets else self.settings.get('model'),
             'provider': self._gettextvalue('provider') if 'provider' in self.widgets else self.settings.get('provider'),
+            'format': self._gettextvalue('format')
         })
 
         return settings
@@ -133,6 +136,7 @@ class ProjectSettings(QGroupBox):
             self.AddMultiLineOption(_("Names"), settings, 'names')
             self.AddMultiLineOption(_("Substitutions"), settings, 'substitutions')
             self.AddDropdownOption(_("Substitution Mode"), settings, 'substitution_mode', Substitutions.Mode)
+            self.AddDropdownOption(_("Format"), settings, 'format', self.format_list)
             self.AddButton("", _("Edit Instructions"), self._edit_instructions)
             self.AddButton("", _("Copy From Another Project"), self._copy_from_another_project)
             if len(self.provider_list) > 1:

--- a/PySubtitle/Formats/AssFileHandler.py
+++ b/PySubtitle/Formats/AssFileHandler.py
@@ -214,4 +214,16 @@ class AssFileHandler(SubtitleFileHandler):
         # Restore aegisub project data if present
         if 'aegisub_project' in metadata and hasattr(subs, 'aegisub_project'):
             subs.aegisub_project.update(metadata['aegisub_project'])
+
+    def convert_from(self, data: SubtitleData) -> SubtitleData:
+        """Convert subtitle data from another format to ASS."""
+        new_data = super().convert_from(data)
+        metadata = new_data.metadata or {}
+        metadata['format'] = 'ass'
+        styles = metadata.get('styles', {})
+        if 'Default' not in styles:
+            styles['Default'] = {}
+        metadata['styles'] = styles
+        new_data.metadata = metadata
+        return new_data
     

--- a/PySubtitle/Formats/SrtFileHandler.py
+++ b/PySubtitle/Formats/SrtFileHandler.py
@@ -77,6 +77,18 @@ class SrtFileHandler(SubtitleFileHandler):
             srt_items.append(srt_item)
         
         return srt.compose(srt_items, reindex=False)  # We handle reindexing above
+
+    def convert_from(self, data: SubtitleData) -> SubtitleData:
+        """Convert subtitle data from another format to SRT."""
+        new_data = super().convert_from(data)
+        metadata = {'format': 'srt'}
+        # Preserve basic metadata like Title/Language if present
+        if 'Title' in new_data.metadata:
+            metadata['Title'] = new_data.metadata['Title']
+        if 'Language' in new_data.metadata:
+            metadata['Language'] = new_data.metadata['Language']
+        new_data.metadata = metadata
+        return new_data
     
 
     def _parse_srt_items(self, source) -> Iterator[SubtitleLine]:

--- a/PySubtitle/SubtitleFileHandler.py
+++ b/PySubtitle/SubtitleFileHandler.py
@@ -58,6 +58,21 @@ class SubtitleFileHandler(ABC):
             str: Formatted subtitle content
         """
         pass
+
+    def convert_from(self, data: SubtitleData) -> SubtitleData:
+        """Create a new :class:`SubtitleData` instance using this handler.
+
+        The default implementation performs a deep copy of subtitle lines and
+        metadata. Handlers may override to perform format-specific
+        adjustments.
+        """
+        from copy import deepcopy
+
+        return SubtitleData(
+            lines=deepcopy(data.lines),
+            metadata=deepcopy(data.metadata),
+            start_line_number=data.start_line_number,
+        )
     
     def get_file_extensions(self) -> list[str]:
         """

--- a/PySubtitle/Subtitles.py
+++ b/PySubtitle/Subtitles.py
@@ -46,7 +46,8 @@ class Subtitles:
         'substitution_mode': None,
         'include_original': None,
         'add_right_to_left_markers': None,
-        'instruction_file': None
+        'instruction_file': None,
+        'format': None
     })
 
     def __init__(self, file_handler: SubtitleFileHandler, filepath: str | None = None, outputpath: str | None = None,
@@ -388,12 +389,12 @@ class Subtitles:
 
             self._update_compatibility(self.settings)
 
-    def UpdateOutputPath(self, outputpath: str|None = None) -> None:
+    def UpdateOutputPath(self, outputpath: str|None = None, extension: str|None = None) -> None:
         """
         Set or generate the output path for the translated subtitles
         """
         if not outputpath:
-            outputpath = GetOutputPath(self.sourcepath, self.target_language)
+            outputpath = GetOutputPath(self.sourcepath, self.target_language, extension)
         self.outputpath = outputpath
 
     def PreProcess(self, preprocessor: SubtitleProcessor) -> None:

--- a/PySubtitle/UnitTests/test_SubtitleFormatConversion.py
+++ b/PySubtitle/UnitTests/test_SubtitleFormatConversion.py
@@ -1,0 +1,84 @@
+import os
+import tempfile
+import unittest
+from copy import deepcopy
+
+from PySubtitle.Options import Options
+from PySubtitle.SubtitleProject import SubtitleProject
+from PySubtitle.Formats.SrtFileHandler import SrtFileHandler
+from PySubtitle.Formats.AssFileHandler import AssFileHandler
+from PySubtitle.SubtitleSerialisation import SubtitleEncoder
+
+ASS_SAMPLE = """[Script Info]
+Title: Sample ASS
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,0,0,0,0,100,100,0,0,1,2,0,2,0,0,0,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello ASS!
+"""
+
+SRT_SAMPLE = """1\n00:00:01,000 --> 00:00:02,000\nHello SRT!\n"""
+
+class TestSubtitleFormatConversion(unittest.TestCase):
+    def _write_temp(self, suffix: str, content: str) -> str:
+        f = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        f.write(content.encode("utf-8"))
+        f.flush()
+        f.close()
+        return f.name
+
+    def test_ass_to_srt_conversion(self):
+        ass_path = self._write_temp(".ass", ASS_SAMPLE)
+        project = SubtitleProject(Options())
+        project.InitialiseProject(ass_path)
+        self.assertIsInstance(project.subtitles.file_handler, AssFileHandler)
+        out_path = ass_path + ".srt"
+        project.ConvertFormat('.srt')
+        self.assertIsInstance(project.subtitles.file_handler, SrtFileHandler)
+        project.SaveOriginal(out_path)
+        self.assertTrue(os.path.exists(out_path))
+
+    def test_srt_to_ass_conversion(self):
+        srt_path = self._write_temp(".srt", SRT_SAMPLE)
+        project = SubtitleProject(Options())
+        project.InitialiseProject(srt_path)
+        self.assertIsInstance(project.subtitles.file_handler, SrtFileHandler)
+        out_path = srt_path + ".ass"
+        project.ConvertFormat('.ass')
+        self.assertIsInstance(project.subtitles.file_handler, AssFileHandler)
+        project.SaveOriginal(out_path)
+        self.assertTrue(os.path.exists(out_path))
+
+    def test_project_roundtrip_after_conversion(self):
+        srt_path = self._write_temp(".srt", SRT_SAMPLE)
+        project = SubtitleProject(Options())
+        project.InitialiseProject(srt_path)
+        project.ConvertFormat('.ass')
+        tmp_project = tempfile.NamedTemporaryFile(delete=False, suffix=".subtrans")
+        tmp_project.close()
+        project.WriteProjectToFile(tmp_project.name, encoder_class=SubtitleEncoder)
+
+        project2 = SubtitleProject(Options())
+        project2.ReadProjectFile(tmp_project.name)
+        self.assertIsInstance(project2.subtitles.file_handler, AssFileHandler)
+        self.assertEqual(project2.subtitles.settings.get('format'), '.ass')
+
+    def test_translation_data_converted(self):
+        srt_path = self._write_temp(".srt", SRT_SAMPLE)
+        project = SubtitleProject(Options())
+        project.InitialiseProject(srt_path)
+        # Set translated lines based on originals
+        translated = deepcopy(project.subtitles.originals)
+        translated[0].text = "Bonjour SRT!"
+        project.subtitles.translated = translated
+        project.ConvertFormat('.ass')
+        self.assertEqual(project.subtitles.translated[0].text, "Bonjour SRT!")
+        self.assertEqual(project.subtitles.metadata.get('format'), 'ass')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/PySubtitle/UnitTests/test_SubtitleFormatConversion.py
+++ b/PySubtitle/UnitTests/test_SubtitleFormatConversion.py
@@ -27,6 +27,7 @@ SRT_SAMPLE = """1\n00:00:01,000 --> 00:00:02,000\nHello SRT!\n"""
 class TestSubtitleFormatConversion(unittest.TestCase):
     def _write_temp(self, suffix: str, content: str) -> str:
         f = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        self.addCleanup(os.remove, f.name)
         f.write(content.encode("utf-8"))
         f.flush()
         f.close()

--- a/docs/multi-format-support-proposal.md
+++ b/docs/multi-format-support-proposal.md
@@ -38,8 +38,14 @@ This document captures the architecture and decisions behind LLM-Subtrans's mult
 ```python
 try:
   new_handler = SubtitleFormatRegistry.create_handler(target_extension)
-  converted_subtitles = new_handler.convert_from(self.subtitles)
-  self.subtitles = converted_subtitles
+  data = SubtitleData(
+      lines=self.subtitles.translated,
+      metadata=self.subtitles.metadata,
+      start_line_number=self.subtitles.start_line_number,
+  )
+  converted_data = new_handler.convert_from(data)
+  self.subtitles.translated = converted_data.lines
+  self.subtitles.metadata = converted_data.metadata
 except Exception as e:
   logging.error(...)
 ```


### PR DESCRIPTION
## Summary
- Refactor SubtitleFileHandler.convert_from to operate on SubtitleData and deep copy lines/metadata
- Update SRT/ASS handlers and SubtitleProject.ConvertFormat to transform only translated data using SubtitleData
- Extend unit tests with translation conversion check and adjust documentation

## Testing
- `python scripts/unit_tests.py` *(fails: can't open file 'scripts/unit_tests.py')*
- `python scripts/run_tests.py` *(fails: ModuleNotFoundError: No module named 'pysubs2')*

------
https://chatgpt.com/codex/tasks/task_e_68b343ca26d8832989c38d15ee7bebec