### PR TITLE
fix: extract basic tags from inline composite blocks

### DIFF
--- a/PySubtitle/UnitTests/test_AssFileHandler.py
+++ b/PySubtitle/UnitTests/test_AssFileHandler.py
@@ -300,6 +300,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             ("No formatting", "No formatting"),
             ("{\\pos(100,200)}Positioned text", "Positioned text"),  # Position removed
             ("{\\c&H00FF00&}Colored text", "Colored text"),  # Color removed
+            ("Text {\\c&H00FF00&\\i1}hello{\\i0}", "Text {\\c&H00FF00&}<i>hello</i>"),
         ]
         
         for ass_input, expected_html in test_cases:


### PR DESCRIPTION
## Summary
- extract basic ASS formatting tags from composite override blocks anywhere in the line
- cover inline composite blocks with unit test

## Testing
- `pytest PySubtitle/UnitTests/test_AssFileHandler.py::TestAssFileHandler::test_ass_to_html_formatting_conversion -q` *(fails: ModuleNotFoundError: No module named 'pysubs2')*

------
https://chatgpt.com/codex/tasks/task_e_68b73ddc0a4c8329b12b17186c9a2030