### PR TITLE
Prepare PySubtrans for standalone packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ gui-subtrans.spec
 llm-subtrans.sh
 mistral-subtrans.sh
 untranslated_msgids_*.txt
+
+/PySubtrans/build
+/PySubtrans/dist
+/PySubtrans/*.egg-info

--- a/PySubtrans/LICENSE
+++ b/PySubtrans/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 machinewrapped
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PySubtrans/README.md
+++ b/PySubtrans/README.md
@@ -47,6 +47,8 @@ The helpers return the same `Options`, `SubtitleProject` and `SubtitleTranslator
 `init_options` creates an `Options` instance and accepts additional keyword arguments for any of the fields documented in `Options.default_settings`. A few examples:
 
 ```python
+import os
+
 options = init_options(
     provider="Gemini",
     model="gemini-2.0-flash",

--- a/PySubtrans/README.md
+++ b/PySubtrans/README.md
@@ -48,6 +48,7 @@ The helpers return the same `Options`, `SubtitleProject` and `SubtitleTranslator
 
 ```python
 import os
+from PySubtrans import init_options
 
 options = init_options(
     provider="Gemini",

--- a/PySubtrans/README.md
+++ b/PySubtrans/README.md
@@ -105,4 +105,4 @@ The full [LLM-Subtrans](https://github.com/machinewrapped/llm-subtrans) and [GUI
 
 ## License
 
-PySubtrans is released under the MIT License. See [`PySubtrans/LICENSE`](LICENSE) for details.
+PySubtrans is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/PySubtrans/README.md
+++ b/PySubtrans/README.md
@@ -1,0 +1,108 @@
+# PySubtrans
+
+PySubtrans is the subtitle preparation and translation engine that powers [LLM-Subtrans](https://github.com/machinewrapped/llm-subtrans). It provides everything required to parse subtitle files, manage translation projects, talk to large language model providers and post-process the resulting text. This package makes those capabilities available as a reusable Python library so you can compose your own translation workflows or integrate them into existing tools.
+
+## Installation
+
+```bash
+pip install pysubtrans
+```
+
+Provider integrations are delivered as optional extras so you only install the SDKs you need:
+
+```bash
+pip install pysubtrans[openai]
+pip install pysubtrans[gemini]
+pip install pysubtrans[mistral]
+```
+
+The extras mirror the options that ship with LLM-Subtrans. Multiple extras can be installed in a single command: `pip install pysubtrans[openai,gemini]`.
+
+## Quick start: translate a subtitle file
+
+The quickest way to get started is to use the helper functions exposed at the package root. They wrap the objects used by LLM-Subtrans so that you can stand up a translation pipeline in a few lines of code.
+
+```python
+from PySubtrans import init_options, init_project, init_translator
+
+options = init_options(
+    provider="OpenAI",
+    model="gpt-4o-mini",
+    api_key="sk-your-api-key",
+    instruction_file="instructions.txt",  # Optional – overrides the default prompt/instructions
+    target_language="es",
+)
+
+project = init_project("movie.srt", persistent=True)
+translator = init_translator(project, options)
+
+project.TranslateSubtitles(translator)
+project.SaveTranslation()  # Writes the translated subtitles to disk
+```
+
+The helpers return the same `Options`, `SubtitleProject` and `SubtitleTranslator` objects that power the main application, so you can continue to customise them as needed.
+
+## Configuration with `init_options`
+
+`init_options` creates an `Options` instance and accepts additional keyword arguments for any of the fields documented in `Options.default_settings`. A few examples:
+
+```python
+options = init_options(
+    provider="Gemini",
+    model="gemini-2.0-flash",
+    api_key=os.environ["GOOGLE_API_KEY"],
+    temperature=0.3,
+    target_language="de",
+    include_original=True,
+)
+```
+
+* Provider credentials, endpoint details and model names can be passed directly. They will be moved into provider-specific settings automatically when the translator is created.
+* Custom instructions can be supplied via `instruction_file` or by overriding `prompt`, `instructions` and `retry_instructions` explicitly.
+* Any additional keyword arguments are merged into the returned `Options` instance, enabling full access to batching thresholds, formatting preferences, language metadata and more.
+
+## Working with projects using `init_project`
+
+`init_project` normalises the provided path, instantiates a `SubtitleProject` and loads the subtitles immediately if a file path is supplied. Passing `persistent=True` mirrors the CLI behaviour by enabling `.subtrans` project files that keep track of in-progress translations and settings.
+
+You can continue to call the usual project helpers:
+
+```python
+project.SaveProjectFile()
+project.SaveTranslation("/custom/output/path.srt")
+project.UpdateProjectSettings(options)
+```
+
+When no file path is supplied the project is created without loading subtitles, making it easy to populate the `Subtitles` object programmatically before translation.
+
+## Building translators with `init_translator`
+
+`init_translator` validates the provider configuration, loads any instruction file declared in the options and wires up a ready-to-use `SubtitleTranslator`. Behind the scenes it uses `TranslationProvider.get_provider` to construct the correct provider client and applies your option overrides to the current project.
+
+Once you have a translator you can:
+
+```python
+translator.events.scene_translated += handle_scene  # Subscribe to events
+project.TranslateSubtitles(translator)
+```
+
+The returned `SubtitleTranslator` exposes all of the batching, retry and provider integration features from the main application.
+
+## Advanced workflows
+
+PySubtrans is designed to be modular. The helper functions above are convenient entry points, but you are free to use lower-level components directly when you need more control:
+
+* Create a `Subtitles` instance by hand (for example when generating subtitles from a transcription pipeline) and pass it straight to `SubtitleTranslator.TranslateSubtitles`.
+* Construct your own `TranslationProvider` instance or subclass to integrate bespoke APIs. All built-in providers live under `PySubtrans.Providers` and serve as reference implementations.
+* Use `SubtitleBatcher` and `SubtitleBatch` to implement custom batching strategies when the default automatic batching does not fit your use case.
+* Hook into `TranslationEvents` to monitor progress or feed translated scenes into additional post-processing steps.
+
+For a detailed breakdown of the module layout and responsibilities refer to the [architecture guide](https://github.com/machinewrapped/llm-subtrans/blob/main/docs/architecture.md).
+
+## Learning from LLM-Subtrans and GUI-Subtrans
+
+The full [LLM-Subtrans](https://github.com/machinewrapped/llm-subtrans) and [GUI-Subtrans](https://github.com/machinewrapped/llm-subtrans/tree/main/GuiSubtrans) applications provide end-to-end examples that combine PySubtrans with logging, configuration UIs and persistence layers. They are excellent references when designing larger systems or when you want to replicate advanced features such as preview runs, retries or translation replays.
+
+## License
+
+PySubtrans is released under the MIT License. See [`PySubtrans/LICENSE`](LICENSE) for details.

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -18,23 +18,66 @@ def init_options(
     instruction_file: str|None = None,
     **settings: SettingType,
 ) -> Options:
-    """Return an :class:`Options` instance configured for a translation provider."""
+    """
+    Create and return an :class:`Options` instance configured for a translation provider.
+
+    Parameters
+    ----------
+    provider : str or None, optional
+        The name of the translation provider to use (e.g., "openai", "google").
+    model : str or None, optional
+        The model identifier to use for translation (e.g., "gpt-3.5-turbo").
+    api_key : str or None, optional
+        API key for authenticating with the translation provider.
+    instruction_file : str or None, optional
+        Path to a file containing custom translation instructions.
+    **settings : SettingType
+        Additional keyword settings to configure the translation provider.
+
+    Returns
+    -------
+    Options
+        An Options instance with the specified configuration.
+
+    Examples
+    --------
+    >>> from PySubtrans import init_options
+    >>> opts = init_options(provider="openai", model="gpt-3.5-turbo", api_key="sk-...", custom_setting="value")
+    >>> print(opts.provider)
+    openai
+    """
     combined_settings = SettingsType(settings)
 
-    if provider is not None:
-        combined_settings['provider'] = provider
-    if model is not None:
-        combined_settings['model'] = model
-    if api_key is not None:
-        combined_settings['api_key'] = api_key
-    if instruction_file is not None:
-        combined_settings['instruction_file'] = instruction_file
+    explicit_settings = {
+        'provider': provider,
+        'model': model,
+        'api_key': api_key,
+        'instruction_file': instruction_file,
+    }
+    combined_settings.update({k: v for k, v in explicit_settings.items() if v is not None})
 
     return Options(combined_settings)
 
 
 def init_project(filepath: str|None, persistent: bool = False) -> SubtitleProject:
-    """Create a :class:`SubtitleProject` and optionally load subtitles from *filepath*."""
+    """
+    Create a :class:`SubtitleProject` and optionally load subtitles from *filepath*.
+
+    Parameters
+    ----------
+    filepath : str or None
+        Path to the subtitle file to load into the project.
+    persistent : bool, optional
+        If True, enables persistent project state by creating and managing a
+        `.subtrans` project file in the working directory. This allows the project
+        to be saved and restored across sessions. If False (default), the project
+        is not persisted to disk.
+
+    Returns
+    -------
+    SubtitleProject
+        The initialized subtitle project.
+    """
     project = SubtitleProject(persistent=persistent)
     normalised_path = GetInputPath(filepath)
 
@@ -45,7 +88,34 @@ def init_project(filepath: str|None, persistent: bool = False) -> SubtitleProjec
 
 
 def init_translator(project: SubtitleProject, settings: Options|Mapping[str, SettingType]) -> SubtitleTranslator:
-    """Return a ready-to-use :class:`SubtitleTranslator` for *project* using *settings*."""
+    """
+    Return a ready-to-use :class:`SubtitleTranslator` for the given subtitle project using the specified settings.
+
+    Parameters
+    ----------
+    project : SubtitleProject
+        The subtitle project to be translated. Must be an instance of :class:`SubtitleProject`.
+    settings : Options or Mapping[str, SettingType]
+        The translation settings. Can be an :class:`Options` instance or a mapping of option values.
+
+    Validation
+    ----------
+    - Checks that `project` is a :class:`SubtitleProject` instance.
+    - Checks that `settings` is either an :class:`Options` instance or a mapping; if a mapping, it is converted to :class:`Options`.
+    - Validates the settings for the translation provider.
+
+    Exceptions
+    ----------
+    TypeError
+        If `project` is not a :class:`SubtitleProject` instance, or if `settings` is not an :class:`Options` instance or a mapping.
+    ValueError
+        If the settings are invalid for the selected translation provider.
+
+    Returns
+    -------
+    SubtitleTranslator
+        A ready-to-use subtitle translator configured with the given settings.
+    """
     if not isinstance(project, SubtitleProject):
         raise TypeError("project must be a SubtitleProject instance")
 

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from PySubtrans.Helpers import GetInputPath
+from PySubtrans.Options import Options
+from PySubtrans.SettingsType import SettingType, SettingsType
+from PySubtrans.SubtitleProject import SubtitleProject
+from PySubtrans.SubtitleTranslator import SubtitleTranslator
+from PySubtrans.TranslationProvider import TranslationProvider
+from PySubtrans.version import __version__
+
+
+def init_options(
+    provider: str|None = None,
+    model: str|None = None,
+    api_key: str|None = None,
+    instruction_file: str|None = None,
+    **settings: SettingType,
+) -> Options:
+    """Return an :class:`Options` instance configured for a translation provider."""
+    combined_settings = SettingsType(settings)
+
+    if provider is not None:
+        combined_settings['provider'] = provider
+    if model is not None:
+        combined_settings['model'] = model
+    if api_key is not None:
+        combined_settings['api_key'] = api_key
+    if instruction_file is not None:
+        combined_settings['instruction_file'] = instruction_file
+
+    return Options(combined_settings)
+
+
+def init_project(filepath: str|None, persistent: bool = False) -> SubtitleProject:
+    """Create a :class:`SubtitleProject` and optionally load subtitles from *filepath*."""
+    project = SubtitleProject(persistent=persistent)
+    normalised_path = GetInputPath(filepath)
+
+    if normalised_path:
+        project.InitialiseProject(normalised_path)
+
+    return project
+
+
+def init_translator(project: SubtitleProject, settings: Options|Mapping[str, SettingType]) -> SubtitleTranslator:
+    """Return a ready-to-use :class:`SubtitleTranslator` for *project* using *settings*."""
+    if not isinstance(project, SubtitleProject):
+        raise TypeError("project must be a SubtitleProject instance")
+
+    if not isinstance(settings, Options):
+        if isinstance(settings, Mapping):
+            settings = Options(SettingsType(settings))
+        else:
+            raise TypeError("settings must be an Options instance or a mapping of option values")
+
+    project.UpdateProjectSettings(settings)
+
+    translation_provider = TranslationProvider.get_provider(settings)
+    if not translation_provider.ValidateSettings():
+        message = translation_provider.validation_message or f"Invalid settings for provider {settings.provider}"
+        raise ValueError(message)
+
+    settings.InitialiseInstructions()
+
+    return SubtitleTranslator(settings, translation_provider)
+
+
+__all__ = [
+    '__version__',
+    'Options',
+    'SubtitleProject',
+    'SubtitleTranslator',
+    'TranslationProvider',
+    'init_options',
+    'init_project',
+    'init_translator',
+]

--- a/PySubtrans/pyproject.toml
+++ b/PySubtrans/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pysubtrans"
+version = "1.4.0"
+description = "Core subtitle translation toolkit used by LLM-Subtrans"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+dependencies = [
+    "python-dotenv",
+    "srt",
+    "pysubs2",
+    "regex",
+    "babel",
+    "appdirs",
+    "events",
+    "requests",
+    "setuptools",
+    "httpx",
+    "httpx[socks]"
+]
+
+[project.optional-dependencies]
+openai = [
+    "openai"
+]
+azure = [
+    "openai"
+]
+gemini = [
+    "google-genai",
+    "google-api-core"
+]
+claude = [
+    "anthropic"
+]
+mistral = [
+    "mistralai"
+]
+bedrock = [
+    "boto3"
+]
+
+[project.urls]
+Homepage = "https://github.com/machinewrapped/llm-subtrans"
+Documentation = "https://github.com/machinewrapped/llm-subtrans/blob/main/PySubtrans/README.md"
+Source = "https://github.com/machinewrapped/llm-subtrans"
+Issues = "https://github.com/machinewrapped/llm-subtrans/issues"
+
+[tool.setuptools]
+package-dir = {"" = ".."}
+
+[tool.setuptools.packages.find]
+where = [".."]
+include = ["PySubtrans*"]

--- a/scripts/publish_package.py
+++ b/scripts/publish_package.py
@@ -243,9 +243,5 @@ def Main() -> None:
             raise
 
 
-def __main__() -> None:
-    Main()
-
-
 if __name__ == "__main__":
-    __main__()
+    Main()

--- a/scripts/publish_package.py
+++ b/scripts/publish_package.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib  # type: ignore
+
+PACKAGE_NAME = "pysubtrans"
+PACKAGE_DESCRIPTION = "Core subtitle translation toolkit used by LLM-Subtrans"
+HOMEPAGE_URL = "https://github.com/machinewrapped/llm-subtrans"
+DOCUMENTATION_URL = "https://github.com/machinewrapped/llm-subtrans/blob/main/PySubtrans/README.md"
+ISSUES_URL = "https://github.com/machinewrapped/llm-subtrans/issues"
+
+
+def ParseArguments() -> argparse.Namespace:
+    """Parse command line arguments for the publish workflow."""
+    parser = argparse.ArgumentParser(description="Build and publish the PySubtrans package")
+    parser.add_argument("--yes", action="store_true", help="Assume yes for all confirmation prompts")
+    parser.add_argument("--skip-upload", action="store_true", help="Skip the upload step")
+    parser.add_argument("--repository", type=str, default=None, help="Named repository configured in ~/.pypirc (e.g. testpypi)")
+    return parser.parse_args()
+
+
+def LoadToml(path: Path) -> dict[str, Any]:
+    """Load a TOML file into a dictionary."""
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def FormatTomlList(items: list[str], indent: int = 4) -> str:
+    """Format a list of strings as a TOML array."""
+    if not items:
+        return "[]"
+
+    indent_str = " " * indent
+    joined_items = ",\n".join(f'{indent_str}"{item}"' for item in items)
+    closing_indent = " " * max(indent - 4, 0)
+    return f"[\n{joined_items}\n{closing_indent}]"
+
+
+def WritePackageToml(
+    path: Path,
+    version: str,
+    dependencies: list[str],
+    optional_dependencies: dict[str, list[str]],
+    requires_python: str,
+) -> None:
+    """Write the dedicated PySubtrans pyproject file."""
+    dependencies_block = FormatTomlList(dependencies)
+
+    lines: list[str] = [
+        "[build-system]",
+        'requires = ["setuptools>=61.0"]',
+        'build-backend = "setuptools.build_meta"',
+        "",
+        "[project]",
+        f'name = "{PACKAGE_NAME}"',
+        f'version = "{version}"',
+        f'description = "{PACKAGE_DESCRIPTION}"',
+        'readme = "README.md"',
+        f'requires-python = "{requires_python}"',
+        'license = {file = "LICENSE"}',
+        f"dependencies = {dependencies_block}",
+        "",
+    ]
+
+    if optional_dependencies:
+        lines.append("[project.optional-dependencies]")
+        for extra, packages in optional_dependencies.items():
+            lines.append(f"{extra} = {FormatTomlList(packages)}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "[project.urls]",
+            f'Homepage = "{HOMEPAGE_URL}"',
+            f'Documentation = "{DOCUMENTATION_URL}"',
+            f'Source = "{HOMEPAGE_URL}"',
+            f'Issues = "{ISSUES_URL}"',
+            "",
+            "[tool.setuptools]",
+            'package-dir = {"" = ".."}',
+            "",
+            "[tool.setuptools.packages.find]",
+            'where = [".."]',
+            'include = ["PySubtrans*"]',
+            "",
+        ]
+    )
+
+    content = "\n".join(lines).rstrip() + "\n"
+    path.write_text(content, encoding="utf-8")
+
+
+def PrintSummary(version: str, dependencies: list[str], optional: dict[str, list[str]]) -> None:
+    """Display the key package metadata before building."""
+    print("PySubtrans package configuration")
+    print(f"  Version: {version}")
+    print("  Dependencies:")
+    for dependency in dependencies:
+        print(f"    - {dependency}")
+
+    if optional:
+        print("  Optional extras:")
+        for name, packages in optional.items():
+            package_list = ", ".join(packages)
+            print(f"    - {name}: {package_list}")
+
+
+def Confirm(prompt: str, assume_yes: bool = False) -> bool:
+    """Ask the user for confirmation."""
+    if assume_yes:
+        print(f"{prompt} [auto-yes]")
+        return True
+
+    try:
+        response = input(f"{prompt} [y/N]: ").strip().lower()
+    except EOFError:
+        return False
+
+    return response in {"y", "yes"}
+
+
+def EnsureBuildTools(upload_requested: bool) -> None:
+    """Validate that build and upload tooling is available."""
+    if importlib.util.find_spec("build") is None:
+        raise ModuleNotFoundError(
+            "The 'build' package is required. Install it with 'pip install build'."
+        )
+
+    if upload_requested and importlib.util.find_spec("twine") is None:
+        raise ModuleNotFoundError(
+            "The 'twine' package is required for uploads. Install it with 'pip install twine'."
+        )
+
+
+def CleanBuildArtifacts(package_dir: Path) -> None:
+    """Remove previous build artefacts to ensure a clean build."""
+    for folder_name in ("build", "dist"):
+        folder = package_dir / folder_name
+        if folder.exists():
+            shutil.rmtree(folder)
+
+    for egg_info in package_dir.glob("*.egg-info"):
+        if egg_info.is_dir():
+            shutil.rmtree(egg_info)
+        else:
+            egg_info.unlink()
+
+
+def BuildPackage(package_dir: Path) -> None:
+    """Build the wheel and source distribution for PySubtrans."""
+    command = [sys.executable, "-m", "build"]
+    subprocess.run(command, cwd=package_dir, check=True)
+
+
+def UploadPackage(dist_dir: Path, repository: str|None = None) -> None:
+    """Upload the built distributions using twine."""
+    if not dist_dir.exists():
+        raise FileNotFoundError(f"Distribution directory {dist_dir} does not exist")
+
+    distributions = sorted(dist_dir.glob("*"))
+    if not distributions:
+        raise FileNotFoundError("No distribution files found to upload")
+
+    command = [sys.executable, "-m", "twine", "upload"]
+    if repository:
+        command.extend(["--repository", repository])
+
+    command.extend(str(path) for path in distributions)
+    subprocess.run(command, check=True)
+
+
+def Main() -> None:
+    """Entrypoint for the publish helper."""
+    args = ParseArguments()
+
+    project_root = Path(__file__).resolve().parent.parent
+    root_pyproject = project_root / "pyproject.toml"
+    package_dir = project_root / "PySubtrans"
+    package_pyproject = package_dir / "pyproject.toml"
+
+    if not root_pyproject.exists():
+        raise FileNotFoundError("Unable to locate the root pyproject.toml")
+
+    if not package_dir.exists():
+        raise FileNotFoundError("PySubtrans directory does not exist")
+
+    root_config = LoadToml(root_pyproject)
+    project_config = root_config.get("project", {})
+
+    version = str(project_config.get("version", "0.0.0"))
+    requires_python = str(project_config.get("requires-python", ">=3.10"))
+    dependencies = list(project_config.get("dependencies", []))
+
+    optional = {
+        name: list(values)
+        for name, values in project_config.get("optional-dependencies", {}).items()
+        if name != "gui"
+    }
+
+    WritePackageToml(package_pyproject, version, dependencies, optional, requires_python)
+    PrintSummary(version, dependencies, optional)
+
+    try:
+        EnsureBuildTools(upload_requested=not args.skip_upload)
+    except ModuleNotFoundError as error:
+        print(error)
+        return
+
+    if not Confirm("Proceed with build?", assume_yes=args.yes):
+        print("Build cancelled")
+        return
+
+    CleanBuildArtifacts(package_dir)
+
+    try:
+        BuildPackage(package_dir)
+    except subprocess.CalledProcessError as error:
+        print(f"Build failed with exit code {error.returncode}")
+        raise
+
+    print(f"Build complete. Distributions written to {package_dir / 'dist'}")
+
+    if args.skip_upload:
+        print("Upload skipped as requested")
+        return
+
+    if Confirm("Upload package with twine?", assume_yes=args.yes):
+        try:
+            UploadPackage(package_dir / "dist", repository=args.repository)
+        except subprocess.CalledProcessError as error:
+            print(f"Upload failed with exit code {error.returncode}")
+            raise
+
+
+def __main__() -> None:
+    Main()
+
+
+if __name__ == "__main__":
+    __main__()


### PR DESCRIPTION
## Summary
- add a dedicated pyproject, README and MIT license so PySubtrans can be published as its own package
- expose convenience helpers in PySubtrans.__init__ for quickly creating options, projects and translators
- create a publish_package.py script that syncs metadata from the root pyproject, builds the distributions and optionally uploads them
- update .gitignore to ignore packaging build artefacts under PySubtrans

## Testing
- python tests/unit_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68cc4d3c9f3483299944d94efb5378ce