### PR TITLE
Detect subtitle format and generalize override tags

### DIFF
--- a/PySubtitle/Formats/AssFileHandler.py
+++ b/PySubtitle/Formats/AssFileHandler.py
@@ -85,13 +85,14 @@ class AssFileHandler(SubtitleFileHandler):
         subs : pysubs2.SSAFile = pysubs2.SSAFile()
         subs.info["TranslatedBy"] = "LLM-Subtrans"
 
-        file_format = data.metadata.get('pysubs2_format', 'ass') if data.metadata else 'ass'
-
         if data.metadata:
             self._build_metadata(subs, data.metadata)
 
-        subs.format = file_format
-        
+            # Restore original detected format (TODO: allow SSA/ASS conversions)
+            file_format = data.metadata.get('pysubs2_format', 'ass')
+        else:
+            file_format = 'ass'
+
         # Convert SubtitleLines to pysubs2 format
         for line in data.lines:
             if line.text and line.start is not None and line.end is not None:
@@ -220,8 +221,6 @@ class AssFileHandler(SubtitleFileHandler):
         Restore pysubs2 metadata from JSON-serialized format.
         Converts Color dicts back to pysubs2.Color objects.
         """
-        subs.format = metadata.get('pysubs2_format', 'ass')
-
         # Restore script info from metadata
         if 'info' in metadata:
             subs.info.update(metadata['info'])

--- a/PySubtitle/Formats/AssFileHandler.py
+++ b/PySubtitle/Formats/AssFileHandler.py
@@ -85,13 +85,10 @@ class AssFileHandler(SubtitleFileHandler):
         subs : pysubs2.SSAFile = pysubs2.SSAFile()
         subs.info["TranslatedBy"] = "LLM-Subtrans"
 
-        if data.metadata:
-            self._build_metadata(subs, data.metadata)
+        self._build_metadata(subs, data.metadata)
 
-            # Restore original detected format (TODO: allow SSA/ASS conversions)
-            file_format = data.metadata.get('pysubs2_format', 'ass')
-        else:
-            file_format = 'ass'
+        # Restore original detected format (TODO: allow SSA/ASS conversions)
+        file_format = data.metadata.get('pysubs2_format', 'ass')
 
         # Convert SubtitleLines to pysubs2 format
         for line in data.lines:

--- a/PySubtitle/Formats/AssFileHandler.py
+++ b/PySubtitle/Formats/AssFileHandler.py
@@ -17,7 +17,7 @@ _TAG_BLOCK_PATTERN = regex.compile(r'\{[^}]+\}')
 _STANDALONE_BASIC_TAG_PATTERN = regex.compile(r'^\{\\(?:[ibs][01]|u[01]?)\}$')
 _BASIC_TAG_PATTERN = regex.compile(r'\\(?:[ibs][01]|u[01]?)')
 
-# Precompiled ASS to HTML conversion patterns
+# Precompiled SSA to HTML conversion patterns
 _ASS_TO_HTML_PATTERNS = [
     (regex.compile(r'{\\i1}'), '<i>'),
     (regex.compile(r'{\\i0}'), '</i>'),
@@ -29,7 +29,7 @@ _ASS_TO_HTML_PATTERNS = [
     (regex.compile(r'{\\s0}'), '</s>')
 ]
 
-# Precompiled HTML to ASS conversion patterns
+# Precompiled HTML to SSA conversion patterns
 _HTML_TO_ASS_PATTERNS = [
     (regex.compile(r'<i>'), r'{\\i1}'),
     (regex.compile(r'</i>'), r'{\\i0}'),
@@ -52,64 +52,41 @@ class AssFileHandler(SubtitleFileHandler):
     
     def parse_file(self, file_obj: TextIO) -> SubtitleData:
         """
-        Parse ASS file content and return SubtitleData with lines and metadata.
+        Parse file content and return SubtitleData with lines and metadata.
         """
         try:
-            # pysubs2 expects file path or string content, so read the file
-            content = file_obj.read()
-            subs = pysubs2.SSAFile.from_string(content)
-            subtitle_format = getattr(subs, "format", "ass")
-
-            lines = []
-            for index, line in enumerate(subs, 1):
-                lines.append(self._pysubs2_to_subtitle_line(line, index, subtitle_format))
-
-            # Extract serializable metadata using helper
-            metadata = self._parse_metadata(subs)
-            
-            return SubtitleData(lines=lines, metadata=metadata)
+            subs : pysubs2.SSAFile = pysubs2.SSAFile.from_file(file_obj)
+            return self._parse_subs(subs)
                 
         except Exception as e:
-            raise SubtitleParseError(_("Failed to parse ASS file: {}").format(str(e)), e)
-    
+            raise SubtitleParseError(_("Failed to parse file: {}").format(str(e)), e)
+
     def parse_string(self, content: str) -> SubtitleData:
         """
