### PR TITLE
Decompose Subtitles class to provide better separation of concerns

### DIFF
--- a/GuiSubtrans/Commands/DeleteLinesCommand.py
+++ b/GuiSubtrans/Commands/DeleteLinesCommand.py
@@ -5,6 +5,7 @@ from PySubtrans.SubtitleValidator import SubtitleValidator
 from PySubtrans.SubtitleBatch import SubtitleBatch
 from PySubtrans.SubtitleLine import SubtitleLine
 from PySubtrans.SubtitleProject import SubtitleProject
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.Helpers.Localization import _
 
 import logging
@@ -32,7 +33,8 @@ class DeleteLinesCommand(Command):
         if not project.subtitles:
             raise CommandError(_("No subtitles"), command=self)
 
-        self.deletions = project.subtitles.DeleteLines(self.line_numbers)
+        with SubtitleEditor(project.subtitles) as editor:
+            self.deletions = editor.DeleteLines(self.line_numbers)
 
         if not self.deletions:
             raise CommandError(_("No lines were deleted"), command=self)

--- a/GuiSubtrans/Commands/MergeBatchesCommand.py
+++ b/GuiSubtrans/Commands/MergeBatchesCommand.py
@@ -3,6 +3,7 @@ from GuiSubtrans.ProjectDataModel import ProjectDataModel
 from GuiSubtrans.ViewModel.ViewModelUpdate import ModelUpdate
 from PySubtrans.Helpers.Localization import _
 from PySubtrans.SubtitleBatch import SubtitleBatch
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleProject import SubtitleProject
 
 import logging
@@ -40,7 +41,8 @@ class MergeBatchesCommand(Command):
             self.original_first_line_numbers = [batch.first_line_number for batch in original_batches if batch and batch.first_line_number]
             self.original_summaries = {batch.number: batch.summary for batch in original_batches if batch and batch.summary}
 
-            project.subtitles.MergeBatches(self.scene_number, self.batch_numbers)
+            with SubtitleEditor(project.subtitles) as editor:
+                editor.MergeBatches(self.scene_number, self.batch_numbers)
 
             merged_batch = scene.GetBatch(merged_batch_number)
             if merged_batch is not None:

--- a/GuiSubtrans/Commands/MergeLinesCommand.py
+++ b/GuiSubtrans/Commands/MergeLinesCommand.py
@@ -2,6 +2,7 @@ from GuiSubtrans.Command import Command, CommandError, UndoError
 from GuiSubtrans.ProjectDataModel import ProjectDataModel
 from GuiSubtrans.ViewModel.ViewModelUpdate import ModelUpdate
 from PySubtrans.SubtitleBatch import SubtitleBatch
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.Subtitles import Subtitles
 from PySubtrans.SubtitleProject import SubtitleProject
 from PySubtrans.Helpers.Localization import _
@@ -50,7 +51,8 @@ class MergeLinesCommand(Command):
 
             self.undo_data.append((batch.scene, batch.number, originals, translated))
 
-            merged_line, merged_translated = subtitles.MergeLinesInBatch(batch.scene, batch.number, batch_lines)
+            with SubtitleEditor(subtitles) as editor:
+                merged_line, merged_translated = editor.MergeLinesInBatch(batch.scene, batch.number, batch_lines)
 
             if not merged_line:
                 raise CommandError(_("Failed to merge lines"), command=self)

--- a/GuiSubtrans/Commands/SplitSceneCommand.py
+++ b/GuiSubtrans/Commands/SplitSceneCommand.py
@@ -1,6 +1,7 @@
 from GuiSubtrans.Command import Command, CommandError
 from GuiSubtrans.ProjectDataModel import ProjectDataModel
 from GuiSubtrans.ViewModel.ViewModelUpdate import ModelUpdate
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleProject import SubtitleProject
 from PySubtrans.Helpers.Localization import _
 
@@ -29,7 +30,8 @@ class SplitSceneCommand(Command):
 
         last_batch = scene.batches[-1].number
 
-        project.subtitles.SplitScene(self.scene_number, self.batch_number)
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.SplitScene(self.scene_number, self.batch_number)
 
         model_update : ModelUpdate =  self.AddModelUpdate()
         for scene_number in range(self.scene_number + 1, len(project.subtitles.scenes)):
@@ -55,7 +57,8 @@ class SplitSceneCommand(Command):
             scene_numbers = [self.scene_number, self.scene_number + 1]
             later_scenes = [scene.number for scene in project.subtitles.scenes if scene.number > scene_numbers[1]]
 
-            merged_scene = project.subtitles.MergeScenes(scene_numbers)
+            with SubtitleEditor(project.subtitles) as editor:
+                merged_scene = editor.MergeScenes(scene_numbers)
 
             # Recombine the split scenes
             model_update : ModelUpdate =  self.AddModelUpdate()

--- a/GuiSubtrans/UnitTests/DataModelHelpers.py
+++ b/GuiSubtrans/UnitTests/DataModelHelpers.py
@@ -3,6 +3,7 @@ from PySubtrans.Helpers.TestCases import AddTranslations, PrepareSubtitles
 from PySubtrans.Options import Options
 from PySubtrans.SettingsType import SettingsType
 from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.Subtitles import Subtitles
 from PySubtrans.SubtitleProject import SubtitleProject
 
