### PR TITLE
f-string fix

### DIFF
--- a/GUI/ProjectActions.py
+++ b/GUI/ProjectActions.py
@@ -293,7 +293,7 @@ class ProjectActions(QObject):
         """
         Update the user-updatable properties of a subtitle batch
         """
-        logging.debug(f"Updating line {line_number} with {original_text or "<empty>"} > {translated_text or "<empty>"}")
+        logging.debug(f"Updating line {line_number} with {original_text or '<empty>'} > {translated_text or '<empty>'}")
 
         self._validate_datamodel()
 

--- a/GUI/SettingsDialog.py
+++ b/GUI/SettingsDialog.py
@@ -339,8 +339,9 @@ class SettingsDialog(QDialog):
 
         self.translation_provider = self.provider_cache[provider]
 
-        if provider not in self.provider_settings or not self.provider_settings[provider]:
-            self.provider_settings[provider] = self.translation_provider.settings.copy()
+        if self.translation_provider is not None:
+            if provider not in self.provider_settings or not self.provider_settings[provider]:
+                self.provider_settings[provider] = self.translation_provider.settings.copy()
 
     def _add_provider_options(self, section_name : str, layout : QFormLayout):
         """

--- a/PySubtitle/UnitTests/test_Options.py
+++ b/PySubtitle/UnitTests/test_Options.py
@@ -837,11 +837,14 @@ class TestSettingsType(unittest.TestCase):
             current_settings['current_test'] = 'current_value'
             
             # Verify through provider_settings access
-            updated_current = options.provider_settings[options.provider]
-            self.assertIn('current_test', updated_current)
-            log_input_expected_result("current provider update propagated", 'current_value', updated_current['current_test'])
-            self.assertEqual(updated_current['current_test'], 'current_value')
-
+            provider : str|None = options.provider
+            self.assertIsNotNone(provider)
+            self.assertIsNotNone(options.provider_settings)
+            if provider is not None:
+                updated_current : SettingsType = options.provider_settings[provider]
+                self.assertIn('current_test', updated_current)
+                log_input_expected_result("current provider update propagated", 'current_value', updated_current['current_test'])
+                self.assertEqual(updated_current['current_test'], 'current_value')
 
 class TestSettingsHelpers(unittest.TestCase):
     """Unit tests for Settings helper functions"""


### PR DESCRIPTION
Use mixed quote types to ensure correct parsing of f-string.

+ fixed some Pylance warnings about potential None references