-        Parse ASS string content and return SubtitleData with lines and metadata.
+        Parse string content and return SubtitleData with lines and metadata.
         """
         try:
-            # pysubs2 can load from string
             subs = pysubs2.SSAFile.from_string(content)
-            subtitle_format = getattr(subs, "format", "ass")
-
-            lines = []
-            for index, line in enumerate(subs, 1):
-                lines.append(self._pysubs2_to_subtitle_line(line, index, subtitle_format))
-
-            # Extract serializable metadata using helper
-            metadata = self._parse_metadata(subs)
-            
-            return SubtitleData(lines=lines, metadata=metadata)
+            return self._parse_subs(subs)
                 
         except Exception as e:
-            raise SubtitleParseError(_("Failed to parse ASS content: {}").format(str(e)), e)
+            raise SubtitleParseError(_("Failed to parse content: {}").format(str(e)), e)
     
     def compose(self, data: SubtitleData) -> str:
         """
-        Compose subtitle lines into ASS format string using metadata.
+        Compose subtitle lines into SSA/ASS format string using metadata.
         
         Args:
             data: SubtitleData containing lines and file metadata
             
         Returns:
-            str: ASS formatted subtitle content
+            str: formatted subtitle content
         """
-        # Create pysubs2 SSAFile
         subs : pysubs2.SSAFile = pysubs2.SSAFile()
         subs.info["TranslatedBy"] = "LLM-Subtrans"
 
         file_format = data.metadata.get('format', 'ass') if data.metadata else 'ass'
 
-        # Restore metadata using helper
         if data.metadata:
             self._build_metadata(subs, data.metadata)
 
@@ -121,24 +98,34 @@ class AssFileHandler(SubtitleFileHandler):
                 pysubs2_line = self._subtitle_line_to_pysubs2(line)
                 subs.append(pysubs2_line)
         
-        # Return as string
         return subs.to_string(file_format)
     
-    
+    def _parse_subs(self, subs : pysubs2.SSAFile):
+        """
+        Convert pysubs2 subtitles to SubtitleLines, adding an index
+        """
+        subtitle_format : str = getattr(subs, "format", "ass")
+
+        lines : list[SubtitleLine] = []
+        for index, line in enumerate(subs, 1):
+            lines.append(self._pysubs2_to_subtitle_line(line, index, subtitle_format))
+
+        # Extract serializable metadata
+        metadata = self._parse_metadata(subs)
+            
+        return SubtitleData(lines=lines, metadata=metadata)
+        
     def _pysubs2_to_subtitle_line(self, pysubs2_line: pysubs2.SSAEvent, index: int,
                                   subtitle_format: str) -> SubtitleLine:
         """Convert pysubs2 SSAEvent to SubtitleLine with metadata preservation."""
         
-        # Convert timing from milliseconds to timedelta
         start = timedelta(milliseconds=pysubs2_line.start)
         end = timedelta(milliseconds=pysubs2_line.end)
         
         # Extract text content using .text to preserve inline formatting,
-        # then convert ASS tags to HTML for GUI compatibility
-        text = self._ass_to_html(pysubs2_line.text)
+        # then convert SSA tags to HTML for SRT and GUI compatibility
+        text = self._ssa_to_html(pysubs2_line.text)
         
-        # Create comprehensive metadata from pysubs2 properties
-        # This is "pass-through" - we preserve everything for format fidelity
         metadata = {
             'format': subtitle_format,
             'style': pysubs2_line.style,
@@ -166,12 +153,11 @@ class AssFileHandler(SubtitleFileHandler):
         )
     
     def _subtitle_line_to_pysubs2(self, line: SubtitleLine) -> pysubs2.SSAEvent:
-        """Convert SubtitleLine back to pysubs2 SSAEvent using preserved metadata."""
-        
-        # Create pysubs2 event
+        """
+        Convert SubtitleLine back to pysubs2 SSAEvent using preserved metadata.
+        """
         event = pysubs2.SSAEvent()
         
-        # Set timing (convert from timedelta to milliseconds)
         if line.start:
             event.start = pysubs2.time.make_time(s=line.start.total_seconds())
         else:
@@ -182,25 +168,25 @@ class AssFileHandler(SubtitleFileHandler):
         else:
             event.end = 0
         
-        # Convert HTML tags back to ASS tags, then set text directly
+        # Convert HTML tags back to SSA tags, then set text directly
         ass_text = self._html_to_ass(line.text or "")
         
-        # Restore whole-line ASS tags from metadata
+        # Restore whole-line SSA tags from metadata
         ass_text = self._restore_whole_line_tags(ass_text, line.metadata or {})
         
         # Use .text property instead of .plaintext to preserve formatting
         event.text = ass_text
         
-        # Restore metadata if available, otherwise use sensible defaults
-        metadata = line.metadata or {}
-        event.style = metadata.get('style', 'Default')
-        event.layer = metadata.get('layer', 0)
-        event.name = metadata.get('name', '')
-        event.marginl = metadata.get('margin_l', 0)
-        event.marginr = metadata.get('margin_r', 0)
-        event.marginv = metadata.get('margin_v', 0)
-        event.effect = metadata.get('effect', '')
-        event.type = metadata.get('type', 'Dialogue')
+        # Restore metadata if available, otherwise use pysubs2 defaults
+        if line.metadata:
+            event.style = line.metadata.get('style', event.style)
+            event.layer = line.metadata.get('layer', event.layer)
+            event.name = line.metadata.get('name', event.name)
+            event.marginl = line.metadata.get('margin_l', event.marginl)
+            event.marginr = line.metadata.get('margin_r', event.marginr)
+            event.marginv = line.metadata.get('margin_v', event.marginv)
+            event.effect = line.metadata.get('effect', event.effect)
+            event.type = line.metadata.get('type', event.type)
         
         return event
 
@@ -267,13 +253,13 @@ class AssFileHandler(SubtitleFileHandler):
             subs.aegisub_project.update(metadata['aegisub_project'])
     
     def _extract_whole_line_tags(self, ass_text: str) -> dict:
-        """Extract whole-line ASS override tags from start of line and return as metadata."""
+        """Extract whole-line SSA override tags from start of line and return as metadata."""
         if not ass_text:
             return {}
             
         metadata = {}
         
-        # Match consecutive ASS tags at the start of the line
+        # Match consecutive SSA tags at the start of the line
         start_tags_match = _START_TAGS_PATTERN.match(ass_text)
         if start_tags_match:
             tags_section = start_tags_match.group(0)
@@ -299,13 +285,13 @@ class AssFileHandler(SubtitleFileHandler):
         return metadata
     
     def _restore_whole_line_tags(self, text: str, metadata: dict) -> str:
-        """Restore whole-line ASS tags from metadata."""
+        """Restore whole-line SSA tags from metadata."""
         if 'override_tags_start' in metadata:
             return f"{metadata['override_tags_start']}{text}"
         return text
     
-    def _ass_to_html(self, ass_text: str) -> str:
-        """Convert ASS inline formatting tags to HTML tags for GUI display."""
+    def _ssa_to_html(self, ass_text: str) -> str:
+        """Convert SSA inline formatting tags to HTML tags for GUI display."""
         if not ass_text:
             return ""
             
@@ -362,14 +348,14 @@ class AssFileHandler(SubtitleFileHandler):
         for pattern, replacement in _ASS_TO_HTML_PATTERNS:
             text = pattern.sub(replacement, text)
         
-        # For any remaining ASS tags that aren't basic formatting, preserve them
+        # For any remaining SSA tags that aren't basic formatting, preserve them
         # This allows translators to see and preserve complex inline formatting
         # (colors, fonts, etc.) that don't have HTML equivalents
         
         return text
     
     def _html_to_ass(self, html_text: str) -> str:
-        """Convert HTML tags back to ASS inline formatting tags."""
+        """Convert HTML tags back to SSA inline formatting tags."""
         if not html_text:
             return ""
             
@@ -381,7 +367,7 @@ class AssFileHandler(SubtitleFileHandler):
         text = text.replace('<wbr>', '\\n')
         text = text.replace('\n', '\\N')
         
-        # Convert HTML tags back to ASS tags using precompiled patterns
+        # Convert HTML tags back to SSA tags using precompiled patterns
         for pattern, replacement in _HTML_TO_ASS_PATTERNS:
             text = pattern.sub(replacement, text)
         

--- a/PySubtitle/Helpers/Tests.py
+++ b/PySubtitle/Helpers/Tests.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 import logging
 import os
 import sys
@@ -5,6 +6,7 @@ from datetime import datetime
 from typing import Any
 
 from PySubtitle.SettingsType import SettingsType
+from PySubtitle.SubtitleFormatRegistry import SubtitleFormatRegistry
 from PySubtitle.Subtitles import Subtitles
 from PySubtitle.Formats.SrtFileHandler import SrtFileHandler
 
@@ -112,7 +114,7 @@ def _add_test_file_logger(logger, results_path, input_filename, test_name):
     logger.addHandler(file_handler)
     return file_handler
 
-def RunTestOnAllSrtFiles(run_test, test_options: list[dict], directory_path: str, results_path: str|None = None):
+def RunTestOnAllSubtitleFiles(run_test : Callable, test_options: list[dict], directory_path: str, results_path: str|None = None):
     """
     Run a series of tests on all .srt files in the test_subtitles directory.
     """
@@ -131,8 +133,11 @@ def RunTestOnAllSrtFiles(run_test, test_options: list[dict], directory_path: str
     logger.info(separator)
     logger.info("")
 
+    supported_formats = SubtitleFormatRegistry.enumerate_formats()
+
     for file in os.listdir(directory_path):
-        if not file.endswith(".srt"):
+        extension = os.path.splitext(file)[1].lower()
+        if extension not in supported_formats:
             continue
 
         file_handler = _add_test_file_logger(logger, results_path, file, test_name)

--- a/PySubtitle/UnitTests/test_AssFileHandler.py
+++ b/PySubtitle/UnitTests/test_AssFileHandler.py
@@ -42,7 +42,6 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
                 end=timedelta(seconds=3),
                 text="First subtitle line",
                 metadata={
-                    'format': 'ass',
                     'layer': 0,
                     'style': 'Default',
                     'name': '',
@@ -58,7 +57,6 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
                 end=timedelta(seconds=6, milliseconds=500),
                 text="Second subtitle line\nwith line break",
                 metadata={
-                    'format': 'ass',
                     'layer': 0,
                     'style': 'Default',
                     'name': '',
@@ -74,7 +72,6 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
                 end=timedelta(seconds=9),
                 text="Third subtitle line",
                 metadata={
-                    'format': 'ass',
                     'layer': 0,
                     'style': 'Default',
                     'name': '',
@@ -112,9 +109,7 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
                 self.assertEqual(actual.number, expected.number)
                 self.assertEqual(actual.start, expected.start)
                 self.assertEqual(actual.end, expected.end)
-                # pysubs2 plaintext property converts \\N to \n for GUI compatibility
                 self.assertEqual(actual.text, expected.text)
-                self.assertEqual(actual.metadata['format'], expected.metadata['format'])
                 self.assertEqual(actual.metadata['style'], expected.metadata['style'])
     
     def test_parse_file(self):
@@ -140,12 +135,12 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
                 start=timedelta(seconds=1, milliseconds=500),
                 end=timedelta(seconds=3),
                 text="Test subtitle",
-                metadata={'format': 'ass', 'style': 'Default', 'layer': 0, 'name': '', 
+                metadata={'style': 'Default', 'layer': 0, 'name': '', 
                          'margin_l': 0, 'margin_r': 0, 'margin_v': 0, 'effect': ''}
             )
         ]
         
-        data = SubtitleData(lines=lines, metadata={'format': 'ass'})
+        data = SubtitleData(lines=lines, metadata={'pysubs2_format': 'ass'})
         result = self.handler.compose(data)
         
         # Log before assertions
@@ -169,12 +164,11 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
                 start=timedelta(seconds=1),
                 end=timedelta(seconds=3),
                 text="First line\nSecond line",
-                metadata={'format': 'ass', 'style': 'Default', 'layer': 0, 'name': '', 
-                         'margin_l': 0, 'margin_r': 0, 'margin_v': 0, 'effect': ''}
+                metadata={'style': 'Default', 'layer': 0, 'name': '', 'margin_l': 0, 'margin_r': 0, 'margin_v': 0, 'effect': ''}
             )
         ]
         
-        data = SubtitleData(lines=lines, metadata={'format': 'ass'})
+        data = SubtitleData(lines=lines, metadata={'pysubs2_format': 'ass'})
         result = self.handler.compose(data)
         
         # pysubs2 converts newlines back to \\N in ASS format output
@@ -241,7 +235,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         
         # Validate metadata preservation
         log_input_expected_result("Metadata preserved", True, True)
-        self.assertEqual(original_data.metadata['format'], round_trip_data.metadata['format'])
+        self.assertEqual(original_data.metadata['pysubs2_format'], round_trip_data.metadata['pysubs2_format'])
         self.assertIn('styles', original_data.metadata)
         self.assertIn('styles', round_trip_data.metadata)
         self.assertEqual(original_data.metadata['styles'], round_trip_data.metadata['styles'])
@@ -268,8 +262,8 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 Dialogue: Marked=0,0:00:01.00,0:00:02.00,Default,,0000,0000,0000,,SSA line"""
 
         data = self.handler.parse_string(sample_ssa)