@@ -33,7 +34,8 @@ def CreateTestDataModelBatched(test_data : dict, options : Options|None = None, 
 
     subtitles : Subtitles = datamodel.project.subtitles
     batcher = SubtitleBatcher(options.GetSettings())
-    subtitles.AutoBatch(batcher)
+    with SubtitleEditor(subtitles) as editor:
+        editor.AutoBatch(batcher)
 
     if translated and 'translated' in test_data:
         AddTranslations(subtitles, test_data, 'translated')

--- a/PySubtrans/Helpers/ContextHelpers.py
+++ b/PySubtrans/Helpers/ContextHelpers.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from PySubtrans.Helpers.Parse import ParseNames
+from PySubtrans.SubtitleError import SubtitleError
+
+if TYPE_CHECKING:
+    from PySubtrans.Subtitles import Subtitles
+
+
+def GetBatchContext(subtitles: Subtitles, scene_number: int, batch_number: int, max_lines: int|None = None) -> dict[str, Any]:
+    """
+    Get context for a batch of subtitles, by extracting summaries from previous scenes and batches
+    """
+    with subtitles.lock:
+        scene = subtitles.GetScene(scene_number)
+        if not scene:
+            raise SubtitleError(f"Failed to find scene {scene_number}")
+
+        batch = subtitles.GetBatch(scene_number, batch_number)
+        if not batch:
+            raise SubtitleError(f"Failed to find batch {batch_number} in scene {scene_number}")
+
+        context : dict[str,Any] = {
+            'scene_number': scene.number,
+            'batch_number': batch.number,
+            'scene': f"Scene {scene.number}: {scene.summary}" if scene.summary else f"Scene {scene.number}",
+            'batch': f"Batch {batch.number}: {batch.summary}" if batch.summary else f"Batch {batch.number}"
+        }
+
+        if 'movie_name' in subtitles.settings:
+            context['movie_name'] = subtitles._get_setting_str('movie_name')
+
+        if 'description' in subtitles.settings:
+            context['description'] = subtitles._get_setting_str('description')
+
+        if 'names' in subtitles.settings:
+            context['names'] = ParseNames(subtitles.settings.get('names', []))
+
+        history_lines = GetHistory(subtitles, scene_number, batch_number, max_lines)
+
+        if history_lines:
+            context['history'] = history_lines
+
+    return context
+
+
+def GetHistory(subtitles: Subtitles, scene_number: int, batch_number: int, max_lines: int|None = None) -> list[str]:
+    """
+    Get a list of historical summaries up to a given scene and batch number
+    """
+    history_lines : list[str] = []
+    last_summary : str = ""
+
+    scenes = [scene for scene in subtitles.scenes if scene.number and scene.number < scene_number]
+    for scene in [scene for scene in scenes if scene.summary]:
+        if scene.summary != last_summary:
+            history_lines.append(f"scene {scene.number}: {scene.summary}")
+            last_summary = scene.summary or ""
+
+    batches = [batch for batch in subtitles.GetScene(scene_number).batches if batch.number is not None and batch.number < batch_number]
+    for batch in [batch for batch in batches if batch.summary]:
+        if batch.summary != last_summary:
+            history_lines.append(f"scene {batch.scene} batch {batch.number}: {batch.summary}")
+            last_summary = batch.summary or ""
+
+    if max_lines:
+        history_lines = history_lines[-max_lines:]
+
+    return history_lines

--- a/PySubtrans/Helpers/TestCases.py
+++ b/PySubtrans/Helpers/TestCases.py
@@ -98,7 +98,7 @@ def PrepareSubtitles(subtitle_data : dict, key : str = 'original', file_handler:
     handler = file_handler or SubtitleFormatRegistry.create_handler(filename=filename)
     subtitles: Subtitles = Subtitles()
     subtitles.LoadSubtitlesFromString(subtitle_data[key], file_handler=handler)
-    subtitles.UpdateProjectSettings(SettingsType(subtitle_data))
+    subtitles.UpdateSettings(SettingsType(subtitle_data))
     return subtitles
 
 def AddTranslations(subtitles : Subtitles, subtitle_data : dict, key : str = 'translated'):

--- a/PySubtrans/SubtitleEditor.py
+++ b/PySubtrans/SubtitleEditor.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import logging
+import bisect
+from typing import Any
+
+from PySubtrans.Helpers.Localization import _
+from PySubtrans.SubtitleError import SubtitleError
+from PySubtrans.SubtitleLine import SubtitleLine
+from PySubtrans.SubtitleScene import SubtitleScene
+from PySubtrans.SubtitleBatch import SubtitleBatch
+from PySubtrans.Subtitles import Subtitles
+from PySubtrans.SubtitleProcessor import SubtitleProcessor
+from PySubtrans.SubtitleBatcher import SubtitleBatcher
+
+
+class SubtitleEditor:
+    """
+    Handles mutation operations on subtitle data with proper thread safety.
+    Use as a context manager to ensure proper locking.
+    """
+
+    def __init__(self, subtitles: Subtitles) -> None:
+        self.subtitles = subtitles
+        self._lock_acquired = False
+
+    def __enter__(self) -> SubtitleEditor:
+        self.subtitles.lock.acquire()
+        self._lock_acquired = True
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._lock_acquired:
+            self.subtitles.lock.release()
+            self._lock_acquired = False
+
+    def PreProcess(self, preprocessor: SubtitleProcessor) -> None:
+        """
+        Preprocess subtitles
+        """
+        if self.subtitles.originals:
+            self.subtitles.originals = preprocessor.PreprocessSubtitles(self.subtitles.originals)
+
+    def AutoBatch(self, batcher: SubtitleBatcher) -> None:
+        """
+        Divide subtitles into scenes and batches based on threshold options
+        """
+        if self.subtitles.originals:
+            self.subtitles.scenes = batcher.BatchSubtitles(self.subtitles.originals)
+
+    def AddScene(self, scene: SubtitleScene) -> None:
+        self.subtitles.scenes.append(scene)
+        logging.debug("Added a new scene")
+
+    def UpdateScene(self, scene_number: int, update: dict[str, Any]) -> Any:
+        scene: SubtitleScene = self.subtitles.GetScene(scene_number)
+        if not scene:
+            raise ValueError(f"Scene {scene_number} does not exist")
+
+        return scene.UpdateContext(update)
+
+    def UpdateBatch(self, scene_number: int, batch_number: int, update: dict[str, Any]) -> bool:
+        batch: SubtitleBatch = self.subtitles.GetBatch(scene_number, batch_number)
+        if not batch:
+            raise ValueError(f"Batch ({scene_number},{batch_number}) does not exist")
+
+        return batch.UpdateContext(update)
+
+    def UpdateLineText(self, line_number: int, original_text: str, translated_text: str) -> None:
+        if self.subtitles.originals is None:
+            raise SubtitleError("Original subtitles are missing!")
+
+        original_line = next((original for original in self.subtitles.originals if original.number == line_number), None)
+        if not original_line:
+            raise ValueError(f"Line {line_number} not found")
+
+        if original_text:
+            original_line.text = original_text
+            original_line.translation = translated_text
+
+        if not translated_text:
+            return
+
+        translated_line = next((translated for translated in self.subtitles.translated if translated.number == line_number), None) if self.subtitles.translated else None
+        if translated_line:
+            translated_line.text = translated_text
+            return
+
+        translated_line = SubtitleLine.Construct(line_number, original_line.start, original_line.end, translated_text, original_line.metadata)
+
+        if not self.subtitles.translated:
+            self.subtitles.translated = []
+
+        insertIndex = bisect.bisect_left([line.number for line in self.subtitles.translated], line_number)
+        self.subtitles.translated.insert(insertIndex, translated_line)
+
+    def DeleteLines(self, line_numbers: list[int]) -> list[tuple[int, int, list[SubtitleLine], list[SubtitleLine]]]:
+        """
+        Delete lines from the subtitles
+        """
+        deletions = []
+        batches = self.subtitles.GetBatchesContainingLines(line_numbers)
+
+        for batch in batches:
+            deleted_originals, deleted_translated = batch.DeleteLines(line_numbers)
+            if len(deleted_originals) > 0 or len(deleted_translated) > 0:
+                deletion = (batch.scene, batch.number, deleted_originals, deleted_translated)
+                deletions.append(deletion)
+
+        if not deletions:
+            raise ValueError("No lines were deleted from any batches")
+
+        return deletions
+
+    def MergeScenes(self, scene_numbers: list[int]) -> SubtitleScene:
+        """
+        Merge several (sequential) scenes into one scene
+        """
+        if not scene_numbers:
+            raise ValueError("No scene numbers supplied to MergeScenes")
+
+        scene_numbers = sorted(scene_numbers)
+        if scene_numbers != list(range(scene_numbers[0], scene_numbers[0] + len(scene_numbers))):
+            raise ValueError("Scene numbers to be merged are not sequential")
+
+        scenes: list[SubtitleScene] = [scene for scene in self.subtitles.scenes if scene.number in scene_numbers]
+        if len(scenes) != len(scene_numbers):
+            raise ValueError(f"Could not find scenes {','.join([str(i) for i in scene_numbers])}")
+
+        # Merge all scenes into the first
+        merged_scene = scenes[0]
+        merged_scene.MergeScenes(scenes[1:])
+
+        # Slice out the merged scenes
+        start_index = self.subtitles.scenes.index(scenes[0])
+        end_index = self.subtitles.scenes.index(scenes[-1])
+        self.subtitles.scenes = self.subtitles.scenes[:start_index + 1] + self.subtitles.scenes[end_index+1:]
+
+        self.RenumberScenes()
+
+        return merged_scene
+
+    def MergeBatches(self, scene_number: int, batch_numbers: list[int]) -> None:
+        """
+        Merge several (sequential) batches from a scene into one batch
+        """
+        if not batch_numbers:
+            raise ValueError("No batch numbers supplied to MergeBatches")
+
+        scene: SubtitleScene|None = next((scene for scene in self.subtitles.scenes if scene.number == scene_number), None)
+        if not scene:
+            raise ValueError(f"Scene {str(scene_number)} not found")
+
+        scene.MergeBatches(batch_numbers)
+
+    def MergeLinesInBatch(self, scene_number: int, batch_number: int, line_numbers: list[int]) -> tuple[SubtitleLine, SubtitleLine|None]:
+        """
+        Merge several sequential lines together, remapping originals and translated lines if necessary.
+        """
+        batch: SubtitleBatch = self.subtitles.GetBatch(scene_number, batch_number)
+        return batch.MergeLines(line_numbers)
+
+    def SplitScene(self, scene_number: int, batch_number: int) -> None:
+        """
+        Split a scene into two at the specified batch number
+        """
+        scene: SubtitleScene = self.subtitles.GetScene(scene_number)
+        batch: SubtitleBatch|None = scene.GetBatch(batch_number) if scene else None
+
+        if not batch:
+            raise ValueError(f"Scene {scene_number} batch {batch_number} does not exist")
+
+        batch_index: int = scene.batches.index(batch)
+
+        new_scene = SubtitleScene({ 'number': scene_number + 1})
+        new_scene.batches = scene.batches[batch_index:]
+        scene.batches = scene.batches[:batch_index]
+
+        for number, batch in enumerate(new_scene.batches, start=1):
+            batch.scene = new_scene.number
+            batch.number = number
+
+        split_index = self.subtitles.scenes.index(scene) + 1
+        if split_index < len(self.subtitles.scenes):
+            self.subtitles.scenes = self.subtitles.scenes[:split_index] + [new_scene] + self.subtitles.scenes[split_index:]
+        else:
+            self.subtitles.scenes.append(new_scene)
+
+        self.RenumberScenes()
+
+    def Sanitise(self) -> None:
+        """
+        Remove invalid lines, empty batches and empty scenes
+        """
+        for scene in self.subtitles.scenes:
+            scene.batches = [batch for batch in scene.batches if batch.originals]
+
+            for batch in scene.batches:
+                batch.originals = [line for line in batch.originals if line.number and line.start is not None]
+                if batch.translated:
+                    batch.translated = [line for line in batch.translated if line.number and line.start is not None ]
+
+                original_line_numbers = [line.number for line in batch.originals]
+                unmatched_translated = [line for line in batch.translated if line.number not in original_line_numbers]
+                if unmatched_translated:
+                    logging.warning(_("Removing {} translations lines in batch ({},{}) that don't match an original line").format(len(unmatched_translated), batch.scene, batch.number))
+                    batch.translated = [line for line in batch.translated if line not in unmatched_translated]
+
+        self.subtitles.scenes = [scene for scene in self.subtitles.scenes if scene.batches]
+        self.RenumberScenes()
+
+    def RenumberScenes(self) -> None:
+        """
+        Ensure scenes are numbered sequentially
+        """
+        for scene_number, scene in enumerate(self.subtitles.scenes, start=1):
+            scene.number = scene_number
+            for batch_number, batch in enumerate(scene.batches, start=1):
+                batch.scene = scene.number
+                batch.number = batch_number
+
+    def DuplicateOriginalsAsTranslations(self) -> None:
+        """
+        Duplicate original lines as translated lines if no translations exist (for testing)
+        """
+        for scene in self.subtitles.scenes:
+            for batch in scene.batches:
+                if batch.any_translated:
+                    raise SubtitleError("Translations already exist")
+
+                batch.translated = [ SubtitleLine.Construct(line.number, line.start, line.end, line.text or "", line.metadata) for line in batch.originals ]

--- a/PySubtrans/SubtitleProject.py
+++ b/PySubtrans/SubtitleProject.py
@@ -7,6 +7,7 @@ from PySubtrans.Helpers import GetOutputPath
 from PySubtrans.Helpers.Localization import _
 from PySubtrans.Options import Options, SettingsType
 from PySubtrans.SettingsType import SettingsType
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleError import SubtitleError, TranslationAbortedError
 from PySubtrans.SubtitleFormatRegistry import SubtitleFormatRegistry
 from PySubtrans.Subtitles import Subtitles
@@ -255,7 +256,8 @@ class SubtitleProject:
                 with open(filepath, 'r', encoding=default_encoding, newline='') as f:
                     subtitles: Subtitles = json.load(f, cls=SubtitleDecoder)
 
-                subtitles.Sanitise()
+                with SubtitleEditor(subtitles) as editor:
+                    editor.Sanitise()
 
                 self.subtitles = subtitles
                 return subtitles

--- a/PySubtrans/SubtitleProject.py
+++ b/PySubtrans/SubtitleProject.py
@@ -5,7 +5,9 @@ import threading
 
 from PySubtrans.Helpers import GetOutputPath
 from PySubtrans.Helpers.Localization import _
+from PySubtrans.Helpers.Parse import ParseNames
 from PySubtrans.Options import Options, SettingsType
+from PySubtrans.Substitutions import Substitutions
 from PySubtrans.SettingsType import SettingsType
 from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleError import SubtitleError, TranslationAbortedError
@@ -24,6 +26,24 @@ class SubtitleProject:
     """
     Handles loading, saving and creation of project files for LLM-Subtrans
     """
+    DEFAULT_PROJECT_SETTINGS : SettingsType = SettingsType({
+        'provider': None,
+        'model': None,
+        'target_language': None,
+        'prompt': None,
+        'task_type': None,
+        'instructions': None,
+        'retry_instructions': None,
+        'movie_name': None,
+        'description': None,
+        'names': None,
+        'substitutions': None,
+        'substitution_mode': None,
+        'include_original': None,
+        'add_right_to_left_markers': None,
+        'instruction_file': None,
+        'format': None
+    })
     def __init__(self, persistent : bool = False):
         """
         A subtitle translation project. 
@@ -33,7 +53,7 @@ class SubtitleProject:
         
         :param persistent: if True, the project will be saved to disk and automatically reloaded next time
         """
-        self.subtitles : Subtitles = Subtitles()
+        self.subtitles : Subtitles = Subtitles(settings=self.DEFAULT_PROJECT_SETTINGS)
         self.events = TranslationEvents()
         self.projectfile : str|None = None
         self.existing_project : bool = False
@@ -97,15 +117,13 @@ class SubtitleProject:
         if project_file_exists and not read_project:
             logging.warning(_("Project file {} exists but will not be used").format(self.projectfile))
 
-        subtitles : Subtitles|None = None
-
         if read_project:
             logging.info(_("Loading existing project file {}").format(self.projectfile))
 
-            # Try to load the project file
-            subtitles = self.ReadProjectFile(self.projectfile)
+            self.ReadProjectFile(self.projectfile)
             project_settings = self.GetProjectSettings()
 
+            subtitles : Subtitles = self.subtitles
             if subtitles:
                 subtitles.UpdateOutputPath()
                 outputpath = outputpath or GetOutputPath(self.projectfile, subtitles.target_language, subtitles.file_format)
@@ -126,15 +144,13 @@ class SubtitleProject:
         if load_subtitles:
             try:
                 # (re)load the source subtitle file if required
-                subtitles = self.LoadSubtitleFile(sourcepath)
-
-                # Reapply project settings
-                if read_project and project_settings:
-                    subtitles.UpdateProjectSettings(project_settings)
+                self.LoadSubtitleFile(sourcepath)
 
             except Exception as e:
                 logging.error(_("Failed to load subtitle file {}: {}").format(filepath, str(e)))
                 raise
+
+        subtitles = self.subtitles
 
         if not subtitles or not subtitles.has_subtitles:
             raise ValueError(_("No subtitles to translate in {}").format(filepath))
@@ -144,7 +160,44 @@ class SubtitleProject:
             subtitles.file_format = SubtitleFormatRegistry.get_format_from_filename(outputpath)
             self.needs_writing = self.use_project_file
 
-        self.subtitles = subtitles
+        # Re-apply any project settings and update for compatibility
+        if read_project:
+            self.UpdateProjectSettings(project_settings)
+
+    def UpdateProjectSettings(self, settings: SettingsType) -> None:
+        """
+        Update the project settings with validation and filtering
+        """
+        if isinstance(settings, Options):
+            settings = SettingsType(settings)
+
+        with self.lock:
+            if not self.subtitles:
+                return
+
+            # Filter settings to only include known project settings (original logic)
+            filtered_settings = SettingsType({key: settings[key] for key in settings if key in self.DEFAULT_PROJECT_SETTINGS})
+
+            # Process names and substitutions
+            if 'names' in filtered_settings:
+                names_list = filtered_settings.get('names', [])
+                filtered_settings['names'] = ParseNames(names_list)
+
+            if 'substitutions' in filtered_settings:
+                substitutions_list = filtered_settings.get('substitutions', [])
+                if substitutions_list:
+                    filtered_settings['substitutions'] = Substitutions.Parse(substitutions_list)
+
+            # Apply compatibility updates
+            self._update_compatibility(filtered_settings)
+
+            # Check if there are actual changes before updating
+            common_keys = filtered_settings.keys() & self.subtitles.settings.keys()
+            new_keys = filtered_settings.keys() - self.subtitles.settings.keys()
+
+            if not all(filtered_settings.get(key) == self.subtitles.settings.get(key) for key in common_keys) or new_keys:
+                self.subtitles.UpdateSettings(filtered_settings)
+                self.needs_writing = bool(self.subtitles.scenes) and self.use_project_file
 
     def SaveOriginal(self, outputpath : str|None = None):
         """
@@ -189,7 +242,8 @@ class SubtitleProject:
         Load subtitles from a file, auto-detecting the format by extension
         """
         with self.lock:
-            self.subtitles = Subtitles(filepath)
+            # Pass default settings for new subtitle files
+            self.subtitles = Subtitles(filepath, settings=self.DEFAULT_PROJECT_SETTINGS)
             self.subtitles.LoadSubtitles()
 
         return self.subtitles
@@ -254,13 +308,12 @@ class SubtitleProject:
                 logging.info(_("Reading project data from {}").format(str(filepath)))
 
                 with open(filepath, 'r', encoding=default_encoding, newline='') as f:
-                    subtitles: Subtitles = json.load(f, cls=SubtitleDecoder)
+                    self.subtitles: Subtitles = json.load(f, cls=SubtitleDecoder)
 
-                with SubtitleEditor(subtitles) as editor:
+                with SubtitleEditor(self.subtitles) as editor:
                     editor.Sanitise()
 
-                self.subtitles = subtitles
-                return subtitles
+                return self.subtitles
 
         except FileNotFoundError:
             logging.error(_("Project file {} not found").format(filepath))
@@ -285,23 +338,8 @@ class SubtitleProject:
         if not self.subtitles:
             return SettingsType()
 
-        return SettingsType({ key : value for key, value in self.subtitles.settings.items() if value })
+        return SettingsType({ key : value for key, value in self.subtitles.settings.items() if value is not None and (value != '' or isinstance(value, list)) })
 
-    def UpdateProjectSettings(self, settings: SettingsType) -> None:
-        """
-        Replace settings if the provided dictionary has an entry with the same key
-        """
-        if isinstance(settings, Options):
-            settings = SettingsType(settings)
-
-        with self.lock:
-            if not self.subtitles:
-                return
-
-            common_keys = settings.keys() & self.subtitles.settings.keys()
-            if not all(settings.get(key) == self.subtitles.settings.get(key) for key in common_keys):
-                self.subtitles.UpdateProjectSettings(settings)
-                self.needs_writing = bool(self.subtitles.scenes) and self.use_project_file
 
     def WriteProjectToFile(self, projectfile: str, encoder_class: type|None = None) -> None:
         """
@@ -394,5 +432,29 @@ class SubtitleProject:
         logging.debug("Scene translated")
         self.needs_writing = self.use_project_file
         self.events.scene_translated(scene)
+
+    def _update_compatibility(self, settings: SettingsType) -> None:
+        """
+        Update settings for compatibility with older versions
+        """
+        if not settings.get('description') and settings.get('synopsis'):
+            settings['description'] = settings.get('synopsis')
+
+        if settings.get('characters'):
+            names = settings.get_str_list('names')
+            names.extend(settings.get_str_list('characters'))
+            settings['names'] = names
+            del settings['characters']
+
+        if settings.get('gpt_prompt'):
+            settings['prompt'] = settings['gpt_prompt']
+            del settings['gpt_prompt']
+
+        if settings.get('gpt_model'):
+            settings['model'] = settings['gpt_model']
+            del settings['gpt_model']
+
+        if not settings.get('substitution_mode'):
+            settings['substitution_mode'] = "Partial Words" if settings.get('match_partial_words') else "Auto"
 
 

--- a/PySubtrans/SubtitleSerialisation.py
+++ b/PySubtrans/SubtitleSerialisation.py
@@ -44,7 +44,7 @@ class SubtitleEncoder(json.JSONEncoder):
                 "sourcepath": obj.sourcepath,
                 "outputpath": obj.outputpath,
                 "scenecount": len(obj.scenes),
-                "settings": getattr(obj, 'settings') or getattr(obj, 'context'),
+                "settings": getattr(obj, 'settings', {}),
                 "metadata": getattr(obj, 'metadata', {}),
                 "format": obj.file_format,
                 "scenes": obj.scenes,
@@ -124,7 +124,6 @@ def _object_hook(dct):
             obj.metadata = dct.get('metadata', {})
             obj.file_format = dct.get('format', '.srt')
             obj.scenes = dct.get('scenes', [])
-            obj.UpdateProjectSettings(SettingsType()) # Force update for legacy files
             return obj
         elif class_name == classname(SubtitleScene):
             obj = SubtitleScene(dct)

--- a/PySubtrans/SubtitleTranslator.py
+++ b/PySubtrans/SubtitleTranslator.py
@@ -11,6 +11,7 @@ from PySubtrans.Instructions import DEFAULT_TASK_TYPE, Instructions
 from PySubtrans.SettingsType import SettingsType
 from PySubtrans.Substitutions import Substitutions
 from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleLine import SubtitleLine
 from PySubtrans.SubtitleProcessor import SubtitleProcessor
 from PySubtrans.Translation import Translation
@@ -107,7 +108,8 @@ class SubtitleTranslator:
         if not subtitles.scenes:
             if self.retranslate or self.reparse:
                 logging.warning(_("No previous translations found, starting fresh..."))
-            subtitles.AutoBatch(self.batcher)
+            with SubtitleEditor(subtitles) as editor:
+                editor.AutoBatch(self.batcher)
 
         if not subtitles.scenes:
             raise TranslationImpossibleError(_("No scenes to translate"))

--- a/PySubtrans/SubtitleTranslator.py
+++ b/PySubtrans/SubtitleTranslator.py
@@ -4,6 +4,7 @@ import threading
 from typing import Any
 
 from PySubtrans.Helpers.SettingsHelpers import GetStrSetting
+from PySubtrans.Helpers.ContextHelpers import GetBatchContext
 from PySubtrans.Helpers.SubtitleHelpers import MergeTranslations
 from PySubtrans.Helpers.Localization import _, tr
 from PySubtrans.Helpers.Text import Linearise, SanitiseSummary
@@ -170,7 +171,7 @@ class SubtitleTranslator:
             context = {}
 
             for batch in batches:
-                context = subtitles.GetBatchContext(scene.number, batch.number, self.max_history)
+                context = GetBatchContext(subtitles, scene.number, batch.number, self.max_history)
 
                 try:
                     self.TranslateBatch(batch, line_numbers, context)

--- a/PySubtrans/Subtitles.py
+++ b/PySubtrans/Subtitles.py
@@ -5,7 +5,6 @@ import os
 import logging
 import threading
 from typing import Any
-import bisect
 from PySubtrans.Helpers.Localization import _
 from PySubtrans.Instructions import DEFAULT_TASK_TYPE
 from PySubtrans.Options import Options, SettingsType
@@ -18,11 +17,9 @@ from PySubtrans.Helpers import GetInputPath, GetOutputPath
 from PySubtrans.Helpers.Parse import ParseNames
 from PySubtrans.SubtitleFileHandler import SubtitleFileHandler, default_encoding
 from PySubtrans.SubtitleFormatRegistry import SubtitleFormatRegistry
-from PySubtrans.SubtitleProcessor import SubtitleProcessor
 from PySubtrans.SubtitleScene import SubtitleScene, UnbatchScenes
 from PySubtrans.SubtitleLine import SubtitleLine
 from PySubtrans.SubtitleData import SubtitleData
-from PySubtrans.SubtitleBatcher import SubtitleBatcher
 
 class Subtitles:
     """
@@ -402,203 +399,6 @@ class Subtitles:
         self.outputpath = outputpath
         self.file_format = extension
 
-    def PreProcess(self, preprocessor: SubtitleProcessor) -> None:
-        """
-        Preprocess subtitles
-        """
-        with self.lock:
-            if self.originals:
-                self.originals = preprocessor.PreprocessSubtitles(self.originals)
-
-    def AutoBatch(self, batcher: SubtitleBatcher) -> None:
-        """
-        Divide subtitles into scenes and batches based on threshold options
-        """
-        with self.lock:
-            if self.originals:
-                self.scenes = batcher.BatchSubtitles(self.originals)
-
-    def AddScene(self, scene: SubtitleScene) -> None:
-        with self.lock:
-            self.scenes.append(scene)
-            logging.debug("Added a new scene")
-
-    def UpdateScene(self, scene_number: int, update: dict[str, Any]) -> Any:
-        with self.lock:
-            scene: SubtitleScene = self.GetScene(scene_number)
-            if not scene:
-                raise ValueError(f"Scene {scene_number} does not exist")
-
-            return scene.UpdateContext(update)
-
-    def UpdateBatch(self, scene_number: int, batch_number: int, update: dict[str, Any]) -> bool:
-        with self.lock:
-            batch: SubtitleBatch = self.GetBatch(scene_number, batch_number)
-            if not batch:
-                raise ValueError(f"Batch ({scene_number},{batch_number}) does not exist")
-
-            return batch.UpdateContext(update)
-
-    def UpdateLineText(self, line_number : int, original_text : str, translated_text : str) -> None:
-        with self.lock:
-            if self.originals is None:
-                raise SubtitleError("Original subtitles are missing!")
-
-            original_line = next((original for original in self.originals if original.number == line_number), None)
-            if not original_line:
-                raise ValueError(f"Line {line_number} not found")
-
-            if original_text:
-                original_line.text = original_text
-                original_line.translation = translated_text
-
-            if not translated_text:
-                return
-
-            translated_line = next((translated for translated in self.translated if translated.number == line_number), None) if self.translated else None
-            if translated_line:
-                translated_line.text = translated_text
-                return
-
-            translated_line = SubtitleLine.Construct(line_number, original_line.start, original_line.end, translated_text, original_line.metadata)
-
-            if not self.translated:
-                self.translated = []
-
-            insertIndex = bisect.bisect_left([line.number for line in self.translated], line_number)
-            self.translated.insert(insertIndex, translated_line)
-
-    def DeleteLines(self, line_numbers: list[int]) -> list[tuple[int, int, list[SubtitleLine], list[SubtitleLine]]]:
-        """
-        Delete lines from the subtitles
-        """
-        deletions = []
-        with self.lock:
-            batches = self.GetBatchesContainingLines(line_numbers)
-
-            for batch in batches:
-                deleted_originals, deleted_translated = batch.DeleteLines(line_numbers)
-                if len(deleted_originals) > 0 or len(deleted_translated) > 0:
-                    deletion = (batch.scene, batch.number, deleted_originals, deleted_translated)
-                    deletions.append(deletion)
-
-            if not deletions:
-                raise ValueError("No lines were deleted from any batches")
-
-        return deletions
-
-    def MergeScenes(self, scene_numbers: list[int]) -> SubtitleScene:
-        """
-        Merge several (sequential) scenes into one scene
-        """
-        if not scene_numbers:
-            raise ValueError("No scene numbers supplied to MergeScenes")
-
-        scene_numbers = sorted(scene_numbers)
-        if scene_numbers != list(range(scene_numbers[0], scene_numbers[0] + len(scene_numbers))):
-            raise ValueError("Scene numbers to be merged are not sequential")
-
-        with self.lock:
-            scenes : list[SubtitleScene] = [scene for scene in self.scenes if scene.number in scene_numbers]
-            if len(scenes) != len(scene_numbers):
-                raise ValueError(f"Could not find scenes {','.join([str(i) for i in scene_numbers])}")
-
-            # Merge all scenes into the first
-            merged_scene = scenes[0]
-            merged_scene.MergeScenes(scenes[1:])
-
-            # Slice out the merged scenes
-            start_index = self.scenes.index(scenes[0])
-            end_index = self.scenes.index(scenes[-1])
-            self.scenes = self.scenes[:start_index + 1] + self.scenes[end_index+1:]
-
-            self._renumber_scenes()
-
-        return merged_scene
-
-    def MergeBatches(self, scene_number: int, batch_numbers: list[int]) -> None:
-        """
-        Merge several (sequential) batches from a scene into one batch
-        """
-        if not batch_numbers:
-            raise ValueError("No batch numbers supplied to MergeBatches")
-
-        with self.lock:
-            scene : SubtitleScene|None = next((scene for scene in self.scenes if scene.number == scene_number), None)
-            if not scene:
-                raise ValueError(f"Scene {str(scene_number)} not found")
-
-            scene.MergeBatches(batch_numbers)
-
-    def MergeLinesInBatch(self, scene_number: int, batch_number: int, line_numbers: list[int]) -> tuple[SubtitleLine, SubtitleLine|None]:
-        """
-        Merge several sequential lines together, remapping originals and translated lines if necessary.
-        """
-        with self.lock:
-            batch : SubtitleBatch = self.GetBatch(scene_number, batch_number)
-            return batch.MergeLines(line_numbers)
-
-    def SplitScene(self, scene_number: int, batch_number: int) -> None:
-        """
-        Split a scene into two at the specified batch number
-        """
-        with self.lock:
-            scene : SubtitleScene = self.GetScene(scene_number)
-            batch : SubtitleBatch|None = scene.GetBatch(batch_number) if scene else None
-
-            if not batch:
-                raise ValueError(f"Scene {scene_number} batch {batch_number} does not exist")
-
-            batch_index : int = scene.batches.index(batch)
-
-            new_scene = SubtitleScene({ 'number' : scene_number + 1})
-            new_scene.batches = scene.batches[batch_index:]
-            scene.batches = scene.batches[:batch_index]
-
-            for number, batch in enumerate(new_scene.batches, start=1):
-                batch.scene = new_scene.number
-                batch.number = number
-
-            split_index = self.scenes.index(scene) + 1
-            if split_index < len(self.scenes):
-                self.scenes = self.scenes[:split_index] + [new_scene] + self.scenes[split_index:]
-            else:
-                self.scenes.append(new_scene)
-
-            self._renumber_scenes()
-
-    def Sanitise(self) -> None:
-        """
-        Remove invalid lines, empty batches and empty scenes
-        """
-        with self.lock:
-            for scene in self.scenes:
-                scene.batches = [batch for batch in scene.batches if batch.originals]
-
-                for batch in scene.batches:
-                    batch.originals = [line for line in batch.originals if line.number and line.start is not None]
-                    if batch.translated:
-                        batch.translated = [line for line in batch.translated if line.number and line.start is not None ]
-
-                    original_line_numbers = [line.number for line in batch.originals]
-                    unmatched_translated = [line for line in batch.translated if line.number not in original_line_numbers]
-                    if unmatched_translated:
-                        logging.warning(_("Removing {} translations lines in batch ({},{}) that don't match an original line").format(len(unmatched_translated), batch.scene, batch.number))
-                        batch.translated = [line for line in batch.translated if line not in unmatched_translated]
-
-        self.scenes = [scene for scene in self.scenes if scene.batches]
-        self._renumber_scenes()
-
-    def _renumber_scenes(self) -> None:
-        """
-        Ensure scenes are numbered sequentially
-        """
-        for scene_number, scene in enumerate(self.scenes, start = 1):
-            scene.number = scene_number
-            for batch_number, batch in enumerate(scene.batches, start = 1):
-                batch.scene = scene.number
-                batch.number = batch_number
-
     def _renumber_if_needed(self, lines : list[SubtitleLine]|None) -> None:
         """
         Renumber subtitle lines if any have number 0 (indicating missing/invalid indices)
@@ -641,17 +441,6 @@ class Subtitles:
                 line.text = f"{line.text}\n{item.text}"
 
         return sorted(lines.values(), key=lambda item: item.key)
-
-    def _duplicate_originals_as_translations(self) -> None:
-        """
-        Duplicate original lines as translated lines if no translations exist (for testing)
-        """
-        for scene in self.scenes:
-            for batch in scene.batches:
-                if batch.any_translated:
-                    raise SubtitleError("Translations already exist")
-
-                batch.translated = [ SubtitleLine.Construct(line.number, line.start, line.end, line.text or "", line.metadata) for line in batch.originals ]
 
     def _get_setting_str(self, key: str, default: str|None = None) -> str|None:
         """

--- a/PySubtrans/UnitTests/test_ChineseDinner.py
+++ b/PySubtrans/UnitTests/test_ChineseDinner.py
@@ -4,6 +4,7 @@ from PySubtrans.Helpers.TestCases import PrepareSubtitles, SubtitleTestCase
 from PySubtrans.Helpers.Tests import log_info, log_input_expected_result, log_test_name
 from PySubtrans.SubtitleBatch import SubtitleBatch
 from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.Subtitles import Subtitles
 from PySubtrans.Formats.SrtFileHandler import SrtFileHandler
 from PySubtrans.SubtitleLine import SubtitleLine
@@ -97,7 +98,8 @@ class ChineseDinnerTests(SubtitleTestCase):
         subtitles : Subtitles = PrepareSubtitles(chinese_dinner_data)
 
         batcher = SubtitleBatcher(self.options)
-        subtitles.AutoBatch(batcher)
+        with SubtitleEditor(subtitles) as editor:
+            editor.AutoBatch(batcher)
 
         log_info("Line count: " + str(subtitles.linecount))
         log_info("Scene count: " + str(subtitles.scenecount))
@@ -168,7 +170,8 @@ class ChineseDinnerTests(SubtitleTestCase):
             log_test_name("Merge scenes tests")
 
             # Merge scenes 3 and 4
-            subtitles.MergeScenes([3,4])
+            with SubtitleEditor(subtitles) as editor:
+                editor.MergeScenes([3,4])
 
             log_input_expected_result(f"Merge [3,4] -> scenecount", 3, subtitles.scenecount)
             self.assertEqual(subtitles.scenecount, 3)
@@ -257,7 +260,8 @@ class ChineseDinnerTests(SubtitleTestCase):
 
         with self.subTest("Merge batches"):
             log_test_name("Merge scene 3 batches 1 & 2")
-            subtitles.MergeBatches(3, [1,2])
+            with SubtitleEditor(subtitles) as editor:
+                editor.MergeBatches(3, [1,2])
 
             log_input_expected_result("Scene count", 3, subtitles.scenecount)
             self.assertEqual(subtitles.scenecount, 3)
@@ -337,7 +341,8 @@ class ChineseDinnerTests(SubtitleTestCase):
         with self.subTest("Split scene 1"):
             log_test_name("Split scene 1")
 
-            subtitles.SplitScene(1, 2)
+            with SubtitleEditor(subtitles) as editor:
+                editor.SplitScene(1, 2)
 
             log_input_expected_result("Scene count", 4, subtitles.scenecount)
             self.assertEqual(subtitles.scenecount, 4)
@@ -378,7 +383,8 @@ class ChineseDinnerTests(SubtitleTestCase):
         self.assertEqual(line.srt_end, "00:15:36,790")
         self.assertEqual(line.text, "どうして俺を殺すんだ.")
 
-        subtitles.UpdateLineText(36, original_text="どうして俺を殺すのか.", translated_text="Why are you going to kill me?")
+        with SubtitleEditor(subtitles) as editor:
+            editor.UpdateLineText(36, original_text="どうして俺を殺すのか.", translated_text="Why are you going to kill me?")
 
         log_input_expected_result("After update", "どうして俺を殺すのか.", line.text)
         log_input_expected_result("Translated", "Why are you going to kill me?", line.translation)

--- a/PySubtrans/UnitTests/test_ChineseDinner.py
+++ b/PySubtrans/UnitTests/test_ChineseDinner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from PySubtrans.Helpers.TestCases import PrepareSubtitles, SubtitleTestCase
+from PySubtrans.Helpers.ContextHelpers import GetBatchContext
 from PySubtrans.Helpers.Tests import log_info, log_input_expected_result, log_test_name
 from PySubtrans.SubtitleBatch import SubtitleBatch
 from PySubtrans.SubtitleBatcher import SubtitleBatcher
@@ -142,7 +143,7 @@ class ChineseDinnerTests(SubtitleTestCase):
                 for scene in subtitles.scenes:
                     scene.AddContext('summary', f"Summary of scene {scene.number}")
 
-                scene_4_context = subtitles.GetBatchContext(4, 1, 10)
+                scene_4_context = GetBatchContext(subtitles, 4, 1, 10)
                 self.assertIsNotNone(scene_4_context)
 
                 self.assertEqual(scene_4_context.get('scene'), "Scene 4: Summary of scene 4")
@@ -198,7 +199,7 @@ class ChineseDinnerTests(SubtitleTestCase):
             log_input_expected_result("Last line number", 61, first_batch.last_line_number)
             self.assertEqual(first_batch.last_line_number, 61)
 
-            first_batch_context = subtitles.GetBatchContext(3, 1, 10)
+            first_batch_context = GetBatchContext(subtitles, 3, 1, 10)
             self.assertIsNotNone(first_batch_context)
             self.assertEqual(first_batch_context.get('scene'), "Scene 3: Summary of scene 3\nSummary of scene 4")
             self.assertEqual(first_batch_context.get('batch'), "Batch 1")
@@ -233,7 +234,7 @@ class ChineseDinnerTests(SubtitleTestCase):
             log_input_expected_result("Last line number", 64, second_batch.last_line_number)
             self.assertEqual(second_batch.last_line_number, 64)
 
-            second_batch_context = subtitles.GetBatchContext(3, 2, 10)
+            second_batch_context = GetBatchContext(subtitles, 3, 2, 10)
             self.assertIsNotNone(second_batch_context)
 
             self.assertEqual(second_batch_context.get('scene'), "Scene 3: Summary of scene 3\nSummary of scene 4")
@@ -284,7 +285,7 @@ class ChineseDinnerTests(SubtitleTestCase):
 
             self.assertEqual(merged_batch.summary, "Summary of batch 1\nSummary of batch 2")
 
-            merged_batch_context = subtitles.GetBatchContext(3, 1, 10)
+            merged_batch_context = GetBatchContext(subtitles, 3, 1, 10)
             self.assertIsNotNone(merged_batch_context)
 
             self.assertEqual(merged_batch_context.get('scene'), "Scene 3: Summary of scene 3\nSummary of scene 4")

--- a/PySubtrans/UnitTests/test_ChineseDinner.py
+++ b/PySubtrans/UnitTests/test_ChineseDinner.py
@@ -47,24 +47,17 @@ class ChineseDinnerTests(SubtitleTestCase):
             self.assertEqual(subtitles.start_line_number, 1)
             self.assertSequenceEqual(subtitles.scenes, [])
 
-        with self.subTest("Update project settings"):
-            log_test_name("Update project settings")
-            subtitles.UpdateProjectSettings(chinese_dinner_data)
-
-            self.assertEqual(subtitles.movie_name, chinese_dinner_data.get('movie_name'))
-            self.assertEqual(subtitles.settings.get('description'), chinese_dinner_data.get('description'))
-            self.assertSequenceEqual(subtitles.settings.get_list('names'), chinese_dinner_data.get_list('names'))
-
         with self.subTest("Create project"):
             log_test_name("Create project")
             project = SubtitleProject()
             project.subtitles = subtitles
+            project.UpdateProjectSettings(chinese_dinner_data)
             project.UpdateProjectSettings(self.options)
 
             self.assertIsNotNone(project.subtitles)
 
             self.assertEqual(project.target_language, self.options.target_language)
-            self.assertEqual(project.movie_name, chinese_dinner_data.get_str('movie_name', '** No movie name**'))
+            self.assertEqual(project.movie_name, chinese_dinner_data.get('movie_name'))
 
             log_info("Movie name: " + (project.movie_name or "** No movie name**"))
             log_info("Target language: " + (project.target_language or "** No target language**"))

--- a/PySubtrans/UnitTests/test_SubtitleProjectFormats.py
+++ b/PySubtrans/UnitTests/test_SubtitleProjectFormats.py
@@ -10,6 +10,7 @@ from PySubtrans.SubtitleFileHandler import SubtitleFileHandler
 from PySubtrans.SubtitleData import SubtitleData
 from PySubtrans.Formats.SrtFileHandler import SrtFileHandler
 from PySubtrans.Formats.SSAFileHandler import SSAFileHandler
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleSerialisation import SubtitleEncoder, SubtitleDecoder
 from PySubtrans.Subtitles import Subtitles
 from PySubtrans.Helpers.Color import Color
@@ -430,8 +431,10 @@ Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello ASS!
         log_input_expected_result("format after setting output path", ".srt", project.subtitles.file_format)
         self.assertEqual(project.subtitles.file_format, ".srt")
         
-        project.subtitles.AutoBatch(SubtitleBatcher(options))
-        project.subtitles._duplicate_originals_as_translations()
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.AutoBatch(SubtitleBatcher(options))
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.DuplicateOriginalsAsTranslations()
         project.needs_writing = True
         project.SaveTranslation()
         
@@ -471,8 +474,10 @@ Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello ASS!
         log_input_expected_result("format after setting output path", ".ass", project.subtitles.file_format)
         self.assertEqual(project.subtitles.file_format, ".ass")
         
-        project.subtitles.AutoBatch(SubtitleBatcher(options))
-        project.subtitles._duplicate_originals_as_translations()
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.AutoBatch(SubtitleBatcher(options))
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.DuplicateOriginalsAsTranslations()
         project.needs_writing = True
         project.SaveTranslation()
         
@@ -510,8 +515,10 @@ Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello ASS!
         log_input_expected_result("project.subtitles not None", True, project.subtitles is not None)
         self.assertIsNotNone(project.subtitles)
         
-        project.subtitles.AutoBatch(SubtitleBatcher(options))
-        project.subtitles._duplicate_originals_as_translations()
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.AutoBatch(SubtitleBatcher(options))
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.DuplicateOriginalsAsTranslations()
         project.needs_writing = True
         
         # Create and write project file

--- a/PySubtrans/UnitTests/test_Translator.py
+++ b/PySubtrans/UnitTests/test_Translator.py
@@ -5,6 +5,7 @@ from PySubtrans.Helpers.TestCases import DummyProvider, PrepareSubtitles, Subtit
 from PySubtrans.Helpers.Tests import log_info, log_input_expected_result, log_test_name
 from PySubtrans.SubtitleBatch import SubtitleBatch
 from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.Subtitles import Subtitles
 from PySubtrans.SubtitleScene import SubtitleScene
 from PySubtrans.SubtitleTranslator import SubtitleTranslator
@@ -33,8 +34,10 @@ class SubtitleTranslatorTests(SubtitleTestCase):
             self.assertEqual(originals.linecount, reference.linecount)
 
             batcher = SubtitleBatcher(self.options)
-            originals.AutoBatch(batcher)
-            reference.AutoBatch(batcher)
+            with SubtitleEditor(originals) as editor:
+                editor.AutoBatch(batcher)
+            with SubtitleEditor(reference) as editor:
+                editor.AutoBatch(batcher)
 
             self.assertEqual(len(originals.scenes), len(reference.scenes))
 
@@ -106,8 +109,10 @@ class SubtitleTranslatorTests(SubtitleTestCase):
             self.assertEqual(originals.linecount, reference.linecount)
 
             batcher = SubtitleBatcher(self.options)
-            originals.AutoBatch(batcher)
-            reference.AutoBatch(batcher)
+            with SubtitleEditor(originals) as editor:
+                editor.AutoBatch(batcher)
+            with SubtitleEditor(reference) as editor:
+                editor.AutoBatch(batcher)
 
             self.assertEqual(len(originals.scenes), len(reference.scenes))
 

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -28,6 +28,7 @@ from PySubtrans.Helpers import GetInputPath
 from PySubtrans.Options import Options
 from PySubtrans.SettingsType import SettingType, SettingsType
 from PySubtrans.SubtitleBuilder import SubtitleBuilder
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleFormatRegistry import SubtitleFormatRegistry
 from PySubtrans.Subtitles import Subtitles
 from PySubtrans.SubtitleScene import SubtitleScene
@@ -253,7 +254,8 @@ def preprocess_subtitles(subtitles: Subtitles, options: Options) -> None:
         raise ValueError("No subtitles to preprocess")
 
     preprocessor = SubtitleProcessor(options)
-    subtitles.PreProcess(preprocessor)
+    with SubtitleEditor(subtitles) as editor:
+        editor.PreProcess(preprocessor)
 
 __all__ = [
     '__version__',
@@ -261,6 +263,7 @@ __all__ = [
     'Subtitles',
     'SubtitleScene',
     'SubtitleBuilder',
+    'SubtitleEditor',
     'SubtitleProject',
     'SubtitleTranslator',
     'TranslationProvider',


### PR DESCRIPTION
Subtitles was a mess of mixed responsibilities, basically anything that needed a lock got dumped in there.

To make the architecture more comprehensible, it has been broken up and responsibilities moved to more appropriate places.

A new SubtitleEditor class handles operations that mutate the subtitles, with its own lock acquisition.

Project-specific settings have been relocated to SubtitleProject - Subtitles now just acts as a container for settings serialisation.

Batch context and history management has been moved to a separate helper file.

Risks: the logic around loading and saving project files is quite fragile, there is a HIGH RISK of these changes leading to issues when loading and saving project files that have non-default settings values.