### PR TITLE
ASS to SSA rename

### DIFF
--- a/PySubtitle/Formats/SSAFileHandler.py
+++ b/PySubtitle/Formats/SSAFileHandler.py
@@ -22,7 +22,7 @@ _STANDALONE_BASIC_TAG_PATTERN = regex.compile(r'^\{\\(?:[ibs][01]|u[01]?)\}$')
 _BASIC_TAG_PATTERN = regex.compile(r'\\(?:[ibs][01]|u[01]?)')
 
 # Precompiled SSA to HTML conversion patterns
-_ASS_TO_HTML_PATTERNS = [
+_SSA_TO_HTML_PATTERNS = [
     (regex.compile(r'{\\i1}'), '<i>'),
     (regex.compile(r'{\\i0}'), '</i>'),
     (regex.compile(r'{\\b1}'), '<b>'),
@@ -34,7 +34,7 @@ _ASS_TO_HTML_PATTERNS = [
 ]
 
 # Precompiled HTML to SSA conversion patterns
-_HTML_TO_ASS_PATTERNS = [
+_HTML_TO_SSA_PATTERNS = [
     (regex.compile(r'<i>'), r'{\\i1}'),
     (regex.compile(r'</i>'), r'{\\i0}'),
     (regex.compile(r'<b>'), r'{\\b1}'),
@@ -46,10 +46,11 @@ _HTML_TO_ASS_PATTERNS = [
 ]
 
 
-class AssFileHandler(SubtitleFileHandler):
+class SSAFileHandler(SubtitleFileHandler):
     """
-    File handler for Advanced SubStation Alpha (ASS/SSA) subtitle format using pysubs2 library.
-    Provides professional-grade ASS handling with full metadata preservation.
+    File handler for Advanced SubStation Alpha (SSA/ASS) subtitle format using pysubs2 library.
+
+    Supports reading and writing SSA/ASS with file- and line-level metadata.
     """
     
     SUPPORTED_EXTENSIONS = {'.ass': 10, '.ssa': 10}
@@ -150,7 +151,7 @@ class AssFileHandler(SubtitleFileHandler):
             'type': pysubs2_line.type
         }
         
-        # Extract whole-line ASS override tags and store in metadata
+        # Extract whole-line SSA override tags and store in metadata
         if pysubs2_line.text:
             extracted_tags = self._extract_whole_line_tags(pysubs2_line.text)
             if extracted_tags:
@@ -356,7 +357,7 @@ class AssFileHandler(SubtitleFileHandler):
         text = text.replace('\\n', '<wbr>')
         
         # Convert basic formatting tags to HTML using precompiled patterns
-        for pattern, replacement in _ASS_TO_HTML_PATTERNS:
+        for pattern, replacement in _SSA_TO_HTML_PATTERNS:
             text = pattern.sub(replacement, text)
         
         # For any remaining SSA tags that aren't basic formatting, preserve them
@@ -379,7 +380,7 @@ class AssFileHandler(SubtitleFileHandler):
         text = text.replace('\n', '\\N')
         
         # Convert HTML tags back to SSA tags using precompiled patterns
-        for pattern, replacement in _HTML_TO_ASS_PATTERNS:
+        for pattern, replacement in _HTML_TO_SSA_PATTERNS:
             text = pattern.sub(replacement, text)
         
         # Preserve any other HTML that might be part of the dialogue content

--- a/PySubtitle/Subtitles.py
+++ b/PySubtitle/Subtitles.py
@@ -363,15 +363,6 @@ class Subtitles:
             with open(outputpath, 'w', encoding=default_encoding) as f:
                 f.write(subtitle_file)
 
-            # Log a warning if any lines had no text or start time
-            num_invalid = len([line for line in translated if line.start is None])
-            if num_invalid:
-                logging.warning(_("{} lines were invalid and were not written to the output file").format(num_invalid))
-
-            num_empty = len([line for line in translated if not line.text])
-            if num_empty:
-                logging.warning(_("{} lines were empty and were not written to the output file").format(num_empty))
-
             self.translated = translated
             self.outputpath = outputpath
 

--- a/PySubtitle/UnitTests/test_SsaFileHandler.py
+++ b/PySubtitle/UnitTests/test_SsaFileHandler.py
@@ -3,20 +3,20 @@ from datetime import timedelta
 import tempfile
 import os
 
-from PySubtitle.Formats.AssFileHandler import AssFileHandler
+from PySubtitle.Formats.SSAFileHandler import SSAFileHandler
 from PySubtitle.SubtitleLine import SubtitleLine
 from PySubtitle.SubtitleData import SubtitleData
 from PySubtitle.SubtitleError import SubtitleParseError
 from PySubtitle.Helpers.Tests import log_info, log_input_expected_result, log_test_name, skip_if_debugger_attached
 
-class TestAssFileHandler(unittest.TestCase):
-    """Test cases for ASS file handler."""
+class TestSSAFileHandler(unittest.TestCase):
+    """Test cases for SSA file handler."""
     
     def setUp(self):
         """Set up test fixtures."""
-        self.handler = AssFileHandler()
+        self.handler = SSAFileHandler()
         
-        # Sample ASS content for testing
+        # Sample SSA content for testing
         self.sample_ass_content = """[Script Info]
 Title: Test Subtitles
 ScriptType: v4.00+
@@ -86,7 +86,7 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
     
     def test_get_file_extensions(self):
         """Test that the handler returns correct file extensions."""
-        log_test_name("AssFileHandler.get_file_extensions")
+        log_test_name("SSAFileHandler.get_file_extensions")
         
         expected = ['.ass', '.ssa']
         result = self.handler.get_file_extensions()
@@ -95,8 +95,8 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
         self.assertEqual(result, expected)
     
     def test_parse_string_basic(self):
-        """Test parsing of basic ASS content."""
-        log_test_name("AssFileHandler.parse_string - basic parsing")
+        """Test parsing of basic SSA content."""
+        log_test_name("SSAFileHandler.parse_string - basic parsing")
         
         data = self.handler.parse_string(self.sample_ass_content)
         lines = data.lines
@@ -115,7 +115,7 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
     
     def test_load_file(self):
         """Test parsing from file path."""
-        log_test_name("AssFileHandler.load_file")
+        log_test_name("SSAFileHandler.load_file")
 
         with tempfile.NamedTemporaryFile('w', delete=False, suffix='.ass', encoding='utf-8') as f:
             f.write(self.sample_ass_content)
@@ -133,8 +133,8 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
     
     
     def test_compose_lines_basic(self):
-        """Test basic line composition to ASS format."""
-        log_test_name("AssFileHandler.compose_lines - basic")
+        """Test basic line composition to SSA format."""
+        log_test_name("SSAFileHandler.compose_lines - basic")
         
         lines = [
             SubtitleLine.Construct(
@@ -155,7 +155,7 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
         has_all_sections = all(section in result for section in expected_sections)
         log_input_expected_result("1 line", True, has_all_sections)
         
-        # Check that the result contains key ASS sections
+        # Check that the result contains key SSA sections
         self.assertIn("[Script Info]", result)
         self.assertIn("[V4+ Styles]", result)
         self.assertIn("[Events]", result)
@@ -163,7 +163,7 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
     
     def test_compose_lines_with_line_breaks(self):
         """Test composition with line breaks."""
-        log_test_name("AssFileHandler.compose_lines - line breaks")
+        log_test_name("SSAFileHandler.compose_lines - line breaks")
         
         lines = [
             SubtitleLine.Construct(
@@ -178,15 +178,15 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Third subtitle line
         data = SubtitleData(lines=lines, metadata={'pysubs2_format': 'ass'})
         result = self.handler.compose(data)
         
-        # pysubs2 converts newlines back to \\N in ASS format output
+        # pysubs2 converts newlines back to \\N in SSA format output
         expected_text = "First line\\NSecond line"
         contains_expected = expected_text in result
-        log_input_expected_result("Contains ASS line break", True, contains_expected)
+        log_input_expected_result("Contains SSA line break", True, contains_expected)
         self.assertIn(expected_text, result)
     
     def test_parse_empty_events_section(self):
-        """Test parsing ASS file with no events."""
-        log_test_name("AssFileHandler.parse_string - no events")
+        """Test parsing SSA file with no events."""
+        log_test_name("SSAFileHandler.parse_string - no events")
         
         content_no_events = """[Script Info]
 Title: Test
@@ -202,17 +202,17 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         data = self.handler.parse_string(content_no_events)
         lines = data.lines
         
-        log_input_expected_result("ASS with no dialogue lines", 0, len(lines))
+        log_input_expected_result("SSA with no dialogue lines", 0, len(lines))
         self.assertEqual(len(lines), 0)
     
     def test_parse_invalid_ass_content(self):
-        """Test error handling for invalid ASS content."""
+        """Test error handling for invalid SSA content."""
         if skip_if_debugger_attached("test_parse_invalid_ass_content"):
             return
             
-        log_test_name("AssFileHandler.parse_string - invalid content")
+        log_test_name("SSAFileHandler.parse_string - invalid content")
         
-        invalid_content = """This is not ASS format content"""
+        invalid_content = """This is not SSA format content"""
         
         assert_raised : bool = True
         with self.assertRaises(SubtitleParseError):
@@ -224,13 +224,13 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
     
     def test_round_trip_conversion(self):
         """Test that parsing and composing results in similar content."""
-        log_test_name("AssFileHandler round-trip conversion")
+        log_test_name("SSAFileHandler round-trip conversion")
         
         # Parse the sample content
         original_data = self.handler.parse_string(self.sample_ass_content)
         original_lines = original_data.lines
         
-        # Compose back to ASS format using original metadata
+        # Compose back to SSA format using original metadata
         composed = self.handler.compose(original_data)
         
         # Parse the composed content again
@@ -255,7 +255,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 
     def test_detect_ssa_format(self):
         """Ensure SSA files retain their format information."""
-        log_test_name("AssFileHandler SSA format detection")
+        log_test_name("SSAFileHandler SSA format detection")
 
         sample_ssa = """[Script Info]
 ScriptType: v4.00
@@ -278,7 +278,7 @@ Dialogue: Marked=0,0:00:01.00,0:00:02.00,Default,,0000,0000,0000,,SSA line"""
     
     def test_subtitle_line_to_pysubs2_time_conversion(self):
         """Test that _subtitle_line_to_pysubs2 correctly converts timedelta to pysubs2 milliseconds."""
-        log_test_name("AssFileHandler._subtitle_line_to_pysubs2 - time conversion")
+        log_test_name("SSAFileHandler._subtitle_line_to_pysubs2 - time conversion")
         
         # Test various time formats with precise timedelta values
         test_cases = [
@@ -309,8 +309,8 @@ Dialogue: Marked=0,0:00:01.00,0:00:02.00,Default,,0000,0000,0000,,SSA line"""
                 self.assertEqual(pysubs2_event.start, expected_ms)
     
     def test_ass_to_html_formatting_conversion(self):
-        """Test ASS tag to HTML conversion."""
-        log_test_name("AssFileHandler._ass_to_html - formatting conversion")
+        """Test SSA tag to HTML conversion."""
+        log_test_name("SSAFileHandler._ass_to_html - formatting conversion")
         
         # Test cases: (input_ass, expected_html)
         test_cases = [
@@ -334,8 +334,8 @@ Dialogue: Marked=0,0:00:01.00,0:00:02.00,Default,,0000,0000,0000,,SSA line"""
                 self.assertEqual(result, expected_html)
     
     def test_html_to_ass_formatting_conversion(self):
-        """Test HTML tag to ASS conversion."""
-        log_test_name("AssFileHandler._html_to_ass - formatting conversion")
+        """Test HTML tag to SSA conversion."""
+        log_test_name("SSAFileHandler._html_to_ass - formatting conversion")
         
         # Test cases: (input_html, expected_ass)
         test_cases = [
@@ -359,9 +359,9 @@ Dialogue: Marked=0,0:00:01.00,0:00:02.00,Default,,0000,0000,0000,,SSA line"""
     
     def test_formatting_round_trip_preservation(self):
         """Test that formatting is preserved through round-trip conversion."""
-        log_test_name("AssFileHandler formatting round-trip")
+        log_test_name("SSAFileHandler formatting round-trip")
         
-        # Sample ASS content with formatting
+        # Sample SSA content with formatting
         formatted_ass_content = """[Script Info]
 Title: Formatting Test
 ScriptType: v4.00+
@@ -392,7 +392,7 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Normal text with\\Nline break
         
         self.assertEqual(original_lines[2].text, "Normal text with\nline break")
         
-        # Compose back to ASS
+        # Compose back to SSA
         composed_ass = self.handler.compose(original_data)
         
         # Parse again to test round-trip
@@ -407,16 +407,16 @@ Dialogue: 0,0:00:07.00,0:00:09.00,Default,,0,0,0,,Normal text with\\Nline break
         
         log_input_expected_result("Round-trip formatting preserved", True, True)
         
-        # Verify original ASS tags are in composed output
-        log_input_expected_result("ASS tags in output", True, "{\\i1}" in composed_ass and "{\\b1}" in composed_ass)
+        # Verify original SSA tags are in composed output
+        log_input_expected_result("SSA tags in output", True, "{\\i1}" in composed_ass and "{\\b1}" in composed_ass)
         self.assertIn("{\\i1}This is italic text{\\i0}", composed_ass)
         self.assertIn("{\\b1}This is bold{\\b0}", composed_ass)
     
     def test_comprehensive_ass_tag_preservation(self):
-        """Test that comprehensive ASS override tags are preserved in metadata."""
-        log_test_name("AssFileHandler comprehensive ASS tag preservation")
+        """Test that comprehensive SSA override tags are preserved in metadata."""
+        log_test_name("SSAFileHandler comprehensive SSA tag preservation")
         
-        # Sample ASS content with various tag types
+        # Sample SSA content with various tag types
         complex_ass_content = """[Script Info]
 Title: Complex Tags Test
 ScriptType: v4.00+
@@ -476,7 +476,7 @@ Dialogue: 0,0:00:13.00,0:00:15.00,Default,,0,0,0,,{\\i1}Italic with {\\b1}bold{\
             self.assertIn("{\\c}", inline_line.text)
             self.assertNotIn('override_tags_start', inline_line.metadata)
         
-        # Test mixed HTML and inline ASS tags
+        # Test mixed HTML and inline SSA tags
         mixed_line = lines[4]
         log_input_expected_result("HTML conversion with inline preservation", 
                                 "<i>Italic with <b>bold</b> inside</i>", mixed_line.text)
@@ -507,8 +507,8 @@ Dialogue: 0,0:00:13.00,0:00:15.00,Default,,0,0,0,,{\\i1}Italic with {\\b1}bold{\
         self.assertEqual(rt_complex.metadata.get('override_tags_start', ''), "{\\pos(100,200)\\an5\\fs20}")
     
     def test_tag_extraction_functions(self):
-        """Test ASS tag extraction and restoration functions."""
-        log_test_name("AssFileHandler tag extraction functions")
+        """Test SSA tag extraction and restoration functions."""
+        log_test_name("SSAFileHandler tag extraction functions")
         
         # Test extraction function
         extraction_cases = [
@@ -568,7 +568,7 @@ Dialogue: 0,0:00:13.00,0:00:15.00,Default,,0,0,0,,{\\i1}Italic with {\\b1}bold{\
     
     def test_composite_tags_with_basic_formatting(self):
         """Test that basic formatting tags within composite blocks are preserved."""
-        log_test_name("AssFileHandler composite tags with basic formatting")
+        log_test_name("SSAFileHandler composite tags with basic formatting")
         
         # Test cases for composite blocks containing basic formatting
         test_cases = [

--- a/PySubtitle/UnitTests/test_SubtitleFormatConversion.py
+++ b/PySubtitle/UnitTests/test_SubtitleFormatConversion.py
@@ -5,10 +5,7 @@ from copy import deepcopy
 
 from PySubtitle.Options import Options
 from PySubtitle.SubtitleBatcher import SubtitleBatcher
-from PySubtitle.SubtitleFileHandler import SubtitleFileHandler
 from PySubtitle.SubtitleProject import SubtitleProject
-from PySubtitle.Formats.SrtFileHandler import SrtFileHandler
-from PySubtitle.Formats.AssFileHandler import AssFileHandler
 from PySubtitle.SubtitleSerialisation import SubtitleEncoder
 
 ASS_SAMPLE = """[Script Info]

--- a/PySubtitle/UnitTests/test_SubtitleFormatRegistry.py
+++ b/PySubtitle/UnitTests/test_SubtitleFormatRegistry.py
@@ -510,7 +510,7 @@ Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Test subtitle
             detected_format = data.metadata.get('detected_format')
             log_input_expected_result(f"detected_format={detected_format}", ".ass", detected_format)
             self.assertEqual(".ass", detected_format)
-            # Check that original metadata from ASS file is preserved
+            # Check that original metadata from SSA file is preserved
             has_info = 'info' in data.metadata
             log_input_expected_result(f"'info' in metadata={has_info}", True, has_info)
             self.assertIn('info', data.metadata)

--- a/PySubtitle/UnitTests/test_SubtitleProjectFormats.py
+++ b/PySubtitle/UnitTests/test_SubtitleProjectFormats.py
@@ -9,7 +9,7 @@ from PySubtitle.SubtitleFormatRegistry import SubtitleFormatRegistry
 from PySubtitle.SubtitleFileHandler import SubtitleFileHandler
 from PySubtitle.SubtitleData import SubtitleData
 from PySubtitle.Formats.SrtFileHandler import SrtFileHandler
-from PySubtitle.Formats.AssFileHandler import AssFileHandler
+from PySubtitle.Formats.SSAFileHandler import SSAFileHandler
 from PySubtitle.SubtitleSerialisation import SubtitleEncoder, SubtitleDecoder
 from PySubtitle.Subtitles import Subtitles
 from PySubtitle.Helpers.Color import Color
@@ -160,7 +160,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,{\\b1}Hello{\\b0} World!
 """
         
-        handler = AssFileHandler()
+        handler = SSAFileHandler()
         subtitles = Subtitles()
         subtitles.LoadSubtitlesFromString(ass_content, handler)
         
@@ -195,7 +195,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Test line
 """
         
-        handler = AssFileHandler()
+        handler = SSAFileHandler()
         subtitles = Subtitles()
         subtitles.LoadSubtitlesFromString(ass_content, handler)
         
@@ -233,7 +233,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,{\\i1}Italic{\\i0} and {\\b1}bold{\\b0} text
 """
         
-        handler = AssFileHandler()
+        handler = SSAFileHandler()
         subtitles = Subtitles()
         subtitles.LoadSubtitlesFromString(ass_content, handler)
         
@@ -259,7 +259,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,{\\pos(100,200)\\b1}Bold text with positioning{\\b0}
 """
         
-        handler = AssFileHandler()
+        handler = SSAFileHandler()
         subtitles = Subtitles()
         subtitles.LoadSubtitlesFromString(ass_content, handler)
         
@@ -290,7 +290,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,{\\pos(100,200)\\b1}Test{\\b0} line
 """
         
-        handler = AssFileHandler()
+        handler = SSAFileHandler()
         data = handler.parse_string(ass_content)
         recomposed = handler.compose(data)
         
@@ -317,7 +317,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Test serialization
 """
         
-        handler = AssFileHandler()
+        handler = SSAFileHandler()
         subtitles = Subtitles()
         subtitles.LoadSubtitlesFromString(ass_content, handler)
         
@@ -365,7 +365,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hard\\Nbreak and\\nsoft break
 """
         
-        handler = AssFileHandler()
+        handler = SSAFileHandler()
         subtitles = Subtitles()
         subtitles.LoadSubtitlesFromString(ass_content, handler)
         

--- a/docs/multi-format-support-proposal.md
+++ b/docs/multi-format-support-proposal.md
@@ -10,13 +10,13 @@ This document captures the architecture and decisions behind LLM-Subtrans's mult
 
 ### Existing Architecture
 - **Core Internal Representation**: `SubtitleLine` objects with timing, text, and metadata
-- **File Format Handling**: `SubtitleFormatRegistry` discovers handlers such as `SrtFileHandler` and `AssFileHandler`
+- **File Format Handling**: `SubtitleFormatRegistry` discovers handlers such as `SrtFileHandler` and `SSAFileHandler`
 - **Integration Points**: `SubtitleProject` reads and writes `Subtitles` files by extension
 - **Serialization**: `SubtitleSerialisation.py` handles project file persistence
 - **Interface**: Abstract `SubtitleFileHandler` defines parsing and composing operations
 
 ### Current Limitations
-- Only SRT and ASS/SSA formats implemented
+- Only SRT and SSA/ASS formats implemented
 - Content-based format detection now implemented via `pysubs2`
 
 ## Architecture Overview
@@ -88,12 +88,12 @@ The implementation prioritizes **subtitle translation** over format conversion:
 - `PySubtitle/Subtitles.py`: Require `file_handler` parameter, remove hardcoded SRT handler
 - `PySubtitle/SubtitleProject.py`: Add format detection, handler selection, conversion logic
 
-### Phase 3: ASS/SSA Format Support [X] COMPLETED
+### Phase 3: SSA/ASS Format Support [X] COMPLETED
 **Requirements**:
-- [X] Implement `AssFileHandler` class supporting Advanced SubStation Alpha format
-- [X] Handle ASS-specific features: styles, positioning, effects, colors
-- [X] Store ASS-specific data in `SubtitleLine.metadata`
-- [X] Support both reading and writing ASS format
+- [X] Implement `SSAFileHandler` class supporting Advanced SubStation Alpha format
+- [X] Handle SSA-specific features: styles, positioning, effects, colors
+- [X] Store SSA-specific data in `SubtitleLine.metadata`
+- [X] Support both reading and writing SSA format
 - [X] Maintain index uniqueness for dialogue events
 
 **Priority System Implementation**:
@@ -103,33 +103,33 @@ The implementation prioritizes **subtitle translation** over format conversion:
 - [x] Registry supports `disable_autodiscovery()` for precise test control
 
 **Acceptance Tests**:
-- [X] Parse basic ASS files with dialogue events
+- [X] Parse basic SSA files with dialogue events
 - [X] Preserve style information in metadata
 - [X] Handle multi-line dialogue correctly
-- [X] Export to ASS format maintaining original styling
+- [X] Export to SSA format maintaining original styling
 - [X] Assign unique indices to all dialogue events
-- [X] Handle ASS timing format conversion
+- [X] Handle SSA timing format conversion
 - [X] Support V4+ Styles and V4 Styles sections
 - [x] `SrtFileHandler` (priority 10) maintains highest priority for .srt files
 
 **Files Created**:
-- [X] `PySubtitle/Formats/AssFileHandler.py` (pysubs2-based implementation)
-- [X] `PySubtitle/UnitTests/test_AssFileHandler.py`
+- [X] `PySubtitle/Formats/SSAFileHandler.py` (pysubs2-based implementation)
+- [X] `PySubtitle/UnitTests/test_SSAFileHandler.py`
 
 **Implementation Outcome**:
-The project standardised on a pysubs2-based `AssFileHandler`, which provides full metadata preservation and round-trip fidelity. Early custom efforts were discarded in favour of the library-backed approach.
+The project standardised on a pysubs2-based `SSAFileHandler`, which provides full metadata preservation and round-trip fidelity. Early custom efforts were discarded in favour of the library-backed approach.
 
 **pysubs2 Library Evaluation**:
 After implementation comparison, `pysubs2` was identified as the superior approach for most formats:
 - **Battle-tested**: Used by video editing professionals
-- **Comprehensive**: Supports ASS, WebVTT, TTML, MicroDVD, MPL2, SAMI, TMP, Whisper formats
+- **Comprehensive**: Supports SSA, WebVTT, TTML, MicroDVD, MPL2, SAMI, TMP, Whisper formats
 - **Perfect fidelity**: Complete metadata preservation with round-trip accuracy
 - **Professional quality**: Proper format structure and compliance
 - **Future-proof**: Automatic updates as library evolves
 
 **Format-Specific Strategy**: 
 - **SRT**: Keep existing `srt` module (well-tested, SRT-specialized)
-- **ASS/WebVTT/TTML**: Use pysubs2 for professional-grade handling
+- **SSA/WebVTT/TTML**: Use pysubs2 for professional-grade handling
 - **Specialized formats**: Evaluate on case-by-case basis
 
 ### Phase 4: Format conversion
@@ -201,7 +201,7 @@ Phase 5 adds a `--list-formats` option to all CLI tools, documents supported ext
 
 **Acceptance Tests**:
 - [x] Detect SRT format with .txt extension
-- [x] Detect ASS format with .txt extension
+- [x] Detect SSA format with .txt extension
 - [x] Detect SSA format with .ass extension
 - [x] Provide clear error messages for undetectable formats
 - [x] Handle edge cases with malformed files gracefully
@@ -218,7 +218,7 @@ Phase 5 adds a `--list-formats` option to all CLI tools, documents supported ext
 ### Phase 7: Additional Format Support
 **Requirements**:
 - Keep existing `SrtFileHandler` (well-tested, SRT-specialized)
-- Maintain `AssFileHandler` for custom handling of tags and metadata
+- Maintain `SSAFileHandler` for custom handling of tags and metadata
 - Implement `VttFileHandler` for WebVTT (common web format) using pysubs2
 - Implement `TtmlFileHandler` for TTML (advanced XML-based format) using pysubs2
 - Consider `SccFileHandler` for SCC (broadcast standard) if needed
@@ -234,7 +234,7 @@ Phase 5 adds a `--list-formats` option to all CLI tools, documents supported ext
 
 **Acceptance Tests**:
 - [ ] Maintain existing SRT parsing with current `srt` module
-- [ ] Maintain existing SSA/ASS parsing with current `AssFileHandler`
+- [ ] Maintain existing SSA/ASS parsing with current `SSAFileHandler`
 - [ ] Parse WebVTT files with WEBVTT header and cue settings using pysubs2
 - [ ] Parse TTML files with XML structure and advanced styling using pysubs2
 - [ ] Preserve speaker identification metadata from transcription workflows
@@ -249,7 +249,7 @@ Phase 5 adds a `--list-formats` option to all CLI tools, documents supported ext
 - `PySubtitle/UnitTests/test_TtmlFileHandler.py`
 
 **Implementation Strategy**:
-Follow the proven pattern from `AssFileHandler`:
+Follow the proven pattern from `SSAFileHandler`:
 - Consistent metadata pass-through approach
 - `_pysubs2_original` preservation for perfect round-trips
 - Format-specific optimizations within each handler
@@ -324,7 +324,7 @@ class ExampleFileHandler(SubtitleFileHandler):
 
 ### Extended SubtitleLine Metadata Schema
 ```python
-# ASS Format Metadata
+# SSA Format Metadata
 {
     "style": "Default",
     "layer": 0,
@@ -347,7 +347,7 @@ class ExampleFileHandler(SubtitleFileHandler):
 File handlers must capture and preserve format-specific file context, e.g.
 
 ```python
-# ASS File Metadata
+# SSA File Metadata
 {
     "format": "ass",
     "script_info": {"Title": "Movie", "ScriptType": "v4.00+", ...},
@@ -374,7 +374,7 @@ All format handlers must:
 7. Support both file and string input/output
 
 ### Unique Index Assignment Strategy
-For formats that don't have native indices (like ASS):
+For formats that don't have native indices (like SSA):
 - Sequential numbering starting from 1
 - Preserve original event order
 - Handle missing/duplicate indices by reassignment
@@ -389,7 +389,7 @@ For formats that don't have native indices (like ASS):
   - **Mitigation**: Efficient detection algorithms, caching mechanisms
 
 ### Medium Risk
-- **Format Complexity**: ASS format has many advanced features that could be difficult to implement
+- **Format Complexity**: SSA format has many advanced features that could be difficult to implement
   - **Mitigation**: Phased implementation, focus on common use cases first
 - **Metadata Loss**: Converting between formats could lose format-specific information
   - **Mitigation**: Comprehensive metadata preservation, format-specific warnings
@@ -428,7 +428,7 @@ For formats that don't have native indices (like ASS):
 
 ### Required Libraries
 - **pysubs2** (v1.8.0+): Universal subtitle format library (MIT License)
-  - Provides professional-grade parsing for ASS, SRT, WebVTT, TTML, and more
+  - Provides professional-grade parsing for SSA, SRT, WebVTT, TTML, and more
   - Battle-tested by video editing community
   - Comprehensive metadata preservation with round-trip accuracy
   - Provides support for format detection from content
@@ -457,12 +457,12 @@ Any libraries used must be:
 
 - [X] **All existing functionality preserved** (81 unit tests continue to pass)
 - [X] **Format Registry implemented** with auto-discovery mechanism
-- [X] **ASS format support** completed with both fallback and pysubs2-based implementations  
+- [X] **SSA format support** completed with both fallback and pysubs2-based implementations  
 - [X] **Multi-format path handling** fixed for project files and output generation
 - [X] **Zero breaking changes** to public API
-- [X] **Comprehensive test coverage** for new components (AssFileHandler, FormatRegistry)
+- [X] **Comprehensive test coverage** for new components (SSAFileHandler, FormatRegistry)
 - [X] Keep existing SRT handling with specialized `srt` module
-- [ ] At least 3 additional formats supported (ASS [X], WebVTT, TTML pending)
+- [ ] At least 3 additional formats supported (SSA [X], WebVTT, TTML pending)
 - [ ] User acceptance validation
 
 **Current Status**: Phase 1-3 completed successfully. pysubs2 integration strategy validated and ready for Phase 4 implementation.
@@ -476,7 +476,7 @@ Any libraries used must be:
 - **Translation Focus**: Optimize for subtitle translation workflow while maintaining format integrity
 
 ### Handler Template Pattern
-All pysubs2-based handlers follow the pattern from `AssFileHandler` (TODO: extract a pysubs2 file parser to handle commonalities)
+All pysubs2-based handlers follow the pattern from `SSAFileHandler` (TODO: extract a pysubs2 file parser to handle commonalities)
 
 ### Metadata Strategy
 - **Standard Fields**: Common subtitle properties (timing, text, style, layer)


### PR DESCRIPTION
All that ASS was funny but a bit distracting. Advanced Substation Alpha is still Substation Alpha, so use the more general and meaningful acronym.