-        log_input_expected_result("SSA format", "ssa", data.metadata.get('format'))
-        self.assertEqual(data.metadata.get('format'), 'ssa')
+        log_input_expected_result("SSA format", "ssa", data.metadata.get('pysubs2_format'))
+        self.assertEqual(data.metadata.get('pysubs2_format'), 'ssa')
 
         composed = self.handler.compose(data)
         log_input_expected_result("Round trip format", True, "ScriptType: v4.00" in composed)
@@ -297,7 +291,7 @@ Dialogue: Marked=0,0:00:01.00,0:00:02.00,Default,,0000,0000,0000,,SSA line"""
                     start=test_timedelta,
                     end=test_timedelta + timedelta(seconds=2),
                     text="Test",
-                    metadata={'format': 'ass', 'style': 'Default', 'layer': 0, 'name': '', 
+                    metadata={'style': 'Default', 'layer': 0, 'name': '', 
                              'margin_l': 0, 'margin_r': 0, 'margin_v': 0, 'effect': ''}
                 )
                 

--- a/PySubtitle/UnitTests/test_AssFileHandler.py
+++ b/PySubtitle/UnitTests/test_AssFileHandler.py
@@ -328,7 +328,7 @@ Dialogue: Marked=0,0:00:01.00,0:00:02.00,Default,,0000,0000,0000,,SSA line"""
         
         for ass_input, expected_html in test_cases:
             with self.subTest(input=ass_input):
