### PR TITLE
Replace out-dated super calls with modern syntax

### DIFF
--- a/GUI/AboutDialog.py
+++ b/GUI/AboutDialog.py
@@ -12,7 +12,7 @@ class AboutDialog(QDialog):
     Show application information etc.
     """
     def __init__(self, parent=None):
-        super(AboutDialog, self).__init__(parent)
+        super().__init__(parent)
         self.setWindowTitle(_("About GUI-Subtrans"))
         self.setMinimumWidth(512)
         self.setMaximumWidth(768)

--- a/GUI/NewProjectSettings.py
+++ b/GUI/NewProjectSettings.py
@@ -38,7 +38,7 @@ class NewProjectSettings(QDialog):
     }
 
     def __init__(self, datamodel : ProjectDataModel, parent=None):
-        super(NewProjectSettings, self).__init__(parent)
+        super().__init__(parent)
         self.setWindowTitle(_("Project Settings"))
         self.setMinimumWidth(800)
 
@@ -126,7 +126,7 @@ class NewProjectSettings(QDialog):
         # Wait for any remaining preview threads to complete
         self._wait_for_threads()
 
-        super(NewProjectSettings, self).accept()
+        super().accept()
 
     def _on_setting_changed(self, key, value):
         if key == 'provider':

--- a/GUI/SettingsDialog.py
+++ b/GUI/SettingsDialog.py
@@ -115,7 +115,7 @@ class SettingsDialog(QDialog):
     }
 
     def __init__(self, options : Options, provider_cache = None, parent=None, focus_provider_settings : bool = False):
-        super(SettingsDialog, self).__init__(parent)
+        super().__init__(parent)
         self.setWindowTitle(_("GUI-Subtrans Settings"))
         self.setMinimumWidth(800)
 
@@ -216,7 +216,7 @@ class SettingsDialog(QDialog):
             logging.error(f"Unable to update settings: {e}")
 
         try:
-            super(SettingsDialog, self).accept()
+            super().accept()
 
         except Exception as e:
             logging.error(f"Error in settings dialog handler: {e}")

--- a/GUI/ViewModel/BatchItem.py
+++ b/GUI/ViewModel/BatchItem.py
@@ -17,7 +17,7 @@ from PySubtitle.Helpers.Localization import _
 class BatchItem(ViewModelItem):
     """ Represents a subtitle batch in the view model"""
     def __init__(self, scene_number : int, batch : SubtitleBatch, debug_view : bool = False):
-        super(BatchItem, self).__init__(_("Scene {scene}, batch {batch}").format(scene=scene_number, batch=batch.number))
+        super().__init__(_("Scene {scene}, batch {batch}").format(scene=scene_number, batch=batch.number))
         self.scene: int = scene_number
         self.number: int = batch.number
         self.debug_view: bool = debug_view

--- a/GUI/ViewModel/LineItem.py
+++ b/GUI/ViewModel/LineItem.py
@@ -15,7 +15,7 @@ class LineItem(QStandardItem):
     This is used to display lines in the GUI and to update the model when changes are made.
     """
     def __init__(self, line_number : int, model : dict[str, str|int|float]):
-        super(LineItem, self).__init__(f"Line {line_number}")
+        super().__init__(f"Line {line_number}")
         self.number : int = line_number
         self.line_model : dict[str, str|int|float] = model
         self.height = max(GetLineHeight(self.line_text), GetLineHeight(self.translation)) if self.translation else GetLineHeight(self.line_text)

--- a/GUI/ViewModel/SceneItem.py
+++ b/GUI/ViewModel/SceneItem.py
@@ -13,7 +13,7 @@ from PySide6.QtCore import Qt
 class SceneItem(ViewModelItem):
     """ Represents a scene in the view model """
     def __init__(self, scene : SubtitleScene):