-                result = self.handler._ass_to_html(ass_input)
+                result = self.handler._ssa_to_html(ass_input)
                 log_input_expected_result(ass_input, expected_html, result)
                 self.assertEqual(result, expected_html)
     
@@ -561,7 +561,7 @@ Dialogue: 0,0:00:13.00,0:00:15.00,Default,,0,0,0,,{\\i1}Italic with {\\b1}bold{\
         
         for ass_input, expected_html in conversion_cases:
             with self.subTest(input=ass_input):
-                result = self.handler._ass_to_html(ass_input)
+                result = self.handler._ssa_to_html(ass_input)
                 log_input_expected_result(f"Convert: {ass_input}", expected_html, result)
                 self.assertEqual(result, expected_html)
     
@@ -585,7 +585,7 @@ Dialogue: 0,0:00:13.00,0:00:15.00,Default,,0,0,0,,{\\i1}Italic with {\\b1}bold{\
         
         for ass_input, expected_html in test_cases:
             with self.subTest(input=ass_input):
-                result = self.handler._ass_to_html(ass_input)
+                result = self.handler._ssa_to_html(ass_input)
                 log_input_expected_result(f"Composite: {ass_input}", expected_html, result)
                 self.assertEqual(result, expected_html)
         

--- a/PySubtitle/UnitTests/test_AssFileHandler.py
+++ b/PySubtitle/UnitTests/test_AssFileHandler.py
@@ -251,6 +251,29 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             self.assertEqual(original.start, round_trip.start)
             self.assertEqual(original.end, round_trip.end)
             self.assertEqual(original.text, round_trip.text)
+
+    def test_detect_ssa_format(self):
+        """Ensure SSA files retain their format information."""
+        log_test_name("AssFileHandler SSA format detection")
+
+        sample_ssa = """[Script Info]
+ScriptType: v4.00
+
+[V4 Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding
+Style: Default,Arial,20,16777215,16777215,16777215,0,-1,0,1,2,2,2,10,10,10,0,0
+
+[Events]
+Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: Marked=0,0:00:01.00,0:00:02.00,Default,,0000,0000,0000,,SSA line"""
+
+        data = self.handler.parse_string(sample_ssa)
+        log_input_expected_result("SSA format", "ssa", data.metadata.get('format'))
+        self.assertEqual(data.metadata.get('format'), 'ssa')
+
+        composed = self.handler.compose(data)
+        log_input_expected_result("Round trip format", True, "ScriptType: v4.00" in composed)
+        self.assertIn("ScriptType: v4.00", composed)
     
     def test_subtitle_line_to_pysubs2_time_conversion(self):
         """Test that _subtitle_line_to_pysubs2 correctly converts timedelta to pysubs2 milliseconds."""
@@ -419,27 +442,27 @@ Dialogue: 0,0:00:13.00,0:00:15.00,Default,,0,0,0,,{\\i1}Italic with {\\b1}bold{\
         # Test complex whole-line tags extraction
         complex_line = lines[0]
         log_input_expected_result("Complex tags extracted", "{\\pos(100,200)\\an5\\fs20}", 
-                                complex_line.metadata.get('ssa_tags_start', ''))
+                                complex_line.metadata.get('override_tags_start', ''))
         
         self.assertEqual(complex_line.text, "Complex positioned text")
-        self.assertIn('ssa_tags_start', complex_line.metadata)
-        self.assertEqual(complex_line.metadata['ssa_tags_start'], "{\\pos(100,200)\\an5\\fs20}")
+        self.assertIn('override_tags_start', complex_line.metadata)
+        self.assertEqual(complex_line.metadata['override_tags_start'], "{\\pos(100,200)\\an5\\fs20}")
         
         # Test multiple tag blocks
         multi_line = lines[1]
         log_input_expected_result("Multiple blocks extracted", "{\\pos(50,100)}{\\c&H00FF00&}", 
-                                multi_line.metadata.get('ssa_tags_start', ''))
+                                multi_line.metadata.get('override_tags_start', ''))
         
         self.assertEqual(multi_line.text, "Multiple tag blocks")
-        self.assertIn('ssa_tags_start', multi_line.metadata)
-        self.assertEqual(multi_line.metadata['ssa_tags_start'], "{\\pos(50,100)}{\\c&H00FF00&}")
+        self.assertIn('override_tags_start', multi_line.metadata)
+        self.assertEqual(multi_line.metadata['override_tags_start'], "{\\pos(50,100)}{\\c&H00FF00&}")
         
         # Test normal text unchanged
         normal_line = lines[2]
         log_input_expected_result("Normal text unchanged", "Normal text", normal_line.text)
         
         self.assertEqual(normal_line.text, "Normal text")
-        self.assertNotIn('ssa_tags_start', normal_line.metadata)
+        self.assertNotIn('override_tags_start', normal_line.metadata)
         
         # Test inline tags preserved
         inline_line = lines[3]
@@ -450,7 +473,7 @@ Dialogue: 0,0:00:13.00,0:00:15.00,Default,,0,0,0,,{\\i1}Italic with {\\b1}bold{\
             
             self.assertIn("{\\c&H0000FF&}", inline_line.text)
             self.assertIn("{\\c}", inline_line.text)
-            self.assertNotIn('ssa_tags_start', inline_line.metadata)
+            self.assertNotIn('override_tags_start', inline_line.metadata)
         
         # Test mixed HTML and inline ASS tags
         mixed_line = lines[4]
@@ -458,7 +481,7 @@ Dialogue: 0,0:00:13.00,0:00:15.00,Default,,0,0,0,,{\\i1}Italic with {\\b1}bold{\
                                 "<i>Italic with <b>bold</b> inside</i>", mixed_line.text)
         
         self.assertEqual(mixed_line.text, "<i>Italic with <b>bold</b> inside</i>")
-        self.assertNotIn('ssa_tags_start', mixed_line.metadata)
+        self.assertNotIn('override_tags_start', mixed_line.metadata)
         
         # Test round-trip preservation
         composed_ass = self.handler.compose(data)
@@ -477,10 +500,10 @@ Dialogue: 0,0:00:13.00,0:00:15.00,Default,,0,0,0,,{\\i1}Italic with {\\b1}bold{\
         # Verify round-trip preservation of metadata
         rt_complex = round_trip_lines[0]
         log_input_expected_result("Round-trip metadata preserved", True, 
-                                rt_complex.metadata.get('ssa_tags_start', '') == "{\\pos(100,200)\\an5\\fs20}")
+                                rt_complex.metadata.get('override_tags_start', '') == "{\\pos(100,200)\\an5\\fs20}")
         
         self.assertEqual(rt_complex.text, "Complex positioned text")
-        self.assertEqual(rt_complex.metadata.get('ssa_tags_start', ''), "{\\pos(100,200)\\an5\\fs20}")
+        self.assertEqual(rt_complex.metadata.get('override_tags_start', ''), "{\\pos(100,200)\\an5\\fs20}")
     
     def test_tag_extraction_functions(self):
         """Test ASS tag extraction and restoration functions."""
@@ -489,11 +512,11 @@ Dialogue: 0,0:00:13.00,0:00:15.00,Default,,0,0,0,,{\\i1}Italic with {\\b1}bold{\
         # Test extraction function
         extraction_cases = [
             # Single tag block
-            ("{\\pos(100,200)}Text here", {"ssa_tags_start": "{\\pos(100,200)}"}),
+            ("{\\pos(100,200)}Text here", {"override_tags_start": "{\\pos(100,200)}"}),
             # Multiple consecutive tags
-            ("{\\pos(100,200)\\an5\\fs20}Text", {"ssa_tags_start": "{\\pos(100,200)\\an5\\fs20}"}),
+            ("{\\pos(100,200)\\an5\\fs20}Text", {"override_tags_start": "{\\pos(100,200)\\an5\\fs20}"}),
             # Multiple tag blocks
-            ("{\\pos(50,100)}{\\c&H00FF00&}Text", {"ssa_tags_start": "{\\pos(50,100)}{\\c&H00FF00&}"}),
+            ("{\\pos(50,100)}{\\c&H00FF00&}Text", {"override_tags_start": "{\\pos(50,100)}{\\c&H00FF00&}"}),
             # No whole-line tags
             ("Normal text", {}),
             # Inline tags only
@@ -509,9 +532,9 @@ Dialogue: 0,0:00:13.00,0:00:15.00,Default,,0,0,0,,{\\i1}Italic with {\\b1}bold{\
         # Test restoration function
         restoration_cases = [
             # Restore single tag
-            ("Text", {"ssa_tags_start": "{\\pos(100,200)}"}, "{\\pos(100,200)}Text"),
+            ("Text", {"override_tags_start": "{\\pos(100,200)}"}, "{\\pos(100,200)}Text"),
             # Restore complex tags
-            ("Text", {"ssa_tags_start": "{\\pos(100,200)\\an5\\fs20}"}, "{\\pos(100,200)\\an5\\fs20}Text"),
+            ("Text", {"override_tags_start": "{\\pos(100,200)\\an5\\fs20}"}, "{\\pos(100,200)\\an5\\fs20}Text"),
             # No metadata
             ("Text", {}, "Text"),
             # Other metadata present
@@ -591,13 +614,13 @@ Dialogue: 0,0:00:04.00,0:00:06.00,Default,,0,0,0,,{\\c&H00FF00&\\b1}Green bold t
         italic_line = lines[0]
         log_input_expected_result("Composite italic in GUI", "<i>Italic positioned text</i>", italic_line.text)
         self.assertEqual(italic_line.text, "<i>Italic positioned text</i>")
-        self.assertEqual(italic_line.metadata.get('ssa_tags_start'), "{\\pos(100,200)}")
+        self.assertEqual(italic_line.metadata.get('override_tags_start'), "{\\pos(100,200)}")
         
         # Verify bold formatting preserved in GUI
         bold_line = lines[1]
         log_input_expected_result("Composite bold in GUI", "<b>Green bold text</b>", bold_line.text)
         self.assertEqual(bold_line.text, "<b>Green bold text</b>")
-        self.assertEqual(bold_line.metadata.get('ssa_tags_start'), "{\\c&H00FF00&}")
+        self.assertEqual(bold_line.metadata.get('override_tags_start'), "{\\c&H00FF00&}")
         
         # Test round-trip - verify both positioning and formatting restored
         composed = self.handler.compose(data)

--- a/PySubtitle/UnitTests/test_SubtitleProjectFormats.py
+++ b/PySubtitle/UnitTests/test_SubtitleProjectFormats.py
@@ -48,7 +48,6 @@ class TestSubtitleProjectFormats(unittest.TestCase):
         project.InitialiseProject(path)
         self.assertIsNotNone(project.subtitles)
         self.assertEqual(project.subtitles.format, ".srt")
-        self.assertEqual(project.subtitles.metadata.get('format'), 'srt')
 
     def test_project_file_roundtrip_preserves_handler(self):
         path = self._create_temp_srt()
@@ -56,7 +55,6 @@ class TestSubtitleProjectFormats(unittest.TestCase):
         project.InitialiseProject(path)
         self.assertIsNotNone(project.subtitles)
         self.assertEqual(project.subtitles.format, ".srt")
-        self.assertEqual(project.subtitles.metadata.get('format'), 'srt')
         
         # Set outputpath so file handler can be restored on load
         project_path = path.replace('.srt', '.subtrans')
@@ -69,7 +67,6 @@ class TestSubtitleProjectFormats(unittest.TestCase):
         reopened_project.ReadProjectFile(project_path)
         self.assertIsNotNone(reopened_project.subtitles)
         self.assertEqual(reopened_project.subtitles.format, ".srt")
-        self.assertEqual(reopened_project.subtitles.metadata.get('format'), 'srt')
 
     def test_srt_metadata_serialization(self):
         """Test SRT metadata survives JSON serialization through Subtitles."""
@@ -82,14 +79,7 @@ class TestSubtitleProjectFormats(unittest.TestCase):
         
         # Verify basic loading
         self.assertEqual(subtitles.linecount, 1)
-        self.assertEqual(subtitles.metadata.get('format'), 'srt')
         
-        # Test JSON serialization roundtrip
-        json_str = json.dumps(subtitles, cls=SubtitleEncoder)
-        subtitles_restored = json.loads(json_str, cls=SubtitleDecoder)
-        
-        self.assertEqual(subtitles_restored.metadata.get('format'), 'srt')
-
     def test_ass_metadata_serialization(self):
         """Test ASS metadata with colors survives JSON serialization through Subtitles."""
         ass_content = """[Script Info]
@@ -112,7 +102,7 @@ Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello World!
         
         # Verify basic loading
         self.assertEqual(subtitles.linecount, 1)
-        self.assertEqual(subtitles.metadata.get('format'), 'ass')
+        self.assertEqual(subtitles.metadata.get('pysubs2_format'), 'ass')
         self.assertIn('styles', subtitles.metadata)
         
         # Check that colors are properly converted to Color object
@@ -129,7 +119,7 @@ Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello World!
         json_str = json.dumps(subtitles, cls=SubtitleEncoder)
         subtitles_restored = json.loads(json_str, cls=SubtitleDecoder)
         
-        self.assertEqual(subtitles_restored.metadata.get('format'), 'ass')
+        self.assertEqual(subtitles_restored.metadata.get('pysubs2_format'), 'ass')
         self.assertIn('styles', subtitles_restored.metadata)
         
         # Verify colors survived serialization

--- a/Tests/batcher_test.py
+++ b/Tests/batcher_test.py
@@ -1,7 +1,7 @@
 import os
 from PySubtitle.SubtitleBatcher import SubtitleBatcher
 from PySubtitle.Subtitles import Subtitles
-from PySubtitle.Helpers.Tests import RunTestOnAllSrtFiles, separator
+from PySubtitle.Helpers.Tests import RunTestOnAllSubtitleFiles, separator
 
 def analyze_scenes(scenes):
     num_scenes = len(scenes)
@@ -59,7 +59,7 @@ def run_tests(directory_path, results_path):
         { 'min_batch_size': 16, 'max_batch_size': 80, 'scene_threshold': 40 },
     ]
 
-    RunTestOnAllSrtFiles(batcher_test, test_options, directory_path, results_path)
+    RunTestOnAllSubtitleFiles(batcher_test, test_options, directory_path, results_path)
 
 if __name__ == "__main__":
     directory_path = os.path.join(os.getcwd(), "test_subtitles")

--- a/Tests/preprocessor_test.py
+++ b/Tests/preprocessor_test.py
@@ -2,7 +2,7 @@ import os
 from PySubtitle.SettingsType import SettingsType
 from PySubtitle.Subtitles import Subtitles
 from PySubtitle.SubtitleProcessor import SubtitleProcessor
-from PySubtitle.Helpers.Tests import RunTestOnAllSrtFiles, separator
+from PySubtitle.Helpers.Tests import RunTestOnAllSubtitleFiles, separator
 
 def preprocess_test(subtitles: Subtitles, logger, options : SettingsType):
     if not subtitles.originals:
@@ -47,7 +47,7 @@ def run_tests(directory_path : str, results_path : str|None = None):
         { 'max_line_duration': 4.0, 'min_line_duration': 0.8, 'min_gap': 0.05, 'min_split_chars': 8, 'whitespaces_to_newline': True, 'break_dialog_on_one_line': False, 'normalise_dialog_tags': False}
     ]
 
-    RunTestOnAllSrtFiles(preprocess_test, test_options, directory_path, results_path)
+    RunTestOnAllSubtitleFiles(preprocess_test, test_options, directory_path, results_path)
 
 if __name__ == "__main__":
     directory_path = os.path.join(os.getcwd(), "test_subtitles")

--- a/docs/multi-format-support-proposal.md
+++ b/docs/multi-format-support-proposal.md
@@ -470,49 +470,7 @@ Any libraries used must be:
 - **Translation Focus**: Optimize for subtitle translation workflow while maintaining format integrity
 
 ### Handler Template Pattern
-All pysubs2-based handlers follow this proven pattern from `AssFileHandler`:
-
-```python
-class [Format]FileHandler(SubtitleFileHandler):
-    def parse_string(self, content: str) -> SubtitleData:
-        subs = pysubs2.SSAFile.from_string(content)
-        
-        lines = []
-        for index, line in enumerate(subs, 1):
-            lines.append(self._pysubs2_to_subtitle_line(line, index))
-        
-        # Extract serializable metadata
-        metadata = {
-            'format': '[format]',
-            'info': dict(subs.info),
-            'styles': {name: style.as_dict() for name, style in subs.styles.items()}
-        }
-        
-        return SubtitleData(lines=lines, metadata=metadata)
-    
-    def compose(self, data: SubtitleData) -> str:
-        subs = pysubs2.SSAFile()
-        
-        # Restore file-level metadata
-        if 'info' in data.metadata:
-            subs.info.update(data.metadata['info'])
-        if 'styles' in data.metadata:
-            for style_name, style_fields in data.metadata['styles'].items():
-                subs.styles[style_name] = pysubs2.SSAStyle(**style_fields)
-        
-        # Convert lines
-        for line in data.lines:
-            pysubs2_line = self._subtitle_line_to_pysubs2(line)
-            subs.append(pysubs2_line)
-        
-        return subs.to_string("[format]")
-    
-    def _pysubs2_to_subtitle_line(self, pysubs2_line, index):
-        # Convert with metadata preservation
-    
-    def _subtitle_line_to_pysubs2(self, line):
-        # Restore from preserved metadata or use defaults
-```
+All pysubs2-based handlers follow the pattern from `AssFileHandler` (TODO: extract a pysubs2 file parser to handle commonalities)
 
 ### Metadata Strategy
 - **Standard Fields**: Common subtitle properties (timing, text, style, layer)


### PR DESCRIPTION
## Summary
- detect ASS vs SSA formats via pysubs2 and retain format in metadata
- write subtitles using stored format and expose override tags generically
- cover SSA detection and override tag logic in updated tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'GUI'; ModuleNotFoundError: No module named 'pysubs2')*

------
https://chatgpt.com/codex/tasks/task_e_68b75a78c9d4832983242a3ac41c0d80