-        super(SceneItem, self).__init__()
+        super().__init__()
         self.number: int = scene.number
         self.batches: dict[int, BatchItem] = {}
         self.scene_model: dict[str, Any] = {

--- a/GUI/Widgets/OptionsWidgets.py
+++ b/GUI/Widgets/OptionsWidgets.py
@@ -15,7 +15,7 @@ class OptionWidget(QWidget):
     contentChanged = Signal()
 
     def __init__(self, key, initial_value, parent=None, tooltip = None):
-        super(OptionWidget, self).__init__(parent)
+        super().__init__(parent)
         self.key = key
         self.name = _(key)
         self.initial_value = initial_value
@@ -31,7 +31,7 @@ class OptionWidget(QWidget):
 
 class TextOptionWidget(OptionWidget):
     def __init__(self, key, initial_value, tooltip = None):
-        super(TextOptionWidget, self).__init__(key, initial_value, tooltip=tooltip)
+        super().__init__(key, initial_value, tooltip=tooltip)
         self._layout = QHBoxLayout(self)
         self._layout.setContentsMargins(0,0,0,0)
         self.text_field = QLineEdit(self)
@@ -57,7 +57,7 @@ class TextOptionWidget(OptionWidget):
 
 class MultilineTextOptionWidget(OptionWidget):
     def __init__(self, key, initial_value, tooltip = None):
-        super(MultilineTextOptionWidget, self).__init__(key, initial_value, tooltip=tooltip)
+        super().__init__(key, initial_value, tooltip=tooltip)
         content = self._get_content(initial_value).strip()
 
         self._layout = QVBoxLayout(self)
@@ -113,7 +113,7 @@ class MultilineTextOptionWidget(OptionWidget):
 
 class IntegerOptionWidget(OptionWidget):
     def __init__(self, key, initial_value, tooltip = None):
-        super(IntegerOptionWidget, self).__init__(key, initial_value, tooltip=tooltip)
+        super().__init__(key, initial_value, tooltip=tooltip)
         self.spin_box = QSpinBox(self)
         self.spin_box.setMaximum(99999)
         self.spin_box.setMinimumWidth(100)
@@ -139,7 +139,7 @@ class IntegerOptionWidget(OptionWidget):
 
 class FloatOptionWidget(OptionWidget):
     def __init__(self, key, initial_value, tooltip = None):
-        super(FloatOptionWidget, self).__init__(key, initial_value, tooltip=tooltip)
+        super().__init__(key, initial_value, tooltip=tooltip)
         self.double_spin_box = QDoubleSpinBox(self)
         self.double_spin_box.setMaximum(9999.99)
         self.double_spin_box.setMinimumWidth(100)
@@ -165,7 +165,7 @@ class FloatOptionWidget(OptionWidget):
 
 class CheckboxOptionWidget(OptionWidget):
     def __init__(self, key, initial_value, tooltip = None):
-        super(CheckboxOptionWidget, self).__init__(key, initial_value, tooltip=tooltip)
+        super().__init__(key, initial_value, tooltip=tooltip)
         self.check_box = QCheckBox(self)
         self.check_box.stateChanged.connect(self.contentChanged)
         if initial_value:
@@ -188,7 +188,7 @@ class CheckboxOptionWidget(OptionWidget):
 
 class DropdownOptionWidget(OptionWidget):
     def __init__(self, key, values, initial_value, tooltip = None):
-        super(DropdownOptionWidget, self).__init__(key, initial_value, tooltip=tooltip)
+        super().__init__(key, initial_value, tooltip=tooltip)
         self.combo_box = QComboBox(self)
         self.combo_box.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
         self.SetOptions(values, initial_value)

--- a/GUI/Widgets/Widgets.py
+++ b/GUI/Widgets/Widgets.py
@@ -14,7 +14,7 @@ from PySubtitle.Helpers.Localization import _
 
 class TreeViewItemWidget(QFrame):
     def __init__(self, content, parent=None):
-        super(TreeViewItemWidget, self).__init__(parent)
+        super().__init__(parent)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 
         properties = content.get('properties', {})
@@ -53,19 +53,19 @@ class TreeViewItemWidget(QFrame):
 
 class WidgetHeader(QLabel):
     def __init__(self, text, parent=None):
-        super(WidgetHeader, self).__init__(parent)
+        super().__init__(parent)
         self.setText(text)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
 class WidgetSubheading(QLabel):
     def __init__(self, text, parent=None):
-        super(WidgetSubheading, self).__init__(parent)
+        super().__init__(parent)
         self.setText(text)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
 class WidgetFooter(QFrame):
     def __init__(self, text, parent=None):
-        super(WidgetFooter, self).__init__(parent)
+        super().__init__(parent)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -81,7 +81,7 @@ class WidgetFooter(QFrame):
 
 class WidgetBody(QLabel):
     def __init__(self, text, parent=None):
-        super(WidgetBody, self).__init__(parent)
+        super().__init__(parent)
         self.setText(text)
         self.setAlignment(Qt.AlignmentFlag.AlignTop)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
@@ -89,7 +89,7 @@ class WidgetBody(QLabel):
 
 class LineItemView(QWidget):
     def __init__(self, line, parent=None):
-        super(LineItemView, self).__init__(parent)
+        super().__init__(parent)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 
         layout = QVBoxLayout()
@@ -105,7 +105,7 @@ class LineItemView(QWidget):
 
 class LineItemHeader(QFrame):
     def __init__(self, line, parent=None):
-        super(LineItemHeader, self).__init__(parent)
+        super().__init__(parent)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         layout = QHBoxLayout()
@@ -124,7 +124,7 @@ class LineItemHeader(QFrame):
 
 class LineItemBody(QLabel):
     def __init__(self, text: str, parent=None):
-        super(LineItemBody, self).__init__(parent)
+        super().__init__(parent)
         self.setText(text)
         self.setAlignment(Qt.AlignmentFlag.AlignTop)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)


### PR DESCRIPTION
Speculative fix for user-reported errors:

```
Error saving settings to C:\Users\User\Downloads\llm-subtrans\settings.json Error initialising project settings: super(type, obj): obj must be an instance or subtype of type
```

Likely triggered by `NewProjectSettings` dialog, though unclear why it affects this specific user. Could not repro locally, but the fix seems at least harmless on my installation - GUI continues to work as expected.