### PR TITLE
Streamline project workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ gui-subtrans.spec
 llm-subtrans.sh
 mistral-subtrans.sh
 untranslated_msgids_*.txt
+
+/PySubtrans/build
+/PySubtrans/dist
+/PySubtrans/*.egg-info

--- a/GuiSubtrans/Commands/DeleteLinesCommand.py
+++ b/GuiSubtrans/Commands/DeleteLinesCommand.py
@@ -5,6 +5,7 @@ from PySubtrans.SubtitleValidator import SubtitleValidator
 from PySubtrans.SubtitleBatch import SubtitleBatch
 from PySubtrans.SubtitleLine import SubtitleLine
 from PySubtrans.SubtitleProject import SubtitleProject
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.Helpers.Localization import _
 
 import logging
@@ -32,7 +33,8 @@ class DeleteLinesCommand(Command):
         if not project.subtitles:
             raise CommandError(_("No subtitles"), command=self)
 
-        self.deletions = project.subtitles.DeleteLines(self.line_numbers)
+        with SubtitleEditor(project.subtitles) as editor:
+            self.deletions = editor.DeleteLines(self.line_numbers)
 
         if not self.deletions:
             raise CommandError(_("No lines were deleted"), command=self)

--- a/GuiSubtrans/Commands/MergeBatchesCommand.py
+++ b/GuiSubtrans/Commands/MergeBatchesCommand.py
@@ -3,6 +3,7 @@ from GuiSubtrans.ProjectDataModel import ProjectDataModel
 from GuiSubtrans.ViewModel.ViewModelUpdate import ModelUpdate
 from PySubtrans.Helpers.Localization import _
 from PySubtrans.SubtitleBatch import SubtitleBatch
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleProject import SubtitleProject
 
 import logging
@@ -40,7 +41,8 @@ class MergeBatchesCommand(Command):
             self.original_first_line_numbers = [batch.first_line_number for batch in original_batches if batch and batch.first_line_number]
             self.original_summaries = {batch.number: batch.summary for batch in original_batches if batch and batch.summary}
 
-            project.subtitles.MergeBatches(self.scene_number, self.batch_numbers)
+            with SubtitleEditor(project.subtitles) as editor:
+                editor.MergeBatches(self.scene_number, self.batch_numbers)
 
             merged_batch = scene.GetBatch(merged_batch_number)
             if merged_batch is not None:

--- a/GuiSubtrans/Commands/MergeLinesCommand.py
+++ b/GuiSubtrans/Commands/MergeLinesCommand.py
@@ -2,6 +2,7 @@ from GuiSubtrans.Command import Command, CommandError, UndoError
 from GuiSubtrans.ProjectDataModel import ProjectDataModel
 from GuiSubtrans.ViewModel.ViewModelUpdate import ModelUpdate
 from PySubtrans.SubtitleBatch import SubtitleBatch
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.Subtitles import Subtitles
 from PySubtrans.SubtitleProject import SubtitleProject
 from PySubtrans.Helpers.Localization import _
@@ -50,7 +51,8 @@ class MergeLinesCommand(Command):
 
             self.undo_data.append((batch.scene, batch.number, originals, translated))
 
-            merged_line, merged_translated = subtitles.MergeLinesInBatch(batch.scene, batch.number, batch_lines)
+            with SubtitleEditor(subtitles) as editor:
+                merged_line, merged_translated = editor.MergeLinesInBatch(batch.scene, batch.number, batch_lines)
 
             if not merged_line:
                 raise CommandError(_("Failed to merge lines"), command=self)

--- a/GuiSubtrans/Commands/SaveProjectFile.py
+++ b/GuiSubtrans/Commands/SaveProjectFile.py
@@ -23,7 +23,7 @@ class SaveProjectFile(Command):
 
         # Update the project path and set the subtitle output path to the same location
         self.project.projectfile = self.project.GetProjectFilepath(self.filepath)
-        self.project.subtitles.UpdateOutputPath(path=self.project.projectfile, extension=self.project.subtitles.file_format)
+        self.project.UpdateOutputPath(path=self.project.projectfile, extension=self.project.subtitles.file_format)
 
         if current_filepath != self.project.projectfile or current_outputpath != self.project.subtitles.outputpath:
             self.project.needs_writing = True

--- a/GuiSubtrans/Commands/SplitSceneCommand.py
+++ b/GuiSubtrans/Commands/SplitSceneCommand.py
@@ -1,6 +1,7 @@
 from GuiSubtrans.Command import Command, CommandError
 from GuiSubtrans.ProjectDataModel import ProjectDataModel
 from GuiSubtrans.ViewModel.ViewModelUpdate import ModelUpdate
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleProject import SubtitleProject
 from PySubtrans.Helpers.Localization import _
 
@@ -29,7 +30,8 @@ class SplitSceneCommand(Command):
 
         last_batch = scene.batches[-1].number
 
-        project.subtitles.SplitScene(self.scene_number, self.batch_number)
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.SplitScene(self.scene_number, self.batch_number)
 
         model_update : ModelUpdate =  self.AddModelUpdate()
         for scene_number in range(self.scene_number + 1, len(project.subtitles.scenes)):
@@ -55,7 +57,8 @@ class SplitSceneCommand(Command):
             scene_numbers = [self.scene_number, self.scene_number + 1]
             later_scenes = [scene.number for scene in project.subtitles.scenes if scene.number > scene_numbers[1]]
 
-            merged_scene = project.subtitles.MergeScenes(scene_numbers)
+            with SubtitleEditor(project.subtitles) as editor:
+                merged_scene = editor.MergeScenes(scene_numbers)
 
             # Recombine the split scenes
             model_update : ModelUpdate =  self.AddModelUpdate()

--- a/GuiSubtrans/Commands/StartTranslationCommand.py
+++ b/GuiSubtrans/Commands/StartTranslationCommand.py
@@ -27,6 +27,11 @@ class StartTranslationCommand(Command):
         project : SubtitleProject = self.datamodel.project
         subtitles : Subtitles = project.subtitles
 
+        # Initialize the project translator if not already done
+        if not project.translator:
+            options = self.datamodel.project_options
+            project.InitialiseTranslator(options, self.datamodel.translation_provider)
+
         if self.resume and subtitles.scenes and all(scene.all_translated for scene in subtitles.scenes):
             logging.info(_("All scenes are fully translated"))
             return True

--- a/GuiSubtrans/ProjectDataModel.py
+++ b/GuiSubtrans/ProjectDataModel.py
@@ -116,7 +116,7 @@ class ProjectDataModel:
             # Update the output path with optional format change
             previous_output_path : str|None = self.project.subtitles.outputpath
 
-            self.project.subtitles.UpdateOutputPath(path=self.project.projectfile)
+            self.project.UpdateOutputPath(path=self.project.projectfile)
 
             if self.project.subtitles.outputpath != previous_output_path:
                 logging.info(_("Setting output path to {}").format(self.project.subtitles.outputpath))
@@ -155,7 +155,7 @@ class ProjectDataModel:
         with QMutexLocker(self.mutex):
             self.viewmodel = ProjectViewModel()
             if self.project is not None:
-                self.viewmodel.CreateModel(self.project.subtitles)
+                self.viewmodel.CreateModel(self.project.subtitles, self.project.task_type)
         return self.viewmodel
 
     def UpdateViewModel(self, update : ModelUpdate):

--- a/GuiSubtrans/UnitTests/DataModelHelpers.py
+++ b/GuiSubtrans/UnitTests/DataModelHelpers.py
@@ -3,6 +3,7 @@ from PySubtrans.Helpers.TestCases import AddTranslations, PrepareSubtitles
 from PySubtrans.Options import Options
 from PySubtrans.SettingsType import SettingsType
 from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.Subtitles import Subtitles
 from PySubtrans.SubtitleProject import SubtitleProject
 
@@ -33,7 +34,8 @@ def CreateTestDataModelBatched(test_data : dict, options : Options|None = None, 
 
     subtitles : Subtitles = datamodel.project.subtitles
     batcher = SubtitleBatcher(options.GetSettings())
-    subtitles.AutoBatch(batcher)
+    with SubtitleEditor(subtitles) as editor:
+        editor.AutoBatch(batcher)
 
     if translated and 'translated' in test_data:
         AddTranslations(subtitles, test_data, 'translated')

--- a/GuiSubtrans/ViewModel/ViewModel.py
+++ b/GuiSubtrans/ViewModel/ViewModel.py
@@ -80,12 +80,12 @@ class ProjectViewModel(QStandardItemModel):
             self.blockSignals(False)
             self.endResetModel()
 
-    def CreateModel(self, data : Subtitles):
+    def CreateModel(self, data : Subtitles, task_type : str|None = None) -> None:
         if not isinstance(data, Subtitles):
             raise ValueError(_("Can only model subtitle files"))
 
         self.model = {}
-        self.task_type = data.task_type
+        self.task_type = task_type or DEFAULT_TASK_TYPE
 
         for scene in data.scenes:
             scene_item = self.CreateSceneItem(scene)

--- a/PySubtrans/Helpers/ContextHelpers.py
+++ b/PySubtrans/Helpers/ContextHelpers.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from PySubtrans.Helpers.Parse import ParseNames
+from PySubtrans.SubtitleError import SubtitleError
+
+if TYPE_CHECKING:
+    from PySubtrans.Subtitles import Subtitles
+
+
+def GetBatchContext(subtitles: Subtitles, scene_number: int, batch_number: int, max_lines: int|None = None) -> dict[str, Any]:
+    """
+    Get context for a batch of subtitles, by extracting summaries from previous scenes and batches
+    """
+    with subtitles.lock:
+        scene = subtitles.GetScene(scene_number)
+        if not scene:
+            raise SubtitleError(f"Failed to find scene {scene_number}")
+
+        batch = subtitles.GetBatch(scene_number, batch_number)
+        if not batch:
+            raise SubtitleError(f"Failed to find batch {batch_number} in scene {scene_number}")
+
+        context : dict[str,Any] = {
+            'scene_number': scene.number,
+            'batch_number': batch.number,
+            'scene': f"Scene {scene.number}: {scene.summary}" if scene.summary else f"Scene {scene.number}",
+            'batch': f"Batch {batch.number}: {batch.summary}" if batch.summary else f"Batch {batch.number}"
+        }
+
+        if 'movie_name' in subtitles.settings:
+            context['movie_name'] = subtitles.settings.get_str('movie_name')
+
+        if 'description' in subtitles.settings:
+            context['description'] = subtitles.settings.get_str('description')
+
+        if 'names' in subtitles.settings:
+            context['names'] = ParseNames(subtitles.settings.get('names', []))
+
+        history_lines = GetHistory(subtitles, scene_number, batch_number, max_lines)
+
+        if history_lines:
+            context['history'] = history_lines
+
+    return context
+
+
+def GetHistory(subtitles: Subtitles, scene_number: int, batch_number: int, max_lines: int|None = None) -> list[str]:
+    """
+    Get a list of historical summaries up to a given scene and batch number
+    """
+    history_lines : list[str] = []
+    last_summary : str = ""
+
+    scenes = [scene for scene in subtitles.scenes if scene.number and scene.number < scene_number]
+    for scene in [scene for scene in scenes if scene.summary]:
+        if scene.summary != last_summary:
+            history_lines.append(f"scene {scene.number}: {scene.summary}")
+            last_summary = scene.summary or ""
+
+    batches = [batch for batch in subtitles.GetScene(scene_number).batches if batch.number is not None and batch.number < batch_number]
+    for batch in [batch for batch in batches if batch.summary]:
+        if batch.summary != last_summary:
+            history_lines.append(f"scene {batch.scene} batch {batch.number}: {batch.summary}")
+            last_summary = batch.summary or ""
+
+    if max_lines:
+        history_lines = history_lines[-max_lines:]
+
+    return history_lines

--- a/PySubtrans/Helpers/TestCases.py
+++ b/PySubtrans/Helpers/TestCases.py
@@ -98,7 +98,7 @@ def PrepareSubtitles(subtitle_data : dict, key : str = 'original', file_handler:
     handler = file_handler or SubtitleFormatRegistry.create_handler(filename=filename)
     subtitles: Subtitles = Subtitles()
     subtitles.LoadSubtitlesFromString(subtitle_data[key], file_handler=handler)
-    subtitles.UpdateProjectSettings(SettingsType(subtitle_data))
+    subtitles.UpdateSettings(SettingsType(subtitle_data))
     return subtitles
 
 def AddTranslations(subtitles : Subtitles, subtitle_data : dict, key : str = 'translated'):

--- a/PySubtrans/LICENSE
+++ b/PySubtrans/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 machinewrapped
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PySubtrans/Options.py
+++ b/PySubtrans/Options.py
@@ -56,7 +56,7 @@ default_settings = {
     'target_language': env_str('TARGET_LANGUAGE', 'English'),
     'include_original': env_bool('INCLUDE_ORIGINAL', False),
     'add_right_to_left_markers': env_bool('add_right_to_left_markers', False),
-    'scene_threshold': env_float('SCENE_THRESHOLD', 30.0),
+    'scene_threshold': env_float('SCENE_THRESHOLD', 60.0),
     'min_batch_size': env_int('MIN_BATCH_SIZE', 10),
     'max_batch_size': env_int('MAX_BATCH_SIZE', 30),
     'max_context_summaries': env_int('MAX_CONTEXT_SUMMARIES', 10),

--- a/PySubtrans/README.md
+++ b/PySubtrans/README.md
@@ -1,0 +1,111 @@
+# PySubtrans
+
+PySubtrans is the subtitle preparation and translation engine that powers [LLM-Subtrans](https://github.com/machinewrapped/llm-subtrans). It provides everything required to parse subtitle files, manage translation projects, talk to large language model providers and post-process the resulting text. This package makes those capabilities available as a reusable Python library so you can compose your own translation workflows or integrate them into existing tools.
+
+## Installation
+
+```bash
+pip install pysubtrans
+```
+
+Provider integrations are delivered as optional extras so you only install the SDKs you need:
+
+```bash
+pip install pysubtrans[openai]
+pip install pysubtrans[gemini]
+pip install pysubtrans[mistral]
+```
+
+The extras mirror the options that ship with LLM-Subtrans. Multiple extras can be installed in a single command: `pip install pysubtrans[openai,gemini]`.
+
+## Quick start: translate a subtitle file
+
+The quickest way to get started is to use the helper functions exposed at the package root. They wrap the objects used by LLM-Subtrans so that you can stand up a translation pipeline in a few lines of code.
+
+```python
+from PySubtrans import init_options, init_project, init_translator
+
+options = init_options(
+    provider="OpenAI",
+    model="gpt-4o-mini",
+    api_key="sk-your-api-key",
+    instruction_file="instructions.txt",  # Optional – overrides the default prompt/instructions
+    target_language="es",
+)
+
+project = init_project("movie.srt", persistent=True)
+translator = init_translator(project, options)
+
+project.TranslateSubtitles(translator)
+project.SaveTranslation()  # Writes the translated subtitles to disk
+```
+
+The helpers return the same `Options`, `SubtitleProject` and `SubtitleTranslator` objects that power the main application, so you can continue to customise them as needed.
+
+## Configuration with `init_options`
+
+`init_options` creates an `Options` instance and accepts additional keyword arguments for any of the fields documented in `Options.default_settings`. A few examples:
+
+```python
+import os
+from PySubtrans import init_options
+
+options = init_options(
+    provider="Gemini",
+    model="gemini-2.0-flash",
+    api_key=os.environ["GOOGLE_API_KEY"],
+    temperature=0.3,
+    target_language="de",
+    include_original=True,
+)
+```
+
+* Provider credentials, endpoint details and model names can be passed directly. They will be moved into provider-specific settings automatically when the translator is created.
+* Custom instructions can be supplied via `instruction_file` or by overriding `prompt`, `instructions` and `retry_instructions` explicitly.
+* Any additional keyword arguments are merged into the returned `Options` instance, enabling full access to batching thresholds, formatting preferences, language metadata and more.
+
+## Working with projects using `init_project`
+
+`init_project` normalises the provided path, instantiates a `SubtitleProject` and loads the subtitles immediately if a file path is supplied. Passing `persistent=True` mirrors the CLI behaviour by enabling `.subtrans` project files that keep track of in-progress translations and settings.
+
+You can continue to call the usual project helpers:
+
+```python
+project.SaveProjectFile()
+project.SaveTranslation("/custom/output/path.srt")
+project.UpdateProjectSettings(options)
+```
+
+When no file path is supplied the project is created without loading subtitles, making it easy to populate the `Subtitles` object programmatically before translation.
+
+## Building translators with `init_translator`
+
+`init_translator` validates the provider configuration, loads any instruction file declared in the options and wires up a ready-to-use `SubtitleTranslator`. Behind the scenes it uses `TranslationProvider.get_provider` to construct the correct provider client and applies your option overrides to the current project.
+
+Once you have a translator you can:
+
+```python
+translator.events.scene_translated += handle_scene  # Subscribe to events
+project.TranslateSubtitles(translator)
+```
+
+The returned `SubtitleTranslator` exposes all of the batching, retry and provider integration features from the main application.
+
+## Advanced workflows
+
+PySubtrans is designed to be modular. The helper functions above are convenient entry points, but you are free to use lower-level components directly when you need more control:
+
+* Create a `Subtitles` instance by hand (for example when generating subtitles from a transcription pipeline) and pass it straight to `SubtitleTranslator.TranslateSubtitles`.
+* Construct your own `TranslationProvider` instance or subclass to integrate bespoke APIs. All built-in providers live under `PySubtrans.Providers` and serve as reference implementations.
+* Use `SubtitleBatcher` and `SubtitleBatch` to implement custom batching strategies when the default automatic batching does not fit your use case.
+* Hook into `TranslationEvents` to monitor progress or feed translated scenes into additional post-processing steps.
+
+For a detailed breakdown of the module layout and responsibilities refer to the [architecture guide](https://github.com/machinewrapped/llm-subtrans/blob/main/docs/architecture.md).
+
+## Learning from LLM-Subtrans and GUI-Subtrans
+
+The full [LLM-Subtrans](https://github.com/machinewrapped/llm-subtrans) and [GUI-Subtrans](https://github.com/machinewrapped/llm-subtrans/tree/main/GuiSubtrans) applications provide end-to-end examples that combine PySubtrans with logging, configuration UIs and persistence layers. They are excellent references when designing larger systems or when you want to replicate advanced features such as preview runs, retries or translation replays.
+
+## License
+
+PySubtrans is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/PySubtrans/README.md
+++ b/PySubtrans/README.md
@@ -168,12 +168,12 @@ from datetime import timedelta
 builder = SubtitleBuilder(max_batch_size=100)
 subtitles = (builder
     .AddScene(summary="Opening dialogue")
-    .ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Hello, my name is...")
-    .ConstructLine(timedelta(seconds=4), timedelta(seconds=6), "Nice to meet you!")
-    .ConstructLine(timedelta(seconds=8), timedelta(seconds=10), "We need to talk.")
+    .BuildLine(timedelta(seconds=1), timedelta(seconds=3), "Hello, my name is...")
+    .BuildLine(timedelta(seconds=4), timedelta(seconds=6), "Nice to meet you!")
+    .BuildLine(timedelta(seconds=8), timedelta(seconds=10), "We need to talk.")
 
     .AddScene(summary="Action sequence")  # New scene
-    .ConstructLine(timedelta(seconds=65), timedelta(seconds=67), "Look out!")
+    .BuildLine(timedelta(seconds=65), timedelta(seconds=67), "Look out!")
     # ... 
     .Build()
 )
@@ -182,7 +182,7 @@ Batching of subtitle lines within each scene is handled automatically.
 
 #### Option 2: Automatic batching with SubtitleBatcher
 
-`SubtitleBatcher` can be used to automatically group a linear list of lines into scenes and batches:
+`SubtitleBatcher` can be used to automatically group lines into scenes and batches:
 
 ```python
 from PySubtrans import init_subtitles, init_options

--- a/PySubtrans/README.md
+++ b/PySubtrans/README.md
@@ -1,8 +1,8 @@
 # PySubtrans
 
-PySubtrans is the subtitle translation engine that powers [LLM-Subtrans](https://github.com/machinewrapped/llm-subtrans). It provides tools to read and write subtitle files in various formats, manage a translation workflow connecting to various LLM APIs and to pre-process or post-process subtitles to ensure readable results. 
+PySubtrans is the subtitle translation engine that powers [LLM-Subtrans](https://github.com/machinewrapped/llm-subtrans). It provides tools to read and write subtitle files in various formats, connect to various LLMs as translators and manage a translation workflow.
 
-This package makes those capabilities available as a library that you can incorporate into your own tools and workflows to take advantage of the best-in-class translation quality that LLM-Subtrans provides.
+This package makes these capabilities available as a library that you can incorporate into your own tools and workflows to take advantage of the best-in-class translation quality that LLM-Subtrans provides.
 
 ## Installation
 
@@ -12,7 +12,7 @@ Basic installation with support for OpenRouter, DeepSeek or any server with an O
 pip install pysubtrans
 ```
 
-Additional specialized provider integrations are delivered as optional extras so you only install the SDKs for providers you want to use:
+Additional specialized provider integrations are delivered as optional extras, so that you only install the SDKs for providers you intend to use:
 
 ```bash
 pip install pysubtrans[openai]
@@ -23,7 +23,7 @@ pip install pysubtrans[openai,gemini,claude,mistral,bedrock]
 
 ## Quick start: translate a subtitle file
 
-The quickest way to get started is to use the helper functions exposed at the package root. They wrap the objects used by LLM-Subtrans so that you can stand up a translation pipeline in a few lines of code.
+The quickest way to get started is to use the helper functions exposed at the package root. They wrap the objects used by LLM-Subtrans so that you can execute a full translation pipeline with a few lines of code.
 
 ```python
 from PySubtrans import init_options, init_subtitles, init_translator
@@ -43,7 +43,7 @@ translator.Translate(subtitles)
 subtitles.SaveTranslation("movie-translated.srt")
 ```
 
-Subtitle format will be auto-detected based on file extension or content, if it matches one of the supported formats (srt,ssa,ass,vtt).
+Subtitle format is auto-detected based on file extension.
 
 ## Configuration with `init_options`
 `init_options` creates an `Options` instance and accepts additional keyword arguments for any of the fields documented in `Options.default_settings`. 
@@ -115,14 +115,9 @@ This is a test"""
 subtitles = init_subtitles(content=srt_content)
 ```
 
-**Key methods on the returned `Subtitles` object:**
-- `LoadSubtitles(filepath)`: Load additional subtitle content
-- `SaveTranslation(path)`: Save translated subtitles to a file
-- `AutoBatch`: Split subtitles into scenes and batches ready for translation.
-
 ## Preparing a `SubtitleTranslator` with `init_translator`
 
-`init_translator` prepares a `SubtitleTranslator` instance that can be used to translate the `Subtitles`. It uses the provided `Options` to initialise a `TranslationProvider` instance that connects to the chosen translation service.
+`init_translator` prepares a `SubtitleTranslator` instance that can be used to translate `Subtitles`. It uses the provided `Options` to initialise a `TranslationProvider` instance that connects to the chosen translation service.
 
 Example
 
@@ -133,23 +128,69 @@ translator.events.scene_translated += on_scene_translated  # Subscribe to events
 translator.TranslateSubtitles(subtitles)
 ```
 
-## Configuring translation with custom instructions
- Custom instructions can be supplied via an `instruction_file` argument or by overriding `prompt` and `instructions` explicitly. 
+### Customising translation with custom instructions
+ Custom instructions can be supplied via an `instruction_file` argument or by explicitly overriding `prompt` and `instructions`. 
 
-`prompt` is a high level description of the task, whilst `instructions` provide detailed instructions for the translation model (the system prompt).
+`prompt` is a high level description of the task, whilst `instructions` provide detailed instructions for the model (as a system prompt, where possible).
 
-This can include specific instructions about how to handle the translation, e.g. "any profanity should be translated without censorship" and notes about the source subtitles (e.g. "the dialogue contains a lot of puns, these should be adapted for the translation").
+This can include directions about how to handle the translation, e.g. "any profanity should be translated without censorship", or notes about the source subtitles (e.g. "the dialogue contains a lot of puns, these should be adapted for the translation").
 
-It is *imperative* that the instructions contain examples of properly formatted output - see the default instructions for an example. Adapting the examples to your use case can greatly improve the model's performance.
+It is *imperative* that the instructions contain examples of properly formatted output - see the default instructions for examples.
+
+```
+Your response will be processed by an automated system, so you MUST respond using the required format:
+
+Example (translating to English):
+
+#200
+Original>
+変わりゆく時代において、
+Translation>
+In an ever-changing era,
+
+#501
+Original>
+進化し続けることが生き残る秘訣です。
+Translation>
+continuing to evolve is the key to survival.
+```
+
+Adapting the examples to your use case can greatly improve the model's performance by teaching it what good looks like.
   
 See [LLM-Subtrans](https://github.com/machinewrapped/llm-subtrans/instructions) for examples of instructions tailored to specific use cases.
 
 ## Working with projects using `init_project`
 `SubtitleProject` provides a higher level interface for managing a translation job, with methods to read and write a project file to disk and events to hook into on scene/batch translation.
 
-`init_project` instantiates a `SubtitleProject` and loads the source subtitles if a file path is supplied.
+`init_project` instantiates a `SubtitleProject` with a pre-initialised `SubtitleTranslator` and loads the source subtitles if a file path is supplied.
+
+```python
+from PySubtrans import init_project
+
+# Create a project with translator ready to go
+translation_settings = {
+    'provider': 'OpenRouter',
+    'model': 'qwen/qwen3-235b-a22b:free',
+    'target_language': 'Spanish',
+    'api_key': 'your-openrouter-api-key'
+}
+
+project = init_project('path_to_source_subtitles.srt', translation_settings=translation_settings)
+
+# Translate the subtitles
+project.TranslateSubtitles()
+
+# Save the translation
+project.SaveTranslation('output_subtitles.srt')
+```
 
 By default projects are only held in memory, but specifying `persistent=True` will write a `.subtrans` project file to disk (or reload an existing project), allowing a translation job to be resumed at a future time.
+
+```python
+# Create a persistent project that can be resumed later
+project = init_project('subtitles.srt', persistent=True, translation_settings=translation_settings)
+project.TranslateSubtitles()  # Progress is automatically saved
+```
 
 ## Advanced workflows
 

--- a/PySubtrans/SubtitleBatcher.py
+++ b/PySubtrans/SubtitleBatcher.py
@@ -48,7 +48,7 @@ class SubtitleBatcher:
 
     def CreateNewScene(self, scenes : list[SubtitleScene], current_lines : list[SubtitleLine]):
         """
-        Create a scene and lines to it in batches
+        Create a scene and add lines to it in batches
         """
         scene = SubtitleScene()
         scenes.append(scene)

--- a/PySubtrans/SubtitleBuilder.py
+++ b/PySubtrans/SubtitleBuilder.py
@@ -1,0 +1,208 @@
+from collections.abc import Sequence
+from datetime import timedelta
+from typing import Any, TypeAlias
+
+from PySubtrans.Options import SettingsType
+from PySubtrans.Subtitles import Subtitles
+from PySubtrans.SubtitleScene import SubtitleScene
+from PySubtrans.SubtitleBatch import SubtitleBatch
+from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SubtitleLine import SubtitleLine
+
+
+LineData : TypeAlias = tuple[timedelta|str, timedelta|str, str] | tuple[timedelta|str, timedelta|str, str, dict[str, Any]]
+
+class SubtitleBuilder:
+    """
+    A helper class for programmatically building subtitle structures with fine-grained control.
+
+    Provides a fluent API for creating scenes, batches, and lines without requiring
+    deep knowledge of the internal scene/batch structure.
+    """
+
+    def __init__(self, max_batch_size : int = 100, min_batch_size : int = 1):
+        """
+        Initialize SubtitleBuilder.
+
+        Parameters
+        ----------
+        subtitles : Subtitles|None
+            An existing Subtitles instance to build upon. If None, creates a new empty instance.
+        max_batch_size : int
+            Maximum number of lines per batch. Lines will be automatically organized into batches
+            using intelligent gap-based splitting.
+        min_batch_size : int
+            Minimum size for batches when splitting. Helps avoid very small batches.
+        """
+        self._scenes : list[SubtitleScene] = []
+        self._current_scene : SubtitleScene|None = None
+        self._current_line_number : int = 0
+        self._scene_counter : int = len(self._scenes)
+        self._max_batch_size : int = max_batch_size
+        self._min_batch_size : int = min_batch_size
+        self._accumulated_lines : list[SubtitleLine] = []
+        self._settings : SettingsType = SettingsType({
+            'max_batch_size': max_batch_size,
+            'min_batch_size': min_batch_size,
+        })
+
+    def AddScene(self, summary : str|None = None, context : dict[str, Any]|None = None) -> 'SubtitleBuilder':
+        """
+        Add a new scene. Lines added after this will be automatically organized into batches.
+
+        Parameters
+        ----------
+        summary : str|None
+            Optional summary of the scene content.
+        context : dict[str, Any]|None
+            Optional context metadata for the scene.
+
+        Returns
+        -------
+        SubtitleBuilder
+            Returns self for method chaining.
+        """
+        # Process any accumulated lines from previous scene
+        self._finalize_current_scene()
+
+        self._scene_counter += 1
+
+        scene_data : dict[str, Any] = {'number': self._scene_counter}
+        if summary:
+            scene_data['context'] = {'summary': summary}
+
+        self._current_scene = SubtitleScene(scene_data)
+        if context:
+            self._current_scene.UpdateContext(context)
+
+        self._scenes.append(self._current_scene)
+        self._accumulated_lines = []
+
+        return self
+
+    def AddLine(self, line : SubtitleLine) -> 'SubtitleBuilder':
+        """
+        Add a SubtitleLine object to the current scene. Lines are accumulated and will be intelligently
+        organized into batches when the scene is finalized.
+
+        Parameters
+        ----------
+        line : SubtitleLine
+            The subtitle line object to add.
+
+        Returns
+        -------
+        SubtitleBuilder
+            Returns self for method chaining.
+        """
+        if not self._current_scene:
+            self.AddScene()
+
+        self._accumulated_lines.append(line)
+
+        return self
+
+    def ConstructLine(self, start : timedelta|str, end : timedelta|str, text : str, metadata : dict[str, Any]|None = None) -> 'SubtitleBuilder':
+        """
+        Construct a SubtitleLine from parameters and add it to the current scene.
+
+        This is a convenience method that combines SubtitleLine.Construct() with AddLine().
+
+        Parameters
+        ----------
+        number : int
+            Line number (should be unique).
+        start : timedelta|str
+            Start time as timedelta or SRT format string.
+        end : timedelta|str
+            End time as timedelta or SRT format string.
+        text : str
+            The subtitle text content.
+        metadata : dict[str, Any]|None
+            Optional metadata for the line.
+
+        Returns
+        -------
+        SubtitleBuilder
+            Returns self for method chaining.
+        """
+        self._current_line_number += 1
+        line : SubtitleLine = SubtitleLine.Construct(self._current_line_number, start, end, text, metadata)
+
+        return self.AddLine(line)
+
+    def AddLines(self, lines : Sequence[SubtitleLine] | Sequence[LineData]) -> 'SubtitleBuilder':
+        """
+        Add multiple subtitle lines to the current scene. Lines are automatically organized into batches.
+
+        Parameters
+        ----------
+        lines : list[SubtitleLine|tuple[timedelta|str, timedelta|str, str, dict]]
+            Either a list of SubtitleLine instances or tuples (number, start, end, text).
+
+        Returns
+        -------
+        SubtitleBuilder
+            Returns self for method chaining.
+
+        Raises
+        ------
+        ValueError
+            If no scene has been added yet.
+        """
+        for line_data in lines:
+            if isinstance(line_data, SubtitleLine):
+                self.AddLine(line_data)
+            elif isinstance(line_data, tuple):
+                if len(line_data) == 3:
+                    start, end, text = line_data
+                    self.ConstructLine(start, end, text)
+                elif len(line_data) == 4:
+                    start, end, text, metadata = line_data
+                    self.ConstructLine(start, end, text, metadata)
+                else:
+                    raise ValueError(f"Invalid line data tuple length: {line_data}")
+            else:
+                raise ValueError(f"Invalid line data format: {line_data}")
+
+        return self
+
+    def Build(self) -> Subtitles:
+        """
+        Finalize and return the built Subtitles instance.
+
+        Returns
+        -------
+        Subtitles
+            The completed subtitles with scenes and batches.
+        """
+        # Finalize the current scene
+        self._finalize_current_scene()
+
+        # Trigger the scenes setter to update flattened lists
+        subtitles = Subtitles()
+        subtitles.scenes = self._scenes
+        return subtitles
+
+    def _finalize_current_scene(self) -> None:
+        """
+        Finalize the current scene by intelligently batching accumulated lines.
+        """
+        if not self._current_scene or not self._accumulated_lines:
+            return
+
+        batcher = SubtitleBatcher(self._settings)
+
+        # Use batcher's intelligent splitting logic
+        split_line_groups : list[list[SubtitleLine]] = batcher._split_lines(self._accumulated_lines)
+
+        # Create batches from the intelligently split groups
+        for i, line_group in enumerate(split_line_groups):
+            batch_data : dict[str, Any] = {
+                'scene': self._current_scene.number,
+                'number': i + 1
+            }
+
+            batch = SubtitleBatch(batch_data)
+            batch._originals = line_group
+            self._current_scene.AddBatch(batch)

--- a/PySubtrans/SubtitleEditor.py
+++ b/PySubtrans/SubtitleEditor.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from PySubtrans.Helpers.Localization import _
+from PySubtrans.SubtitleError import SubtitleError
+from PySubtrans.SubtitleLine import SubtitleLine
+from PySubtrans.SubtitleScene import SubtitleScene
+from PySubtrans.SubtitleBatch import SubtitleBatch
+from PySubtrans.Subtitles import Subtitles
+from PySubtrans.SubtitleProcessor import SubtitleProcessor
+from PySubtrans.SubtitleBatcher import SubtitleBatcher
+
+
+class SubtitleEditor:
+    """
+    Handles mutation operations on subtitle data with proper thread safety.
+    Use as a context manager to ensure proper locking.
+    """
+
+    def __init__(self, subtitles: Subtitles) -> None:
+        self.subtitles = subtitles
+        self._lock_acquired = False
+
+    def __enter__(self) -> SubtitleEditor:
+        self.subtitles.lock.acquire()
+        self._lock_acquired = True
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._lock_acquired:
+            self.subtitles.lock.release()
+            self._lock_acquired = False
+
+    def PreProcess(self, preprocessor: SubtitleProcessor) -> None:
+        """
+        Preprocess subtitles
+        """
+        if self.subtitles.originals:
+            self.subtitles.originals = preprocessor.PreprocessSubtitles(self.subtitles.originals)
+
+    def AutoBatch(self, batcher: SubtitleBatcher) -> None:
+        """
+        Divide subtitles into scenes and batches based on threshold options
+        """
+        if self.subtitles.originals:
+            self.subtitles.scenes = batcher.BatchSubtitles(self.subtitles.originals)
+
+    def AddScene(self, scene: SubtitleScene) -> None:
+        self.subtitles.scenes.append(scene)
+        logging.debug("Added a new scene")
+
+    def UpdateScene(self, scene_number: int, update: dict[str, Any]) -> Any:
+        scene: SubtitleScene = self.subtitles.GetScene(scene_number)
+        if not scene:
+            raise ValueError(f"Scene {scene_number} does not exist")
+
+        return scene.UpdateContext(update)
+
+    def UpdateBatch(self, scene_number: int, batch_number: int, update: dict[str, Any]) -> bool:
+        batch: SubtitleBatch = self.subtitles.GetBatch(scene_number, batch_number)
+        if not batch:
+            raise ValueError(f"Batch ({scene_number},{batch_number}) does not exist")
+
+        return batch.UpdateContext(update)
+
+
+    def DeleteLines(self, line_numbers: list[int]) -> list[tuple[int, int, list[SubtitleLine], list[SubtitleLine]]]:
+        """
+        Delete lines from the subtitles
+        """
+        deletions = []
+        batches = self.subtitles.GetBatchesContainingLines(line_numbers)
+
+        for batch in batches:
+            deleted_originals, deleted_translated = batch.DeleteLines(line_numbers)
+            if len(deleted_originals) > 0 or len(deleted_translated) > 0:
+                deletion = (batch.scene, batch.number, deleted_originals, deleted_translated)
+                deletions.append(deletion)
+
+        if not deletions:
+            raise ValueError("No lines were deleted from any batches")
+
+        return deletions
+
+    def MergeScenes(self, scene_numbers: list[int]) -> SubtitleScene:
+        """
+        Merge several (sequential) scenes into one scene
+        """
+        if not scene_numbers:
+            raise ValueError("No scene numbers supplied to MergeScenes")
+
+        scene_numbers = sorted(scene_numbers)
+        if scene_numbers != list(range(scene_numbers[0], scene_numbers[0] + len(scene_numbers))):
+            raise ValueError("Scene numbers to be merged are not sequential")
+
+        scenes: list[SubtitleScene] = [scene for scene in self.subtitles.scenes if scene.number in scene_numbers]
+        if len(scenes) != len(scene_numbers):
+            raise ValueError(f"Could not find scenes {','.join([str(i) for i in scene_numbers])}")
+
+        # Merge all scenes into the first
+        merged_scene = scenes[0]
+        merged_scene.MergeScenes(scenes[1:])
+
+        # Slice out the merged scenes
+        start_index = self.subtitles.scenes.index(scenes[0])
+        end_index = self.subtitles.scenes.index(scenes[-1])
+        self.subtitles.scenes = self.subtitles.scenes[:start_index + 1] + self.subtitles.scenes[end_index+1:]
+
+        self.RenumberScenes()
+
+        return merged_scene
+
+    def MergeBatches(self, scene_number: int, batch_numbers: list[int]) -> None:
+        """
+        Merge several (sequential) batches from a scene into one batch
+        """
+        if not batch_numbers:
+            raise ValueError("No batch numbers supplied to MergeBatches")
+
+        scene: SubtitleScene|None = next((scene for scene in self.subtitles.scenes if scene.number == scene_number), None)
+        if not scene:
+            raise ValueError(f"Scene {str(scene_number)} not found")
+
+        scene.MergeBatches(batch_numbers)
+
+    def MergeLinesInBatch(self, scene_number: int, batch_number: int, line_numbers: list[int]) -> tuple[SubtitleLine, SubtitleLine|None]:
+        """
+        Merge several sequential lines together, remapping originals and translated lines if necessary.
+        """
+        batch: SubtitleBatch = self.subtitles.GetBatch(scene_number, batch_number)
+        return batch.MergeLines(line_numbers)
+
+    def SplitScene(self, scene_number: int, batch_number: int) -> None:
+        """
+        Split a scene into two at the specified batch number
+        """
+        scene: SubtitleScene = self.subtitles.GetScene(scene_number)
+        batch: SubtitleBatch|None = scene.GetBatch(batch_number) if scene else None
+
+        if not batch:
+            raise ValueError(f"Scene {scene_number} batch {batch_number} does not exist")
+
+        batch_index: int = scene.batches.index(batch)
+
+        new_scene = SubtitleScene({ 'number': scene_number + 1})
+        new_scene.batches = scene.batches[batch_index:]
+        scene.batches = scene.batches[:batch_index]
+
+        for number, batch in enumerate(new_scene.batches, start=1):
+            batch.scene = new_scene.number
+            batch.number = number
+
+        split_index = self.subtitles.scenes.index(scene) + 1
+        if split_index < len(self.subtitles.scenes):
+            self.subtitles.scenes = self.subtitles.scenes[:split_index] + [new_scene] + self.subtitles.scenes[split_index:]
+        else:
+            self.subtitles.scenes.append(new_scene)
+
+        self.RenumberScenes()
+
+    def Sanitise(self) -> None:
+        """
+        Remove invalid lines, empty batches and empty scenes
+        """
+        for scene in self.subtitles.scenes:
+            scene.batches = [batch for batch in scene.batches if batch.originals]
+
+            for batch in scene.batches:
+                batch.originals = [line for line in batch.originals if line.number and line.start is not None]
+                if batch.translated:
+                    batch.translated = [line for line in batch.translated if line.number and line.start is not None ]
+
+                original_line_numbers = [line.number for line in batch.originals]
+                translated = batch.translated or []
+                unmatched_translated = [line for line in translated if line.number not in original_line_numbers]
+                if unmatched_translated:
+                    logging.warning(_("Removing {} translated lines in batch ({},{}) that don't match an original line").format(len(unmatched_translated), batch.scene, batch.number))
+                    batch.translated = [line for line in translated if line not in unmatched_translated]
+
+        self.subtitles.scenes = [scene for scene in self.subtitles.scenes if scene.batches]
+        self.RenumberScenes()
+
+    def RenumberScenes(self) -> None:
+        """
+        Ensure scenes are numbered sequentially
+        """
+        for scene_number, scene in enumerate(self.subtitles.scenes, start=1):
+            scene.number = scene_number
+            for batch_number, batch in enumerate(scene.batches, start=1):
+                batch.scene = scene.number
+                batch.number = batch_number
+
+    def DuplicateOriginalsAsTranslations(self) -> None:
+        """
+        Duplicate original lines as translated lines if no translations exist (for testing)
+        """
+        for scene in self.subtitles.scenes:
+            for batch in scene.batches:
+                if batch.any_translated:
+                    raise SubtitleError("Translations already exist")
+
+                batch.translated = [ SubtitleLine.Construct(line.number, line.start, line.end, line.text or "", line.metadata) for line in batch.originals ]

--- a/PySubtrans/SubtitleFormatRegistry.py
+++ b/PySubtrans/SubtitleFormatRegistry.py
@@ -129,6 +129,27 @@ class SubtitleFormatRegistry:
         return extension.lower() if extension else None
 
     @classmethod
+    def detect_format_from_content(cls, content: str) -> str|None:
+        """
+        Detect subtitle format from content using pysubs2.
+        """
+        cls._ensure_discovered()
+        try:
+            detected_format = pysubs2.formats.autodetect_format(content)
+
+            detected_extension = pysubs2.formats.get_file_extension(detected_format)
+
+            logging.info(_("Detected subtitle format '{format}' from content").format(format=detected_extension))
+
+            if detected_extension not in cls._handlers:
+                return None
+
+            return detected_extension
+
+        except Exception as e:
+            raise SubtitleParseError(_("Failed to detect subtitle format: {}" ).format(str(e)), e)
+
+    @classmethod
     def detect_format_and_load_file(cls, path: str) -> SubtitleData:
         """
         Detect subtitle format using content and load file accordingly.

--- a/PySubtrans/SubtitleProject.py
+++ b/PySubtrans/SubtitleProject.py
@@ -18,6 +18,7 @@ from PySubtrans.SubtitleScene import SubtitleScene
 from PySubtrans.SubtitleSerialisation import SubtitleDecoder, SubtitleEncoder
 from PySubtrans.SubtitleTranslator import SubtitleTranslator
 from PySubtrans.TranslationEvents import TranslationEvents
+from PySubtrans.TranslationProvider import TranslationProvider
 
 default_encoding = os.getenv('DEFAULT_ENCODING', 'utf-8')
 
@@ -45,11 +46,11 @@ class SubtitleProject:
     })
     def __init__(self, persistent : bool = False):
         """
-        A subtitle translation project. 
-        
+        A subtitle translation project.
+
         Can be initialised from a project file or a subtitle file,
         or manually configured by assigning a SubtitleFile and updating settings if necessary.
-        
+
         :param persistent: if True, the project will be saved to disk and automatically reloaded next time
         """
         self.subtitles : Subtitles = Subtitles(settings=self.DEFAULT_PROJECT_SETTINGS)
@@ -58,6 +59,7 @@ class SubtitleProject:
         self.existing_project : bool = False
         self.needs_writing : bool = False
         self.lock = threading.RLock()
+        self._translator : SubtitleTranslator|None = None
 
         # By default the project is not persistent, i.e. it will not be saved to a file and automatically reloaded next time
         self.use_project_file : bool = persistent
@@ -86,6 +88,11 @@ class SubtitleProject:
     def all_translated(self) -> bool:
         with self.lock:
             return bool(self.subtitles and self.subtitles.all_translated)
+
+    @property
+    def translator(self) -> SubtitleTranslator|None:
+        """Get the current translator instance"""
+        return self._translator
 
     def InitialiseProject(self, filepath : str, outputpath : str|None = None, reload_subtitles : bool = False):
         """
@@ -372,30 +379,58 @@ class SubtitleProject:
                 project_json = json.dumps(self.subtitles, cls=encoder_class, ensure_ascii=False, indent=4) # type: ignore
                 f.write(project_json)
 
-    def TranslateSubtitles(self, translator : SubtitleTranslator) -> None:
+    def InitialiseTranslator(self, options : Options, translation_provider : TranslationProvider|None = None) -> None:
+        """
+        Initialize the project translator with the provided options.
+        If the translation provider is not explictly specified it will be determined automatically from the options.
+
+        :param options: The options to use for creating the translator
+        :param provider: [optional] translation provider to use.
+        """
+        if not translation_provider:
+            translation_provider = TranslationProvider.get_provider(options)
+            if not translation_provider:
+                raise ValueError(f"Unable to create translation provider {options.provider}")
+
+        if not translation_provider.ValidateSettings():
+            logging.error(f"Provider settings are not valid: {translation_provider.validation_message}")
+            raise ValueError(f"Invalid settings for provider {options.provider}")
+
+        logging.info(f"Using translation provider {translation_provider.name}")
+
+        # Load the instructions
+        options.InitialiseInstructions()
+
+        with self.lock:
+            self._translator = SubtitleTranslator(options, translation_provider)
+
+    def TranslateSubtitles(self) -> None:
         """
         One-stop shop: Use the translation provider to translate a project, then save the translation.
         """
         if not self.subtitles:
             raise Exception("No subtitles to translate")
 
+        if not self._translator:
+            raise Exception("No translator initialized. Call InitialiseTranslator() first.")
+
         # Prime new project files
         self.UpdateProjectFile()
 
-        save_translation : bool = self.write_translation and not translator.preview
+        save_translation : bool = self.write_translation and not self._translator.preview
 
         try:
-            translator.events.preprocessed += self._on_preprocessed # type: ignore
-            translator.events.batch_translated += self._on_batch_translated # type: ignore
-            translator.events.scene_translated += self._on_scene_translated # type: ignore
+            self._translator.events.preprocessed += self._on_preprocessed # type: ignore
+            self._translator.events.batch_translated += self._on_batch_translated # type: ignore
+            self._translator.events.scene_translated += self._on_scene_translated # type: ignore
 
-            translator.TranslateSubtitles(self.subtitles)
+            self._translator.TranslateSubtitles(self.subtitles)
 
-            translator.events.preprocessed -= self._on_preprocessed # type: ignore
-            translator.events.batch_translated -= self._on_batch_translated # type: ignore
-            translator.events.scene_translated -= self._on_scene_translated # type: ignore
+            self._translator.events.preprocessed -= self._on_preprocessed # type: ignore
+            self._translator.events.batch_translated -= self._on_batch_translated # type: ignore
+            self._translator.events.scene_translated -= self._on_scene_translated # type: ignore
 
-            if save_translation and not translator.aborted:
+            if save_translation and not self._translator.aborted:
                 self.SaveTranslation()
 
         except TranslationAbortedError:
@@ -409,22 +444,25 @@ class SubtitleProject:
             logging.error(_("Failed to translate subtitles: {}").format(str(e)))
             raise
 
-    def TranslateScene(self, translator : SubtitleTranslator, scene_number : int, batch_numbers : list[int]|None = None, line_numbers : list[int]|None = None) -> SubtitleScene|None:
+    def TranslateScene(self, scene_number : int, batch_numbers : list[int]|None = None, line_numbers : list[int]|None = None) -> SubtitleScene|None:
         """
         Pass batches of subtitles to the translation engine.
         """
         if not self.subtitles:
             raise Exception("No subtitles to translate")
 
-        translator.events.preprocessed += self._on_preprocessed             # type: ignore
-        translator.events.batch_translated += self._on_batch_translated     # type: ignore
+        if not self._translator:
+            raise Exception("No translator initialized. Call InitialiseTranslator() first.")
+
+        self._translator.events.preprocessed += self._on_preprocessed             # type: ignore
+        self._translator.events.batch_translated += self._on_batch_translated     # type: ignore
 
         try:
             scene : SubtitleScene = self.subtitles.GetScene(scene_number)
 
             scene.errors = []
 
-            translator.TranslateScene(self.subtitles, scene, batch_numbers=batch_numbers, line_numbers=line_numbers)
+            self._translator.TranslateScene(self.subtitles, scene, batch_numbers=batch_numbers, line_numbers=line_numbers)
 
             return scene
 
@@ -432,8 +470,9 @@ class SubtitleProject:
             pass
 
         finally:
-            translator.events.preprocessed -= self._on_preprocessed # type: ignore
-            translator.events.batch_translated -= self._on_batch_translated # type: ignore
+            self._translator.events.preprocessed -= self._on_preprocessed # type: ignore
+            self._translator.events.batch_translated -= self._on_batch_translated # type: ignore
+
 
     def _on_preprocessed(self, scenes) -> None:
         logging.debug("Pre-processing finished")

--- a/PySubtrans/SubtitleSerialisation.py
+++ b/PySubtrans/SubtitleSerialisation.py
@@ -44,7 +44,7 @@ class SubtitleEncoder(json.JSONEncoder):
                 "sourcepath": obj.sourcepath,
                 "outputpath": obj.outputpath,
                 "scenecount": len(obj.scenes),
-                "settings": getattr(obj, 'settings') or getattr(obj, 'context'),
+                "settings": getattr(obj, 'settings', {}),
                 "metadata": getattr(obj, 'metadata', {}),
                 "format": obj.file_format,
                 "scenes": obj.scenes,
@@ -120,11 +120,10 @@ def _object_hook(dct):
             sourcepath = dct.get('sourcepath')
             outpath = dct.get('outputpath') or dct.get('filename')
             obj = Subtitles(sourcepath, outpath)
-            obj.settings = SettingsType(dct.get('settings', {}) or dct.get('context', {}))
+            obj.settings = SettingsType(dct.get('settings', dct.get('context', {})))
             obj.metadata = dct.get('metadata', {})
             obj.file_format = dct.get('format', '.srt')
             obj.scenes = dct.get('scenes', [])
-            obj.UpdateProjectSettings(SettingsType()) # Force update for legacy files
             return obj
         elif class_name == classname(SubtitleScene):
             obj = SubtitleScene(dct)

--- a/PySubtrans/SubtitleTranslator.py
+++ b/PySubtrans/SubtitleTranslator.py
@@ -4,6 +4,7 @@ import threading
 from typing import Any
 
 from PySubtrans.Helpers.SettingsHelpers import GetStrSetting
+from PySubtrans.Helpers.ContextHelpers import GetBatchContext
 from PySubtrans.Helpers.SubtitleHelpers import MergeTranslations
 from PySubtrans.Helpers.Localization import _, tr
 from PySubtrans.Helpers.Text import Linearise, SanitiseSummary
@@ -11,6 +12,7 @@ from PySubtrans.Instructions import DEFAULT_TASK_TYPE, Instructions
 from PySubtrans.SettingsType import SettingsType
 from PySubtrans.Substitutions import Substitutions
 from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleLine import SubtitleLine
 from PySubtrans.SubtitleProcessor import SubtitleProcessor
 from PySubtrans.Translation import Translation
@@ -107,7 +109,8 @@ class SubtitleTranslator:
         if not subtitles.scenes:
             if self.retranslate or self.reparse:
                 logging.warning(_("No previous translations found, starting fresh..."))
-            subtitles.AutoBatch(self.batcher)
+            with SubtitleEditor(subtitles) as editor:
+                editor.AutoBatch(self.batcher)
 
         if not subtitles.scenes:
             raise TranslationImpossibleError(_("No scenes to translate"))
@@ -168,7 +171,7 @@ class SubtitleTranslator:
             context = {}
 
             for batch in batches:
-                context = subtitles.GetBatchContext(scene.number, batch.number, self.max_history)
+                context = GetBatchContext(subtitles, scene.number, batch.number, self.max_history)
 
                 try:
                     self.TranslateBatch(batch, line_numbers, context)

--- a/PySubtrans/Subtitles.py
+++ b/PySubtrans/Subtitles.py
@@ -5,49 +5,25 @@ import os
 import logging
 import threading
 from typing import Any
-import bisect
 from PySubtrans.Helpers.Localization import _
-from PySubtrans.Instructions import DEFAULT_TASK_TYPE
-from PySubtrans.Options import Options, SettingsType
+from PySubtrans.Options import Options
 
 from PySubtrans.SettingsType import SettingsType
-from PySubtrans.Substitutions import Substitutions
 from PySubtrans.SubtitleBatch import SubtitleBatch
 from PySubtrans.SubtitleError import SubtitleError, SubtitleParseError
 from PySubtrans.Helpers import GetInputPath, GetOutputPath
-from PySubtrans.Helpers.Parse import ParseNames
 from PySubtrans.SubtitleFileHandler import SubtitleFileHandler, default_encoding
 from PySubtrans.SubtitleFormatRegistry import SubtitleFormatRegistry
-from PySubtrans.SubtitleProcessor import SubtitleProcessor
 from PySubtrans.SubtitleScene import SubtitleScene, UnbatchScenes
 from PySubtrans.SubtitleLine import SubtitleLine
 from PySubtrans.SubtitleData import SubtitleData
-from PySubtrans.SubtitleBatcher import SubtitleBatcher
 
 class Subtitles:
     """
     High level class for manipulating subtitles
     """
-    DEFAULT_PROJECT_SETTINGS : SettingsType = SettingsType({
-        'provider': None,
-        'model': None,
-        'target_language': None,
-        'prompt': None,
-        'task_type': None,
-        'instructions': None,
-        'retry_instructions': None,
-        'movie_name': None,
-        'description': None,
-        'names': None,
-        'substitutions': None,
-        'substitution_mode': None,
-        'include_original': None,
-        'add_right_to_left_markers': None,
-        'instruction_file': None,
-        'format': None
-    })
 
-    def __init__(self, filepath: str|None = None, outputpath: str|None = None) -> None:
+    def __init__(self, filepath: str|None = None, outputpath: str|None = None, settings: SettingsType|None = None) -> None:
         self.originals : list[SubtitleLine]|None = None
         self.translated : list[SubtitleLine]|None = None
         self.start_line_number : int = 1
@@ -60,19 +36,11 @@ class Subtitles:
         self.metadata : dict[str, Any] = {}
         self.file_format : str|None = None
 
-        self.settings : SettingsType = deepcopy(self.DEFAULT_PROJECT_SETTINGS)
-
-    @property
-    def movie_name(self) -> str|None:
-        return self._get_setting_str('movie_name')
+        self.settings : SettingsType = SettingsType(deepcopy(settings)) if settings else SettingsType()
 
     @property
     def target_language(self) -> str|None:
-        return self._get_setting_str('target_language')
-
-    @property
-    def task_type(self) -> str:
-        return self._get_setting_str('task_type') or DEFAULT_TASK_TYPE
+        return self.settings.get_str('target_language')
 
     @property
     def has_subtitles(self) -> bool:
@@ -218,41 +186,6 @@ class Subtitles:
 
         return out_batches
 
-    def GetBatchContext(self, scene_number: int, batch_number: int, max_lines: int|None = None) -> dict[str, Any]:
-        """
-        Get context for a batch of subtitles, by extracting summaries from previous scenes and batches
-        """
-        with self.lock:
-            scene = self.GetScene(scene_number)
-            if not scene:
-                raise SubtitleError(f"Failed to find scene {scene_number}")
-
-            batch = self.GetBatch(scene_number, batch_number)
-            if not batch:
-                raise SubtitleError(f"Failed to find batch {batch_number} in scene {scene_number}")
-
-            context : dict[str,Any] = {
-                'scene_number': scene.number,
-                'batch_number': batch.number,
-                'scene': f"Scene {scene.number}: {scene.summary}" if scene.summary else f"Scene {scene.number}",
-                'batch': f"Batch {batch.number}: {batch.summary}" if batch.summary else f"Batch {batch.number}"
-            }
-
-            if 'movie_name' in self.settings:
-                context['movie_name'] = self._get_setting_str('movie_name')
-
-            if 'description' in self.settings:
-                context['description'] = self._get_setting_str('description')
-
-            if 'names' in self.settings:
-                context['names'] = ParseNames(self.settings.get('names', []))
-
-            history_lines = self._get_history(scene_number, batch_number, max_lines)
-
-            if history_lines:
-                context['history'] = history_lines
-
-        return context
 
     def LoadSubtitles(self, filepath: str|None = None) -> None:
         """
@@ -354,7 +287,7 @@ class Subtitles:
                 start_line_number=self.start_line_number
             )
 
-            data.metadata['Title'] = self.movie_name
+            data.metadata['Title'] = self.settings.get_str('movie_name', data.metadata.get('Title'))
             data.metadata['Language'] = self.target_language
             
             # Apply RTL markers if requested (handler will decide format-specific implementation)
@@ -367,237 +300,15 @@ class Subtitles:
             self.translated = translated
             self.outputpath = outputpath
 
-    def UpdateProjectSettings(self, settings: SettingsType) -> None:
+    def UpdateSettings(self, settings: SettingsType) -> None:
         """
-        Update the project settings
+        Update the subtitle settings
         """
         if isinstance(settings, Options):
-            return self.UpdateProjectSettings(settings)
+            settings = SettingsType(settings)
 
         with self.lock:
-            self.settings.update({key: settings[key] for key in settings if key in self.DEFAULT_PROJECT_SETTINGS})
-
-            names_list = self.settings.get('names', [])
-            self.settings['names'] = ParseNames(names_list)
-            substitions_list = self.settings.get('substitutions', [])
-            if substitions_list:
-                self.settings['substitutions'] = Substitutions.Parse(substitions_list)
-
-            self._update_compatibility(self.settings)
-
-    def UpdateOutputPath(self, path: str|None = None, extension: str|None = None) -> None:
-        """
-        Set or generate the output path for the translated subtitles
-        """
-        path = path or self.sourcepath
-        extension = extension or self.file_format
-        if not extension:
-            extension = SubtitleFormatRegistry.get_format_from_filename(path) if path else None
-            extension = extension or '.srt'
-
-        if extension == ".subtrans":
-            raise SubtitleError("Cannot use .subtrans as output format")
-
-        outputpath = GetOutputPath(path, self.target_language, extension)
-        self.outputpath = outputpath
-        self.file_format = extension
-
-    def PreProcess(self, preprocessor: SubtitleProcessor) -> None:
-        """
-        Preprocess subtitles
-        """
-        with self.lock:
-            if self.originals:
-                self.originals = preprocessor.PreprocessSubtitles(self.originals)
-
-    def AutoBatch(self, batcher: SubtitleBatcher) -> None:
-        """
-        Divide subtitles into scenes and batches based on threshold options
-        """
-        with self.lock:
-            if self.originals:
-                self.scenes = batcher.BatchSubtitles(self.originals)
-
-    def AddScene(self, scene: SubtitleScene) -> None:
-        with self.lock:
-            self.scenes.append(scene)
-            logging.debug("Added a new scene")
-
-    def UpdateScene(self, scene_number: int, update: dict[str, Any]) -> Any:
-        with self.lock:
-            scene: SubtitleScene = self.GetScene(scene_number)
-            if not scene:
-                raise ValueError(f"Scene {scene_number} does not exist")
-
-            return scene.UpdateContext(update)
-
-    def UpdateBatch(self, scene_number: int, batch_number: int, update: dict[str, Any]) -> bool:
-        with self.lock:
-            batch: SubtitleBatch = self.GetBatch(scene_number, batch_number)
-            if not batch:
-                raise ValueError(f"Batch ({scene_number},{batch_number}) does not exist")
-
-            return batch.UpdateContext(update)
-
-    def UpdateLineText(self, line_number : int, original_text : str, translated_text : str) -> None:
-        with self.lock:
-            if self.originals is None:
-                raise SubtitleError("Original subtitles are missing!")
-
-            original_line = next((original for original in self.originals if original.number == line_number), None)
-            if not original_line:
-                raise ValueError(f"Line {line_number} not found")
-
-            if original_text:
-                original_line.text = original_text
-                original_line.translation = translated_text
-
-            if not translated_text:
-                return
-
-            translated_line = next((translated for translated in self.translated if translated.number == line_number), None) if self.translated else None
-            if translated_line:
-                translated_line.text = translated_text
-                return
-
-            translated_line = SubtitleLine.Construct(line_number, original_line.start, original_line.end, translated_text, original_line.metadata)
-
-            if not self.translated:
-                self.translated = []
-
-            insertIndex = bisect.bisect_left([line.number for line in self.translated], line_number)
-            self.translated.insert(insertIndex, translated_line)
-
-    def DeleteLines(self, line_numbers: list[int]) -> list[tuple[int, int, list[SubtitleLine], list[SubtitleLine]]]:
-        """
-        Delete lines from the subtitles
-        """
-        deletions = []
-        with self.lock:
-            batches = self.GetBatchesContainingLines(line_numbers)
-
-            for batch in batches:
-                deleted_originals, deleted_translated = batch.DeleteLines(line_numbers)
-                if len(deleted_originals) > 0 or len(deleted_translated) > 0:
-                    deletion = (batch.scene, batch.number, deleted_originals, deleted_translated)
-                    deletions.append(deletion)
-
-            if not deletions:
-                raise ValueError("No lines were deleted from any batches")
-
-        return deletions
-
-    def MergeScenes(self, scene_numbers: list[int]) -> SubtitleScene:
-        """
-        Merge several (sequential) scenes into one scene
-        """
-        if not scene_numbers:
-            raise ValueError("No scene numbers supplied to MergeScenes")
-
-        scene_numbers = sorted(scene_numbers)
-        if scene_numbers != list(range(scene_numbers[0], scene_numbers[0] + len(scene_numbers))):
-            raise ValueError("Scene numbers to be merged are not sequential")
-
-        with self.lock:
-            scenes : list[SubtitleScene] = [scene for scene in self.scenes if scene.number in scene_numbers]
-            if len(scenes) != len(scene_numbers):
-                raise ValueError(f"Could not find scenes {','.join([str(i) for i in scene_numbers])}")
-
-            # Merge all scenes into the first
-            merged_scene = scenes[0]
-            merged_scene.MergeScenes(scenes[1:])
-
-            # Slice out the merged scenes
-            start_index = self.scenes.index(scenes[0])
-            end_index = self.scenes.index(scenes[-1])
-            self.scenes = self.scenes[:start_index + 1] + self.scenes[end_index+1:]
-
-            self._renumber_scenes()
-
-        return merged_scene
-
-    def MergeBatches(self, scene_number: int, batch_numbers: list[int]) -> None:
-        """
-        Merge several (sequential) batches from a scene into one batch
-        """
-        if not batch_numbers:
-            raise ValueError("No batch numbers supplied to MergeBatches")
-
-        with self.lock:
-            scene : SubtitleScene|None = next((scene for scene in self.scenes if scene.number == scene_number), None)
-            if not scene:
-                raise ValueError(f"Scene {str(scene_number)} not found")
-
-            scene.MergeBatches(batch_numbers)
-
-    def MergeLinesInBatch(self, scene_number: int, batch_number: int, line_numbers: list[int]) -> tuple[SubtitleLine, SubtitleLine|None]:
-        """
-        Merge several sequential lines together, remapping originals and translated lines if necessary.
-        """
-        with self.lock:
-            batch : SubtitleBatch = self.GetBatch(scene_number, batch_number)
-            return batch.MergeLines(line_numbers)
-
-    def SplitScene(self, scene_number: int, batch_number: int) -> None:
-        """
-        Split a scene into two at the specified batch number
-        """
-        with self.lock:
-            scene : SubtitleScene = self.GetScene(scene_number)
-            batch : SubtitleBatch|None = scene.GetBatch(batch_number) if scene else None
-
-            if not batch:
-                raise ValueError(f"Scene {scene_number} batch {batch_number} does not exist")
-
-            batch_index : int = scene.batches.index(batch)
-
-            new_scene = SubtitleScene({ 'number' : scene_number + 1})
-            new_scene.batches = scene.batches[batch_index:]
-            scene.batches = scene.batches[:batch_index]
-
-            for number, batch in enumerate(new_scene.batches, start=1):
-                batch.scene = new_scene.number
-                batch.number = number
-
-            split_index = self.scenes.index(scene) + 1
-            if split_index < len(self.scenes):
-                self.scenes = self.scenes[:split_index] + [new_scene] + self.scenes[split_index:]
-            else:
-                self.scenes.append(new_scene)
-
-            self._renumber_scenes()
-
-    def Sanitise(self) -> None:
-        """
-        Remove invalid lines, empty batches and empty scenes
-        """
-        with self.lock:
-            for scene in self.scenes:
-                scene.batches = [batch for batch in scene.batches if batch.originals]
-
-                for batch in scene.batches:
-                    batch.originals = [line for line in batch.originals if line.number and line.start is not None]
-                    if batch.translated:
-                        batch.translated = [line for line in batch.translated if line.number and line.start is not None ]
-
-                    original_line_numbers = [line.number for line in batch.originals]
-                    unmatched_translated = [line for line in batch.translated if line.number not in original_line_numbers]
-                    if unmatched_translated:
-                        logging.warning(_("Removing {} translations lines in batch ({},{}) that don't match an original line").format(len(unmatched_translated), batch.scene, batch.number))
-                        batch.translated = [line for line in batch.translated if line not in unmatched_translated]
-
-        self.scenes = [scene for scene in self.scenes if scene.batches]
-        self._renumber_scenes()
-
-    def _renumber_scenes(self) -> None:
-        """
-        Ensure scenes are numbered sequentially
-        """
-        for scene_number, scene in enumerate(self.scenes, start = 1):
-            scene.number = scene_number
-            for batch_number, batch in enumerate(scene.batches, start = 1):
-                batch.scene = scene.number
-                batch.number = batch_number
+            self.settings.update(settings)
 
     def _renumber_if_needed(self, lines : list[SubtitleLine]|None) -> None:
         """
@@ -608,29 +319,6 @@ class Subtitles:
             for line_number, line in enumerate(lines, start=1):
                 line.number = line_number
 
-    def _get_history(self, scene_number: int, batch_number: int, max_lines: int|None = None) -> list[str]:
-        """
-        Get a list of historical summaries up to a given scene and batch number
-        """
-        history_lines : list[str] = []
-        last_summary : str = ""
-
-        scenes = [scene for scene in self.scenes if scene.number and scene.number < scene_number]
-        for scene in [scene for scene in scenes if scene.summary]:
-            if scene.summary != last_summary:
-                history_lines.append(f"scene {scene.number}: {scene.summary}")
-                last_summary = scene.summary or ""
-
-        batches = [batch for batch in self.GetScene(scene_number).batches if batch.number is not None and batch.number < batch_number]
-        for batch in [batch for batch in batches if batch.summary]:
-            if batch.summary != last_summary:
-                history_lines.append(f"scene {batch.scene} batch {batch.number}: {batch.summary}")
-                last_summary = batch.summary or ""
-
-        if max_lines:
-            history_lines = history_lines[-max_lines:]
-
-        return history_lines
 
     def _merge_original_and_translated(self, originals: list[SubtitleLine], translated: list[SubtitleLine]) -> list[SubtitleLine]:
         lines = {item.key: SubtitleLine(item) for item in originals if item.key}
@@ -642,44 +330,3 @@ class Subtitles:
 
         return sorted(lines.values(), key=lambda item: item.key)
 
-    def _duplicate_originals_as_translations(self) -> None:
-        """
-        Duplicate original lines as translated lines if no translations exist (for testing)
-        """
-        for scene in self.scenes:
-            for batch in scene.batches:
-                if batch.any_translated:
-                    raise SubtitleError("Translations already exist")
-
-                batch.translated = [ SubtitleLine.Construct(line.number, line.start, line.end, line.text or "", line.metadata) for line in batch.originals ]
-
-    def _get_setting_str(self, key: str, default: str|None = None) -> str|None:
-        """
-        Get a setting as a string, or None if not set
-        """
-        value = self.settings.get(key, default)
-        return value if isinstance(value, str) else default
-
-    def _update_compatibility(self, settings: SettingsType) -> None:
-        """
-        Update settings for compatibility with older versions
-        """
-        if not settings.get('description') and settings.get('synopsis'):
-            settings['description'] = settings.get('synopsis')
-
-        if settings.get('characters'):
-            names = settings.get_str_list('names')
-            names.extend(settings.get_str_list('characters'))
-            settings['names'] = names
-            del settings['characters']
-
-        if settings.get('gpt_prompt'):
-            settings['prompt'] = settings['gpt_prompt']
-            del settings['gpt_prompt']
-
-        if settings.get('gpt_model'):
-            settings['model'] = settings['gpt_model']
-            del settings['gpt_model']
-
-        if not settings.get('substitution_mode'):
-            settings['substitution_mode'] = "Partial Words" if settings.get('match_partial_words') else "Auto"

--- a/PySubtrans/UnitTests/test_Options.py
+++ b/PySubtrans/UnitTests/test_Options.py
@@ -36,7 +36,7 @@ class TestOptions(unittest.TestCase):
         # Check a selection of stable default options
         test_cases = [
             ('target_language', 'English'),
-            ('scene_threshold', 30.0),
+            ('scene_threshold', 60.0),
             ('max_newlines', 2),
             ('ui_language', 'en'),
             ('filler_words', standard_filler_words),
@@ -98,7 +98,7 @@ class TestOptions(unittest.TestCase):
         # Check that defaults are still present for unspecified options
         default_test_cases = [
             ('min_batch_size', 10),
-            ('scene_threshold', 30.0),
+            ('scene_threshold', 60.0),
         ]
         
         for key, expected in default_test_cases:

--- a/PySubtrans/UnitTests/test_SubtitleBuilder.py
+++ b/PySubtrans/UnitTests/test_SubtitleBuilder.py
@@ -237,7 +237,7 @@ class TestSubtitleBuilder(unittest.TestCase):
 
         # Test that all methods return SubtitleBuilder for chaining
         result = (builder
-                 .AddScene(summary="Test scene", context={"genre": "comedy"})
+                 .AddScene(summary="Test scene")
                  .BuildLine(timedelta(seconds=1), timedelta(seconds=3), "Hello")
                  .BuildLine(timedelta(seconds=4), timedelta(seconds=6), "World")
         )
@@ -247,15 +247,21 @@ class TestSubtitleBuilder(unittest.TestCase):
 
         # Verify the structure was built correctly
         subtitles = result.Build()
-        scene = subtitles.scenes[0]
-        batch = scene.batches[0]
 
-        log_input_expected_result("scene context genre", "comedy", scene.GetContext("genre"))
-        self.assertEqual(scene.GetContext("genre"), "comedy")
+        log_input_expected_result("scenes count", 1, len(subtitles.scenes))
+        self.assertEqual(len(subtitles.scenes), 1)
+        scene = subtitles.scenes[0]
+
+        log_input_expected_result("batches count", 1, len(scene.batches))
+        self.assertEqual(len(scene.batches), 1)
+        batch = scene.batches[0]
 
         log_input_expected_result("batch lines count", 2, len(batch.originals))
         self.assertEqual(len(batch.originals), 2)
 
+        batch_line_numbers = [line.number for line in batch.originals]
+        log_input_expected_result("batch line numbers", [1, 2], batch_line_numbers)
+        self.assertSequenceEqual(batch_line_numbers, [1, 2])
 
 if __name__ == '__main__':
     unittest.main()

--- a/PySubtrans/UnitTests/test_SubtitleBuilder.py
+++ b/PySubtrans/UnitTests/test_SubtitleBuilder.py
@@ -47,7 +47,7 @@ class TestSubtitleBuilder(unittest.TestCase):
         """Test that batches are created automatically when scene is finalized."""
         builder = SubtitleBuilder()
         builder.AddScene()
-        result = builder.ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Test line")
+        result = builder.BuildLine(timedelta(seconds=1), timedelta(seconds=3), "Test line")
 
         log_input_expected_result("AddLine return type", SubtitleBuilder, type(result))
         self.assertEqual(type(result), SubtitleBuilder)
@@ -69,7 +69,7 @@ class TestSubtitleBuilder(unittest.TestCase):
         """Test that adding a line without a scene automatically adds the scene."""
         builder = SubtitleBuilder()
 
-        builder.ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Test")
+        builder.BuildLine(timedelta(seconds=1), timedelta(seconds=3), "Test")
 
         subtitles = builder.Build()
         log_input_expected_result("scenes count", 1, len(subtitles.scenes))
@@ -80,7 +80,7 @@ class TestSubtitleBuilder(unittest.TestCase):
         builder = SubtitleBuilder()
         builder.AddScene()
 
-        result = builder.ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Test line")
+        result = builder.BuildLine(timedelta(seconds=1), timedelta(seconds=3), "Test line")
 
         log_input_expected_result("AddLine return type", SubtitleBuilder, type(result))
         self.assertEqual(type(result), SubtitleBuilder)
@@ -152,10 +152,10 @@ class TestSubtitleBuilder(unittest.TestCase):
 
         (builder
          .AddScene(summary="Scene 1")
-         .ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Line 1")
-         .ConstructLine(timedelta(seconds=4), timedelta(seconds=6), "Line 2")
+         .BuildLine(timedelta(seconds=1), timedelta(seconds=3), "Line 1")
+         .BuildLine(timedelta(seconds=4), timedelta(seconds=6), "Line 2")
          .AddScene(summary="Scene 2")
-         .ConstructLine(timedelta(seconds=65), timedelta(seconds=67), "Line 3")
+         .BuildLine(timedelta(seconds=65), timedelta(seconds=67), "Line 3")
         )
 
         # Finalize to create batches
@@ -176,7 +176,7 @@ class TestSubtitleBuilder(unittest.TestCase):
 
         # Add many lines to trigger automatic batch splitting
         for i in range(1, 11):  # 10 lines
-            builder.ConstructLine(timedelta(seconds=i), timedelta(seconds=i+1), f"Line {i}")
+            builder.BuildLine(timedelta(seconds=i), timedelta(seconds=i+1), f"Line {i}")
 
         # Batching happens when scene is finalized
         subtitles = builder.Build()
@@ -198,7 +198,7 @@ class TestSubtitleBuilder(unittest.TestCase):
 
         # Add few lines that don't exceed max_batch_size
         for i in range(1, 6):  # 5 lines
-            builder.ConstructLine(timedelta(seconds=i), timedelta(seconds=i+1), f"Line {i}")
+            builder.BuildLine(timedelta(seconds=i), timedelta(seconds=i+1), f"Line {i}")
 
         # Batching happens when scene is finalized
         subtitles = builder.Build()
@@ -216,7 +216,7 @@ class TestSubtitleBuilder(unittest.TestCase):
 
         subtitles = (builder
                     .AddScene()
-                    .ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Test line")
+                    .BuildLine(timedelta(seconds=1), timedelta(seconds=3), "Test line")
                     .Build()
         )
 
@@ -238,8 +238,8 @@ class TestSubtitleBuilder(unittest.TestCase):
         # Test that all methods return SubtitleBuilder for chaining
         result = (builder
                  .AddScene(summary="Test scene", context={"genre": "comedy"})
-                 .ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Hello")
-                 .ConstructLine(timedelta(seconds=4), timedelta(seconds=6), "World")
+                 .BuildLine(timedelta(seconds=1), timedelta(seconds=3), "Hello")
+                 .BuildLine(timedelta(seconds=4), timedelta(seconds=6), "World")
         )
 
         log_input_expected_result("fluent API result type", SubtitleBuilder, type(result))

--- a/PySubtrans/UnitTests/test_SubtitleBuilder.py
+++ b/PySubtrans/UnitTests/test_SubtitleBuilder.py
@@ -1,0 +1,261 @@
+import unittest
+from datetime import timedelta
+
+from PySubtrans.SubtitleBuilder import SubtitleBuilder
+from PySubtrans.SubtitleLine import SubtitleLine
+from PySubtrans.Subtitles import Subtitles
+from PySubtrans.Helpers.Tests import log_input_expected_result, log_test_name
+
+
+class TestSubtitleBuilder(unittest.TestCase):
+
+    def setUp(self):
+        """Set up test cases."""
+        log_test_name(self._testMethodName)
+
+    def test_empty_builder_initialization(self):
+        """Test creating an empty SubtitleBuilder."""
+        builder = SubtitleBuilder()
+        subtitles = builder.Build()
+
+        log_input_expected_result("subtitles type", Subtitles, type(subtitles))
+        self.assertEqual(type(subtitles), Subtitles)
+
+        log_input_expected_result("subtitles.scenes length", 0, len(subtitles.scenes))
+        self.assertEqual(len(subtitles.scenes), 0)
+
+    def test_add_scene_creation(self):
+        """Test adding a new scene."""
+        builder = SubtitleBuilder()
+        result = builder.AddScene(summary="Test scene")
+        subtitles = builder.Build()
+
+        log_input_expected_result("AddScene return type", SubtitleBuilder, type(result))
+        self.assertEqual(type(result), SubtitleBuilder)
+
+        log_input_expected_result("scenes count", 1, len(subtitles.scenes))
+        self.assertEqual(len(subtitles.scenes), 1)
+
+        scene = subtitles.scenes[0]
+        log_input_expected_result("scene number", 1, scene.number)
+        self.assertEqual(scene.number, 1)
+
+        log_input_expected_result("scene summary", "Test scene", scene.summary)
+        self.assertEqual(scene.summary, "Test scene")
+
+    def test_automatic_batch_creation(self):
+        """Test that batches are created automatically when scene is finalized."""
+        builder = SubtitleBuilder()
+        builder.AddScene()
+        result = builder.ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Test line")
+
+        log_input_expected_result("AddLine return type", SubtitleBuilder, type(result))
+        self.assertEqual(type(result), SubtitleBuilder)
+
+        # Batches are created when scene is finalized
+        subtitles = builder.Build()
+        scene = subtitles.scenes[0]
+        log_input_expected_result("batches created automatically", 1, len(scene.batches))
+        self.assertEqual(len(scene.batches), 1)
+
+        batch = scene.batches[0]
+        log_input_expected_result("batch number", 1, batch.number)
+        self.assertEqual(batch.number, 1)
+
+        log_input_expected_result("batch has line", 1, len(batch.originals))
+        self.assertEqual(len(batch.originals), 1)
+
+    def test_add_line_without_scene(self):
+        """Test that adding a line without a scene automatically adds the scene."""
+        builder = SubtitleBuilder()
+
+        builder.ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Test")
+
+        subtitles = builder.Build()
+        log_input_expected_result("scenes count", 1, len(subtitles.scenes))
+        self.assertEqual(len(subtitles.scenes), 1)
+
+    def test_add_line(self):
+        """Test adding a subtitle line."""
+        builder = SubtitleBuilder()
+        builder.AddScene()
+
+        result = builder.ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Test line")
+
+        log_input_expected_result("AddLine return type", SubtitleBuilder, type(result))
+        self.assertEqual(type(result), SubtitleBuilder)
+
+        subtitles = builder.Build()
+
+        log_input_expected_result("scenes count", 1, len(subtitles.scenes))
+        self.assertEqual(len(subtitles.scenes), 1)
+
+        log_input_expected_result("batches count", 1, len(subtitles.scenes[0].batches))
+        self.assertEqual(len(subtitles.scenes[0].batches), 1)
+
+        batch = subtitles.scenes[0].batches[0]
+        log_input_expected_result("batch originals count", 1, len(batch.originals))
+        self.assertEqual(len(batch.originals), 1)
+
+        line = batch.originals[0]
+        log_input_expected_result("line number", 1, line.number)
+        self.assertEqual(line.number, 1)
+
+        log_input_expected_result("line text", "Test line", line.text)
+        self.assertEqual(line.text, "Test line")
+
+    def test_add_lines_with_subtitle_line_objects(self):
+        """Test adding multiple SubtitleLine objects."""
+        builder = SubtitleBuilder()
+        builder.AddScene()
+
+        lines = [
+            SubtitleLine.Construct(1, timedelta(seconds=1), timedelta(seconds=3), "Line 1"),
+            SubtitleLine.Construct(2, timedelta(seconds=4), timedelta(seconds=6), "Line 2")
+        ]
+
+        result = builder.AddLines(lines)
+
+        log_input_expected_result("AddLines return type", SubtitleBuilder, type(result))
+        self.assertEqual(type(result), SubtitleBuilder)
+
+        # Batches are created when scene is finalized
+        subtitles = builder.Build()
+        batch = subtitles.scenes[0].batches[0]
+        log_input_expected_result("batch originals count", 2, len(batch.originals))
+        self.assertEqual(len(batch.originals), 2)
+
+    def test_add_lines_with_tuples(self):
+        """Test adding multiple lines as tuples."""
+        builder = SubtitleBuilder()
+        builder.AddScene()
+
+        lines = [
+            (timedelta(seconds=1), timedelta(seconds=3), "Line 1"),
+            (timedelta(seconds=4), timedelta(seconds=6), "Line 2")
+        ]
+
+        builder.AddLines(lines)
+
+        # Batches are created when scene is finalized
+        subtitles = builder.Build()
+        batch = subtitles.scenes[0].batches[0]
+        log_input_expected_result("batch originals count", 2, len(batch.originals))
+        self.assertEqual(len(batch.originals), 2)
+
+        log_input_expected_result("first line text", "Line 1", batch.originals[0].text)
+        self.assertEqual(batch.originals[0].text, "Line 1")
+
+    def test_multiple_scenes_and_batches(self):
+        """Test creating multiple scenes and batches."""
+        builder = SubtitleBuilder()
+
+        (builder
+         .AddScene(summary="Scene 1")
+         .ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Line 1")
+         .ConstructLine(timedelta(seconds=4), timedelta(seconds=6), "Line 2")
+         .AddScene(summary="Scene 2")
+         .ConstructLine(timedelta(seconds=65), timedelta(seconds=67), "Line 3")
+        )
+
+        # Finalize to create batches
+        subtitles = builder.Build()
+        log_input_expected_result("scenes count", 2, len(subtitles.scenes))
+        self.assertEqual(len(subtitles.scenes), 2)
+
+        log_input_expected_result("scene 1 batches count", 1, len(subtitles.scenes[0].batches))
+        self.assertEqual(len(subtitles.scenes[0].batches), 1)
+
+        log_input_expected_result("scene 2 batches count", 1, len(subtitles.scenes[1].batches))
+        self.assertEqual(len(subtitles.scenes[1].batches), 1)
+
+    def test_automatic_batch_splitting(self):
+        """Test that batches are automatically split when they exceed max_batch_size."""
+        builder = SubtitleBuilder(max_batch_size=5)
+        builder.AddScene()
+
+        # Add many lines to trigger automatic batch splitting
+        for i in range(1, 11):  # 10 lines
+            builder.ConstructLine(timedelta(seconds=i), timedelta(seconds=i+1), f"Line {i}")
+
+        # Batching happens when scene is finalized
+        subtitles = builder.Build()
+        scene = subtitles.scenes[0]
+
+        # Should have multiple batches due to intelligent splitting
+        log_input_expected_result("batches created", True, len(scene.batches) > 1)
+        self.assertTrue(len(scene.batches) > 1)
+
+        # Verify all batches are within size limit
+        for batch in scene.batches:
+            log_input_expected_result(f"batch {batch.number} size <= 5", True, len(batch.originals) <= 5)
+            self.assertTrue(len(batch.originals) <= 5)
+
+    def test_no_split_when_within_limit(self):
+        """Test that batches are not split when within max_batch_size."""
+        builder = SubtitleBuilder(max_batch_size=10)
+        builder.AddScene()
+
+        # Add few lines that don't exceed max_batch_size
+        for i in range(1, 6):  # 5 lines
+            builder.ConstructLine(timedelta(seconds=i), timedelta(seconds=i+1), f"Line {i}")
+
+        # Batching happens when scene is finalized
+        subtitles = builder.Build()
+        scene = subtitles.scenes[0]
+
+        log_input_expected_result("single batch count", 1, len(scene.batches))
+        self.assertEqual(len(scene.batches), 1)
+
+        log_input_expected_result("batch size", 5, len(scene.batches[0].originals))
+        self.assertEqual(len(scene.batches[0].originals), 5)
+
+    def test_build_finalizes_subtitles(self):
+        """Test that Build() properly finalizes the subtitles structure."""
+        builder = SubtitleBuilder()
+
+        subtitles = (builder
+                    .AddScene()
+                    .ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Test line")
+                    .Build()
+        )
+
+        log_input_expected_result("built subtitles type", Subtitles, type(subtitles))
+        self.assertEqual(type(subtitles), Subtitles)
+
+        # Check that flattened originals are properly set
+        log_input_expected_result("originals is not None", True, subtitles.originals is not None)
+        self.assertIsNotNone(subtitles.originals)
+
+        if subtitles.originals:
+            log_input_expected_result("originals count", 1, len(subtitles.originals))
+            self.assertEqual(len(subtitles.originals), 1)
+
+    def test_fluent_api_chaining(self):
+        """Test that all methods support fluent API chaining."""
+        builder = SubtitleBuilder()
+
+        # Test that all methods return SubtitleBuilder for chaining
+        result = (builder
+                 .AddScene(summary="Test scene", context={"genre": "comedy"})
+                 .ConstructLine(timedelta(seconds=1), timedelta(seconds=3), "Hello")
+                 .ConstructLine(timedelta(seconds=4), timedelta(seconds=6), "World")
+        )
+
+        log_input_expected_result("fluent API result type", SubtitleBuilder, type(result))
+        self.assertEqual(type(result), SubtitleBuilder)
+
+        # Verify the structure was built correctly
+        subtitles = result.Build()
+        scene = subtitles.scenes[0]
+        batch = scene.batches[0]
+
+        log_input_expected_result("scene context genre", "comedy", scene.GetContext("genre"))
+        self.assertEqual(scene.GetContext("genre"), "comedy")
+
+        log_input_expected_result("batch lines count", 2, len(batch.originals))
+        self.assertEqual(len(batch.originals), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/PySubtrans/UnitTests/test_SubtitleEditor.py
+++ b/PySubtrans/UnitTests/test_SubtitleEditor.py
@@ -1,0 +1,598 @@
+import os
+import tempfile
+import unittest
+from datetime import timedelta
+
+from PySubtrans.Helpers.TestCases import SubtitleTestCase
+from PySubtrans.Helpers.Tests import log_input_expected_result, log_test_name
+from PySubtrans.SettingsType import SettingsType
+from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SubtitleEditor import SubtitleEditor
+from PySubtrans.SubtitleLine import SubtitleLine
+from PySubtrans.Subtitles import Subtitles
+from PySubtrans.UnitTests.TestData.chinese_dinner import chinese_dinner_data
+
+class SubtitleEditorTests(SubtitleTestCase):
+    """Test suite for SubtitleEditor class functionality"""
+
+    def __init__(self, methodName):
+        super().__init__(methodName, custom_options={
+            'max_batch_size': 10,
+            'min_batch_size': 1,
+            'scene_threshold': 5.0,  # 5 second scene breaks for testing
+        })
+
+    def setUp(self):
+        """Set up test fixtures"""
+        log_test_name(self._testMethodName)
+
+        self.temp_dir = tempfile.mkdtemp()
+        self.test_srt_file = os.path.join(self.temp_dir, "test.srt")
+
+        # Create test subtitles with some realistic timing
+        self.test_lines = [
+            SubtitleLine.Construct(1, timedelta(seconds=1), timedelta(seconds=3), "First line", {}),
+            SubtitleLine.Construct(2, timedelta(seconds=4), timedelta(seconds=6), "Second line", {}),
+            SubtitleLine.Construct(3, timedelta(seconds=7), timedelta(seconds=9), "Third line", {}),
+            SubtitleLine.Construct(4, timedelta(seconds=15), timedelta(seconds=17), "Fourth line (new scene)", {}),
+            SubtitleLine.Construct(5, timedelta(seconds=18), timedelta(seconds=20), "Fifth line", {}),
+        ]
+
+        # Write test SRT content
+        with open(self.test_srt_file, 'w', encoding='utf-8') as f:
+            original_content = chinese_dinner_data.get_str('original') or ''
+            f.write(original_content)
+
+        # Create subtitles object with test data
+        self.subtitles = Subtitles(settings=SettingsType({'target_language': 'English'}))
+        self.subtitles.originals = self.test_lines.copy()
+
+    def tearDown(self):
+        """Clean up test fixtures"""
+        try:
+            if os.path.exists(self.test_srt_file):
+                os.remove(self.test_srt_file)
+            os.rmdir(self.temp_dir)
+        except Exception:
+            pass
+
+    def test_context_manager_functionality(self):
+        """Test SubtitleEditor context manager properly acquires and releases locks"""
+
+        editor = SubtitleEditor(self.subtitles)
+
+        # Initially lock should not be acquired
+        log_input_expected_result("initial lock acquired", False, editor._lock_acquired)
+        self.assertFalse(editor._lock_acquired)
+
+        # Test entering context
+        with editor as ctx_editor:
+            log_input_expected_result("context manager returns self", editor, ctx_editor)
+            self.assertIs(ctx_editor, editor)
+
+            log_input_expected_result("lock acquired in context", True, editor._lock_acquired)
+            self.assertTrue(editor._lock_acquired)
+
+        # After exiting context, lock should be released
+        log_input_expected_result("lock released after context", False, editor._lock_acquired)
+        self.assertFalse(editor._lock_acquired)
+
+
+    def test_autobatch_functionality(self):
+        """Test AutoBatch divides subtitles into scenes and batches"""
+
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            # Initially no scenes
+            initial_scene_count = self.subtitles.scenecount
+            log_input_expected_result("initial scene count", 0, initial_scene_count)
+            self.assertEqual(initial_scene_count, 0)
+
+            # Apply batching
+            editor.AutoBatch(batcher)
+
+            # Should have created scenes
+            scene_count = self.subtitles.scenecount
+            log_input_expected_result("scene count after batching > 0", True, scene_count > 0)
+            self.assertGreater(scene_count, 0)
+
+            # With our test data and 5-second threshold, should have 2 scenes
+            # Lines 1-3 (gaps of 1s, 1s) and line 4-5 (gap of 8s between line 3 and 4)
+            expected_scenes = 2
+            log_input_expected_result("expected scene count", expected_scenes, scene_count)
+            self.assertEqual(scene_count, expected_scenes)
+
+            # Verify scene structure
+            first_scene = self.subtitles.GetScene(1)
+            log_input_expected_result("first scene exists", True, first_scene is not None)
+            self.assertIsNotNone(first_scene)
+
+            if first_scene:
+                first_scene_batch_count = len(first_scene.batches)
+                log_input_expected_result("first scene has batches", True, first_scene_batch_count > 0)
+                self.assertGreater(first_scene_batch_count, 0)
+
+    def test_add_scene(self):
+        """Test AddScene adds a new scene to the subtitles"""
+
+        from PySubtrans.SubtitleScene import SubtitleScene
+
+        with SubtitleEditor(self.subtitles) as editor:
+            initial_count = len(self.subtitles.scenes)
+
+            # Create and add a new scene
+            new_scene = SubtitleScene({'number': 99, 'summary': 'Test scene'})
+            editor.AddScene(new_scene)
+
+            new_count = len(self.subtitles.scenes)
+            log_input_expected_result("scene count increased", initial_count + 1, new_count)
+            self.assertEqual(new_count, initial_count + 1)
+
+            # Verify the scene was added
+            added_scene = self.subtitles.scenes[-1]
+            log_input_expected_result("added scene number", 99, added_scene.number)
+            self.assertEqual(added_scene.number, 99)
+
+    def test_add_translation_via_batch(self):
+        """Test adding translations through proper batch-based approach"""
+
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            # Find first batch and add a translation
+            scene = self.subtitles.GetScene(1)
+            if scene and scene.batches:
+                batch = scene.batches[0]
+                if batch.originals:
+                    line_number = batch.originals[0].number
+                    translation_text = "Proper batch-based translation"
+
+                    # Add translation through batch (proper approach)
+                    translated_line = SubtitleLine.Construct(
+                        line_number,
+                        batch.originals[0].start,
+                        batch.originals[0].end,
+                        translation_text,
+                        {}
+                    )
+                    batch.AddTranslatedLine(translated_line)
+
+                    # Verify translation was added
+                    log_input_expected_result("batch has translations", True, batch.any_translated)
+                    self.assertTrue(batch.any_translated)
+
+                    # Verify we can retrieve the translation
+                    retrieved_translation = batch.GetTranslatedLine(line_number)
+                    log_input_expected_result("translation retrieved", True, retrieved_translation is not None)
+                    self.assertIsNotNone(retrieved_translation)
+
+                    if retrieved_translation:
+                        log_input_expected_result("translation text correct", translation_text, retrieved_translation.text)
+                        self.assertEqual(retrieved_translation.text, translation_text)
+
+    def test_sanitise_removes_invalid_content(self):
+        """Test Sanitise removes invalid lines, empty batches and scenes"""
+
+        # First create some scenes with batching
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            # Add some invalid content to test sanitization
+            scene = self.subtitles.GetScene(1)
+            if scene and scene.batches:
+                batch = scene.batches[0]
+
+                # Add invalid line (no line number)
+                invalid_line = SubtitleLine.Construct(0, timedelta(seconds=1), timedelta(seconds=2), "Invalid line", {})
+                batch.originals.append(invalid_line)
+
+                # Add line with missing start time
+                missing_start_line = SubtitleLine.Construct(999, None, timedelta(seconds=2), "Missing start", {})
+                batch.originals.append(missing_start_line)
+
+                initial_line_count = len(batch.originals)
+                log_input_expected_result("initial line count includes invalid", True, initial_line_count >= 5)
+                self.assertGreaterEqual(initial_line_count, 5)  # Should have original 3 + 2 invalid = 5+
+
+                # Apply sanitization
+                editor.Sanitise()
+
+                # Should remove invalid lines
+                final_line_count = len(batch.originals)
+                log_input_expected_result("final line count after sanitise", True, final_line_count < initial_line_count)
+                self.assertLess(final_line_count, initial_line_count)
+
+                # All remaining lines should be valid
+                for line in batch.originals:
+                    log_input_expected_result(f"line {line.number} has valid number", True, line.number and line.number > 0)
+                    log_input_expected_result(f"line {line.number} has start time", True, line.start is not None)
+                    self.assertTrue(line.number and line.number > 0)
+                    self.assertIsNotNone(line.start)
+
+    def test_renumber_scenes(self):
+        """Test RenumberScenes ensures sequential numbering"""
+
+        # Create scenes with batching first
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            # Mess up the scene numbering
+            if len(self.subtitles.scenes) >= 2:
+                self.subtitles.scenes[0].number = 5
+                self.subtitles.scenes[1].number = 10
+
+                # Verify numbering is messed up
+                first_scene_number = self.subtitles.scenes[0].number
+                second_scene_number = self.subtitles.scenes[1].number
+                log_input_expected_result("first scene number before renumber", 5, first_scene_number)
+                log_input_expected_result("second scene number before renumber", 10, second_scene_number)
+                self.assertEqual(first_scene_number, 5)
+                self.assertEqual(second_scene_number, 10)
+
+                # Apply renumbering
+                editor.RenumberScenes()
+
+                # Should be sequential now
+                renumbered_first = self.subtitles.scenes[0].number
+                renumbered_second = self.subtitles.scenes[1].number
+                log_input_expected_result("first scene renumbered", 1, renumbered_first)
+                log_input_expected_result("second scene renumbered", 2, renumbered_second)
+                self.assertEqual(renumbered_first, 1)
+                self.assertEqual(renumbered_second, 2)
+
+    def test_duplicate_originals_as_translations(self):
+        """Test DuplicateOriginalsAsTranslations creates translation copies"""
+
+        # Create scenes with batching first
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            # Initially should have no translations
+            any_translated_before = self.subtitles.any_translated
+            log_input_expected_result("no translations initially", False, any_translated_before)
+            self.assertFalse(any_translated_before)
+
+            # Duplicate originals as translations
+            editor.DuplicateOriginalsAsTranslations()
+
+            # Should now have translations
+            any_translated_after = self.subtitles.any_translated
+            log_input_expected_result("has translations after duplication", True, any_translated_after)
+            self.assertTrue(any_translated_after)
+
+            # Verify translations match originals
+            for scene in self.subtitles.scenes:
+                for batch in scene.batches:
+                    if batch.originals and batch.translated:
+                        log_input_expected_result(f"batch ({batch.scene},{batch.number}) original count", len(batch.originals), len(batch.translated))
+                        self.assertEqual(len(batch.translated), len(batch.originals))
+
+                        for orig, trans in zip(batch.originals, batch.translated):
+                            log_input_expected_result(f"line {orig.number} number matches", orig.number, trans.number)
+                            log_input_expected_result(f"line {orig.number} text matches", orig.text, trans.text)
+                            self.assertEqual(trans.number, orig.number)
+                            self.assertEqual(trans.text, orig.text)
+
+    def test_duplicate_originals_fails_with_existing_translations(self):
+        """Test DuplicateOriginalsAsTranslations raises error if translations exist"""
+
+        # Create scenes with batching and add a translation
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            # Add a translation directly to a batch to trigger the error
+            scene = self.subtitles.GetScene(1)
+            if scene and scene.batches:
+                batch = scene.batches[0]
+                if batch.originals:
+                    # Create a translated line directly in the batch
+                    translated_line = SubtitleLine.Construct(
+                        batch.originals[0].number,
+                        batch.originals[0].start,
+                        batch.originals[0].end,
+                        "Direct translation",
+                        {}
+                    )
+                    batch.translated = [translated_line]
+
+            # Should fail because translations already exist
+            from PySubtrans.SubtitleError import SubtitleError
+            with self.assertRaises(SubtitleError) as context:
+                editor.DuplicateOriginalsAsTranslations()
+
+            error_message = str(context.exception)
+            log_input_expected_result("error mentions existing translations", True, "already exist" in error_message.lower())
+            self.assertIn("already exist", error_message.lower())
+
+    def test_update_scene_context(self):
+        """Test UpdateScene updates scene context"""
+
+        # Create scenes with batching first
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            scene_number = 1
+            update_data = {'summary': 'Updated scene summary', 'custom_field': 'test_value'}
+
+            # Apply update
+            result = editor.UpdateScene(scene_number, update_data)
+
+            # Verify update was applied (result should be truthy if successful)
+            log_input_expected_result("update scene returned result", True, result is not None)
+            self.assertIsNotNone(result)
+
+            # Verify scene was updated
+            updated_scene = self.subtitles.GetScene(scene_number)
+            if updated_scene:
+                # Check if summary was updated (depending on SubtitleScene.UpdateContext implementation)
+                log_input_expected_result("scene exists after update", True, updated_scene is not None)
+                self.assertIsNotNone(updated_scene)
+
+    def test_update_batch_context(self):
+        """Test UpdateBatch updates batch context"""
+
+        # Create scenes with batching first
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            scene_number = 1
+            batch_number = 1
+            update_data = {'summary': 'Updated batch summary', 'custom_field': 'test_value'}
+
+            # Apply update
+            result = editor.UpdateBatch(scene_number, batch_number, update_data)
+
+            # Verify update was applied
+            log_input_expected_result("update batch returned boolean", bool, type(result))
+            self.assertIsInstance(result, bool)
+
+            # Verify batch still exists and is accessible
+            updated_batch = self.subtitles.GetBatch(scene_number, batch_number)
+            log_input_expected_result("batch exists after update", True, updated_batch is not None)
+            self.assertIsNotNone(updated_batch)
+
+    def test_delete_lines(self):
+        """Test DeleteLines removes lines from batches"""
+
+        # Create scenes with batching first
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            # Get initial line counts
+            initial_line_count = self.subtitles.linecount
+            log_input_expected_result("initial line count > 0", True, initial_line_count > 0)
+            self.assertGreater(initial_line_count, 0)
+
+            # Delete some lines
+            lines_to_delete = [1, 2]
+            deletions = editor.DeleteLines(lines_to_delete)
+
+            # Should return deletion info
+            log_input_expected_result("deletions returned", True, len(deletions) > 0)
+            self.assertGreater(len(deletions), 0)
+
+            # Each deletion should be a tuple of (scene, batch, deleted_originals, deleted_translated)
+            for deletion in deletions:
+                log_input_expected_result("deletion is tuple", tuple, type(deletion))
+                self.assertIsInstance(deletion, tuple)
+
+                scene_num, batch_num, deleted_originals, deleted_translated = deletion #type: ignore
+                log_input_expected_result(f"deleted originals from batch ({scene_num},{batch_num})", True, len(deleted_originals) > 0)
+                self.assertGreater(len(deleted_originals), 0)
+
+    def test_delete_lines_nonexistent(self):
+        """Test DeleteLines raises error when no lines are deleted"""
+
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            # Try to delete nonexistent lines
+            with self.assertRaises(ValueError) as context:
+                editor.DeleteLines([999, 1000])
+
+            error_message = str(context.exception)
+            log_input_expected_result("error mentions no lines deleted", True, "no lines were deleted" in error_message.lower())
+            self.assertIn("no lines were deleted", error_message.lower())
+
+    def test_merge_scenes(self):
+        """Test MergeScenes combines sequential scenes"""
+
+        # Create subtitles with wider scene gaps to ensure multiple scenes
+        wide_gap_lines = [
+            SubtitleLine.Construct(1, timedelta(seconds=1), timedelta(seconds=3), "Scene 1 line 1", {}),
+            SubtitleLine.Construct(2, timedelta(seconds=4), timedelta(seconds=6), "Scene 1 line 2", {}),
+            SubtitleLine.Construct(3, timedelta(seconds=20), timedelta(seconds=22), "Scene 2 line 1", {}), # 14s gap
+            SubtitleLine.Construct(4, timedelta(seconds=23), timedelta(seconds=25), "Scene 2 line 2", {}),
+            SubtitleLine.Construct(5, timedelta(seconds=40), timedelta(seconds=42), "Scene 3 line 1", {}), # 15s gap
+        ]
+
+        self.subtitles.originals = wide_gap_lines
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            initial_scene_count = self.subtitles.scenecount
+            log_input_expected_result("initial scene count >= 3", True, initial_scene_count >= 3)
+            self.assertGreaterEqual(initial_scene_count, 3)
+
+            # Merge first two scenes
+            merged_scene = editor.MergeScenes([1, 2])
+
+            # Should have one fewer scene
+            final_scene_count = self.subtitles.scenecount
+            log_input_expected_result("scene count decreased", initial_scene_count - 1, final_scene_count)
+            self.assertEqual(final_scene_count, initial_scene_count - 1)
+
+            # Merged scene should exist
+            log_input_expected_result("merged scene returned", True, merged_scene is not None)
+            self.assertIsNotNone(merged_scene)
+
+            # Scenes should be renumbered sequentially
+            for i, scene in enumerate(self.subtitles.scenes, 1):
+                log_input_expected_result(f"scene {i} has correct number", i, scene.number)
+                self.assertEqual(scene.number, i)
+
+    def test_merge_scenes_invalid_input(self):
+        """Test MergeScenes raises errors for invalid input"""
+
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            # Test empty list
+            with self.assertRaises(ValueError) as context:
+                editor.MergeScenes([])
+            log_input_expected_result("empty list error", True, "no scene numbers" in str(context.exception).lower())
+            self.assertIn("no scene numbers", str(context.exception).lower())
+
+            # Test non-sequential scenes
+            if self.subtitles.scenecount >= 3:
+                with self.assertRaises(ValueError) as context:
+                    editor.MergeScenes([1, 3])  # Skip scene 2
+                log_input_expected_result("non-sequential error", True, "not sequential" in str(context.exception).lower())
+                self.assertIn("not sequential", str(context.exception).lower())
+
+    def test_split_scene(self):
+        """Test SplitScene divides a scene at specified batch"""
+
+        # Use wider gap lines to get scenes with multiple batches
+        multi_batch_lines = [
+            SubtitleLine.Construct(1, timedelta(seconds=1), timedelta(seconds=3), "Batch 1 line 1", {}),
+            SubtitleLine.Construct(2, timedelta(seconds=4), timedelta(seconds=6), "Batch 1 line 2", {}),
+            SubtitleLine.Construct(3, timedelta(seconds=7), timedelta(seconds=9), "Batch 1 line 3", {}),
+            SubtitleLine.Construct(4, timedelta(seconds=10), timedelta(seconds=12), "Batch 2 line 1", {}),
+            SubtitleLine.Construct(5, timedelta(seconds=13), timedelta(seconds=15), "Batch 2 line 2", {}),
+        ]
+
+        self.subtitles.originals = multi_batch_lines
+        # Use smaller batch size to create multiple batches
+        small_batch_batcher = SubtitleBatcher(SettingsType({
+            'max_batch_size': 3,
+            'min_batch_size': 1,
+            'scene_threshold': 30.0  # Large threshold to keep in one scene
+        }))
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(small_batch_batcher)
+
+            initial_scene_count = self.subtitles.scenecount
+
+            # Find a scene with multiple batches to split
+            scene_to_split = None
+            for scene in self.subtitles.scenes:
+                if len(scene.batches) >= 2:
+                    scene_to_split = scene
+                    break
+
+            if scene_to_split:
+                initial_batch_count = len(scene_to_split.batches)
+                log_input_expected_result("scene has multiple batches", True, initial_batch_count >= 2)
+                self.assertGreaterEqual(initial_batch_count, 2)
+
+                # Split at batch 2
+                editor.SplitScene(scene_to_split.number, 2)
+
+                # Should have one more scene
+                final_scene_count = self.subtitles.scenecount
+                log_input_expected_result("scene count increased", initial_scene_count + 1, final_scene_count)
+                self.assertEqual(final_scene_count, initial_scene_count + 1)
+
+                # All scenes should be numbered sequentially
+                for i, scene in enumerate(self.subtitles.scenes, 1):
+                    log_input_expected_result(f"scene {i} numbered correctly", i, scene.number)
+                    self.assertEqual(scene.number, i)
+
+    def test_merge_lines_in_batch(self):
+        """Test MergeLinesInBatch combines lines within a batch"""
+
+        batcher = SubtitleBatcher(self.options)
+
+        with SubtitleEditor(self.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+            # Find a batch with multiple lines
+            target_batch = None
+            scene_num = batch_num = 0
+
+            for scene in self.subtitles.scenes:
+                for batch in scene.batches:
+                    if len(batch.originals) >= 2:
+                        target_batch = batch
+                        scene_num = scene.number
+                        batch_num = batch.number
+                        break
+                if target_batch:
+                    break
+
+            if target_batch:
+                initial_line_count = len(target_batch.originals)
+                log_input_expected_result("batch has multiple lines", True, initial_line_count >= 2)
+                self.assertGreaterEqual(initial_line_count, 2)
+
+                # Get first two line numbers
+                line_numbers = [target_batch.originals[0].number, target_batch.originals[1].number]
+
+                # Merge the lines
+                merged_original, _ = editor.MergeLinesInBatch(scene_num, batch_num, line_numbers)
+
+                # Should return merged lines
+                log_input_expected_result("merged original returned", True, merged_original is not None)
+                self.assertIsNotNone(merged_original)
+
+                # Batch should have fewer lines now
+                final_line_count = len(target_batch.originals)
+                log_input_expected_result("line count decreased", True, final_line_count < initial_line_count)
+                self.assertLess(final_line_count, initial_line_count)
+
+    def test_context_manager_with_real_subtitles(self):
+        """Test SubtitleEditor context manager with real subtitle data"""
+
+        # Load real subtitles from file
+        real_subtitles = Subtitles(self.test_srt_file)
+        real_subtitles.LoadSubtitles()
+
+        log_input_expected_result("real subtitles loaded", True, real_subtitles.has_subtitles)
+        self.assertTrue(real_subtitles.has_subtitles)
+
+        # Test context manager works with real data
+        with SubtitleEditor(real_subtitles) as editor:
+            log_input_expected_result("editor lock acquired", True, editor._lock_acquired)
+            self.assertTrue(editor._lock_acquired)
+
+            # Perform some operation
+            batcher = SubtitleBatcher(self.options)
+            editor.AutoBatch(batcher)
+
+            # Verify operation worked
+            scene_count = real_subtitles.scenecount
+            log_input_expected_result("scenes created from real data", True, scene_count > 0)
+            self.assertGreater(scene_count, 0)
+
+        # Verify lock was released
+        log_input_expected_result("editor lock released", False, editor._lock_acquired)
+        self.assertFalse(editor._lock_acquired)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/PySubtrans/UnitTests/test_SubtitleProject.py
+++ b/PySubtrans/UnitTests/test_SubtitleProject.py
@@ -1,0 +1,571 @@
+import os
+import tempfile
+import unittest
+
+from PySubtrans.Helpers.TestCases import SubtitleTestCase
+from PySubtrans.Helpers.Tests import log_input_expected_result, log_test_name
+from PySubtrans.SettingsType import SettingsType
+from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SubtitleEditor import SubtitleEditor
+from PySubtrans.SubtitleProject import SubtitleProject
+from PySubtrans.Subtitles import Subtitles
+from PySubtrans.UnitTests.TestData.chinese_dinner import chinese_dinner_data
+
+
+class SubtitleProjectTests(SubtitleTestCase):
+    """Test suite for SubtitleProject class functionality"""
+
+    def __init__(self, methodName):
+        super().__init__(methodName, custom_options={
+            'max_batch_size': 100,
+        })
+
+    def setUp(self):
+        """Set up test fixtures"""
+        log_test_name(self._testMethodName)
+
+        self.temp_dir = tempfile.mkdtemp()
+        self.test_srt_file = os.path.join(self.temp_dir, "test.srt")
+        self.test_project_file = os.path.join(self.temp_dir, "test.subtrans")
+
+        # Write test SRT content
+        with open(self.test_srt_file, 'w', encoding='utf-8') as f:
+            original_content = chinese_dinner_data.get_str('original') or ''
+            f.write(original_content)
+
+    def tearDown(self):
+        """Clean up test fixtures"""
+        try:
+            if os.path.exists(self.test_srt_file):
+                os.remove(self.test_srt_file)
+            if os.path.exists(self.test_project_file):
+                os.remove(self.test_project_file)
+            os.rmdir(self.temp_dir)
+        except Exception:
+            pass
+
+    def test_default_initialization(self):
+        """Test SubtitleProject initializes with default settings"""
+
+        project = SubtitleProject()
+
+        # Test basic initialization
+        log_input_expected_result("project.subtitles exists", True, project.subtitles is not None)
+        self.assertIsNotNone(project.subtitles)
+
+        log_input_expected_result("project.subtitles type", Subtitles, type(project.subtitles))
+        self.assertIsInstance(project.subtitles, Subtitles)
+
+        # Test that default project settings are applied
+        default_settings = SubtitleProject.DEFAULT_PROJECT_SETTINGS
+        for key in default_settings.keys():
+            if default_settings[key] is None:
+                continue
+            actual_value = project.subtitles.settings.get(key)
+            expected_value = default_settings[key]
+            log_input_expected_result(f"default setting '{key}'", expected_value, actual_value)
+            self.assertEqual(actual_value, expected_value)
+
+        # Test project-specific properties
+        log_input_expected_result("project.projectfile", None, project.projectfile)
+        self.assertIsNone(project.projectfile)
+
+        log_input_expected_result("project.existing_project", False, project.existing_project)
+        self.assertFalse(project.existing_project)
+
+        log_input_expected_result("project.needs_writing", False, project.needs_writing)
+        self.assertFalse(project.needs_writing)
+
+        log_input_expected_result("project.use_project_file", False, project.use_project_file)
+        self.assertFalse(project.use_project_file)
+
+    def test_persistent_initialization(self):
+        """Test SubtitleProject initialization with persistent=True"""
+
+        project = SubtitleProject(persistent=True)
+
+        log_input_expected_result("persistent project.use_project_file", True, project.use_project_file)
+        self.assertTrue(project.use_project_file)
+
+    def test_update_project_settings_normal(self):
+        """Test UpdateProjectSettings with normal settings"""
+
+        project = SubtitleProject()
+
+        # Test updating with normal settings - mix valid and invalid to test filtering
+        normal_settings = SettingsType({
+            'target_language': 'Spanish',        # Valid project setting
+            'movie_name': 'Test Movie',          # Valid project setting
+            'description': 'Test description',   # Valid project setting
+            'names': ['Character1', 'Character2'], # Valid project setting
+            'provider': 'Test Provider',         # Valid project setting
+            'invalid_setting': 'should_be_filtered',  # NOT in DEFAULT_PROJECT_SETTINGS
+            'scene_threshold': 45.0,             # Valid option but NOT project setting
+        })
+
+        project.UpdateProjectSettings(normal_settings)
+
+        # Verify valid settings were applied
+        test_cases = [
+            ('target_language', 'Spanish'),
+            ('movie_name', 'Test Movie'),
+            ('description', 'Test description'),
+            ('provider', 'Test Provider')
+        ]
+
+        for key, expected in test_cases:
+            actual = project.subtitles.settings.get(key)
+            log_input_expected_result(f"valid setting '{key}'", expected, actual)
+            self.assertEqual(actual, expected, f"Valid project setting '{key}' should be stored")
+
+        # Test names were parsed correctly
+        names = project.subtitles.settings.get_str_list('names')
+        expected_names = ['Character1', 'Character2']
+        log_input_expected_result(names, expected_names, names)
+        self.assertEqual(names, expected_names)
+
+        # CRITICAL: Test that invalid settings were filtered out
+        invalid_setting = project.subtitles.settings.get('invalid_setting')
+        log_input_expected_result(invalid_setting, None, invalid_setting)
+        self.assertIsNone(invalid_setting, "Invalid settings should be filtered out by UpdateProjectSettings")
+
+        scene_threshold = project.subtitles.settings.get('scene_threshold')
+        log_input_expected_result("scene_threshold filtered", None, scene_threshold)
+        self.assertIsNone(scene_threshold, "Non-project settings should be filtered out by UpdateProjectSettings")
+
+    def test_update_project_settings_legacy(self):
+        """Test UpdateProjectSettings with legacy settings compatibility"""
+
+        project = SubtitleProject()
+
+        # Test legacy settings that should be converted
+        legacy_settings = SettingsType({
+            'synopsis': 'Legacy description',  # Should become 'description'
+            'characters': ['Old Character'],   # Should become part of 'names'
+            'names': ['New Character'],        # Existing names to merge with
+            'gpt_prompt': 'Legacy prompt',     # Should become 'prompt'
+            'gpt_model': 'legacy-model',       # Should become 'model'
+            'match_partial_words': True        # Should affect 'substitution_mode'
+        })
+
+        project.UpdateProjectSettings(legacy_settings)
+
+        # Test that legacy conversions worked
+        # synopsis -> description
+        description = project.subtitles.settings.get('description')
+        log_input_expected_result(description, 'Legacy description', description)
+        self.assertEqual(description, 'Legacy description')
+
+        # gpt_prompt -> prompt
+        prompt = project.subtitles.settings.get('prompt')
+        log_input_expected_result(prompt, 'Legacy prompt', prompt)
+        self.assertEqual(prompt, 'Legacy prompt')
+
+        # gpt_model -> model
+        model = project.subtitles.settings.get('model')
+        log_input_expected_result(model, 'legacy-model', model)
+        self.assertEqual(model, 'legacy-model')
+
+        # characters merged with names
+        names = project.subtitles.settings.get_str_list('names')
+        log_input_expected_result(names, ['New Character', 'Old Character'], names)
+        self.assertIn('New Character', names)
+        self.assertIn('Old Character', names)
+
+        # match_partial_words -> substitution_mode
+        substitution_mode = project.subtitles.settings.get('substitution_mode')
+        log_input_expected_result(substitution_mode, 'Partial Words', substitution_mode)
+        self.assertEqual(substitution_mode, 'Partial Words')
+
+        # Verify original legacy keys were removed
+        characters = project.subtitles.settings.get('characters')
+        log_input_expected_result(characters, None, characters)
+        self.assertIsNone(characters)
+
+    def test_update_output_path(self):
+        """Test UpdateOutputPath functionality thoroughly"""
+
+        project = SubtitleProject()
+        project.subtitles.sourcepath = self.test_srt_file
+        project.subtitles.settings['target_language'] = 'Spanish'
+
+        # Test basic output path generation
+        project.UpdateOutputPath()
+
+        output_path = project.subtitles.outputpath
+        log_input_expected_result("output path generated", True, output_path is not None)
+        self.assertIsNotNone(output_path)
+
+        # Should contain target language in filename (case insensitive)
+        if output_path:
+            log_input_expected_result(output_path, True, 'spanish' in output_path.lower())
+            self.assertIn('spanish', output_path.lower())
+
+            # Should have .srt extension by default
+            log_input_expected_result(output_path, True, output_path.endswith('.srt'))
+            self.assertTrue(output_path.endswith('.srt'))
+
+        # Test with custom path - UpdateOutputPath processes through GetOutputPath
+        custom_path = os.path.join(self.temp_dir, "custom_output.vtt")
+        # Need to also specify the extension since UpdateOutputPath uses the current file_format if available
+        project.UpdateOutputPath(custom_path, '.vtt')
+
+        new_output_path = project.subtitles.outputpath
+        # GetOutputPath will add language suffix, so expect that behavior
+        expected_custom_path = os.path.join(self.temp_dir, "custom_output.spanish.vtt")
+        log_input_expected_result("custom output path with language", expected_custom_path, new_output_path)
+        self.assertEqual(new_output_path, expected_custom_path)
+
+        # Should update file format
+        file_format = project.subtitles.file_format
+        log_input_expected_result("file format updated", '.vtt', file_format)
+        self.assertEqual(file_format, '.vtt')
+
+        # Test with custom extension
+        project.UpdateOutputPath(extension='.ass')
+
+        ass_output_path = project.subtitles.outputpath
+        if ass_output_path:
+            log_input_expected_result(ass_output_path, True, ass_output_path.endswith('.ass'))
+            self.assertTrue(ass_output_path.endswith('.ass'))
+
+    def test_initialise_project_with_explicit_output_path(self):
+        """Test InitialiseProject respects explicit output path (CLI scenario)"""
+
+        project = SubtitleProject()
+
+        # This tests the CLI scenario where an explicit output path is provided
+        explicit_output = os.path.join(self.temp_dir, "explicit_output.vtt")
+        project.InitialiseProject(self.test_srt_file, outputpath=explicit_output)
+
+        # Verify the explicit output path was set
+        actual_output = project.subtitles.outputpath
+        log_input_expected_result("explicit output path respected", explicit_output, actual_output)
+        self.assertEqual(actual_output, explicit_output, "InitialiseProject should respect explicit outputpath")
+
+        # Verify file format was updated
+        file_format = project.subtitles.file_format
+        log_input_expected_result("file format from explicit path", '.vtt', file_format)
+        self.assertEqual(file_format, '.vtt', "File format should be derived from explicit output path")
+
+    def test_initialise_project_new_srt(self):
+        """Test InitialiseProject with a new SRT file"""
+
+        project = SubtitleProject()
+
+        # Initialize with SRT file
+        project.InitialiseProject(self.test_srt_file)
+
+        # Verify project was initialized correctly
+        log_input_expected_result("subtitles loaded", True, project.subtitles is not None)
+        self.assertIsNotNone(project.subtitles)
+
+        log_input_expected_result("has subtitles", True, project.subtitles.has_subtitles)
+        self.assertTrue(project.subtitles.has_subtitles)
+
+        line_count = project.subtitles.linecount
+        expected_line_count = 64  # From chinese_dinner_data
+        log_input_expected_result("line count", expected_line_count, line_count)
+        self.assertEqual(line_count, expected_line_count)
+
+        # Verify source path is set
+        source_path = project.subtitles.sourcepath
+        log_input_expected_result("source path", self.test_srt_file, source_path)
+        self.assertEqual(source_path, self.test_srt_file)
+
+        # Verify output path is generated
+        output_path = project.subtitles.outputpath
+        log_input_expected_result("output path generated", True, output_path is not None)
+        self.assertIsNotNone(output_path)
+
+        # Verify project file path is set
+        expected_project_file = self.test_srt_file.replace('.srt', '.subtrans')
+        actual_project_file = project.projectfile
+        log_input_expected_result("project file path", expected_project_file, actual_project_file)
+        self.assertEqual(actual_project_file, expected_project_file)
+
+    def test_save_and_reload_project_preserves_settings(self):
+        """Test saving and reloading project preserves custom settings"""
+
+        # Create project with custom settings
+        project = SubtitleProject(persistent=True)
+        project.InitialiseProject(self.test_srt_file)
+
+        # Add custom settings (only valid project settings)
+        custom_settings = SettingsType({
+            'target_language': 'French',
+            'movie_name': 'Custom Movie',
+            'description': 'Custom description',
+            'names': ['Custom Character 1', 'Custom Character 2'],
+            'provider': 'Custom Provider'
+        })
+
+        project.UpdateProjectSettings(custom_settings)
+
+        # Batch the subtitles so we have scenes to save
+        batcher = SubtitleBatcher(self.options)
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+        # Save the project
+        project.SaveProjectFile(self.test_project_file)
+
+        # Create new project and load from file
+        new_project = SubtitleProject()
+        new_project.ReadProjectFile(self.test_project_file)
+
+        # Verify custom settings were preserved
+        test_cases = [
+            ('target_language', 'French'),
+            ('movie_name', 'Custom Movie'),
+            ('description', 'Custom description'),
+            ('provider', 'Custom Provider')
+        ]
+
+        for key, expected in test_cases:
+            actual = new_project.subtitles.settings.get(key)
+            log_input_expected_result(f"preserved setting '{key}'", expected, actual)
+            self.assertEqual(actual, expected)
+
+        # Verify names were preserved
+        names = new_project.subtitles.settings.get_str_list('names')
+        expected_names = ['Custom Character 1', 'Custom Character 2']
+        log_input_expected_result(names, expected_names, names)
+        self.assertEqual(names, expected_names)
+
+        # Verify subtitles data was preserved
+        original_line_count = project.subtitles.linecount
+        new_line_count = new_project.subtitles.linecount
+        log_input_expected_result("preserved line count", original_line_count, new_line_count)
+        self.assertEqual(new_line_count, original_line_count)
+
+        original_scene_count = project.subtitles.scenecount
+        new_scene_count = new_project.subtitles.scenecount
+        log_input_expected_result("preserved scene count", original_scene_count, new_scene_count)
+        self.assertEqual(new_scene_count, original_scene_count)
+
+
+    def test_initialise_project_existing_subtrans(self):
+        """Test InitialiseProject with existing subtrans file"""
+
+        # First create a project file
+        project = SubtitleProject(persistent=True)
+        project.InitialiseProject(self.test_srt_file)
+
+        # Add some settings and batch
+        settings = SettingsType({
+            'target_language': 'German',
+            'movie_name': 'Existing Project Movie'
+        })
+        project.UpdateProjectSettings(settings)
+
+        batcher = SubtitleBatcher(self.options)
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+        project.SaveProjectFile(self.test_project_file)
+
+        # Now test initializing from the existing project file
+        new_project = SubtitleProject()
+        new_project.InitialiseProject(self.test_project_file)
+
+        # Should load existing project
+        log_input_expected_result("existing_project flag", True, new_project.existing_project)
+        self.assertTrue(new_project.existing_project)
+
+        log_input_expected_result("use_project_file flag", True, new_project.use_project_file)
+        self.assertTrue(new_project.use_project_file)
+
+        # Should preserve settings
+        target_language = new_project.subtitles.settings.get('target_language')
+        movie_name = new_project.subtitles.settings.get('movie_name')
+        log_input_expected_result("preserved target_language", 'German', target_language)
+        log_input_expected_result("preserved movie_name", 'Existing Project Movie', movie_name)
+        self.assertEqual(target_language, 'German')
+        self.assertEqual(movie_name, 'Existing Project Movie')
+
+        # Should have scenes from batching
+        scene_count = new_project.subtitles.scenecount
+        log_input_expected_result("scene count > 0", True, scene_count > 0)
+        self.assertGreater(scene_count, 0)
+
+    def test_initialise_project_existing_subtrans_reload(self):
+        """Test InitialiseProject with existing subtrans file and reload_subtitles=True"""
+
+        # Create a project file first
+        project = SubtitleProject(persistent=True)
+        project.InitialiseProject(self.test_srt_file)
+
+        settings = SettingsType({
+            'target_language': 'Portuguese',
+            'movie_name': 'Reload Test Movie'
+        })
+        project.UpdateProjectSettings(settings)
+
+        batcher = SubtitleBatcher(self.options)
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.AutoBatch(batcher)
+
+        project.SaveProjectFile(self.test_project_file)
+
+        # Modify the source SRT file to simulate changes
+        modified_srt_content = """1
+00:00:01,000 --> 00:00:03,000
+Modified subtitle line 1
+
+2
+00:00:04,000 --> 00:00:06,000
+Modified subtitle line 2
+"""
+        with open(self.test_srt_file, 'w', encoding='utf-8') as f:
+            f.write(modified_srt_content)
+
+        # Initialize with reload_subtitles=True
+        new_project = SubtitleProject()
+        new_project.InitialiseProject(self.test_project_file, reload_subtitles=True)
+
+        # Should preserve project settings
+        target_language = new_project.subtitles.settings.get('target_language')
+        movie_name = new_project.subtitles.settings.get('movie_name')
+        log_input_expected_result("preserved target_language", 'Portuguese', target_language)
+        log_input_expected_result("preserved movie_name", 'Reload Test Movie', movie_name)
+        self.assertEqual(target_language, 'Portuguese')
+        self.assertEqual(movie_name, 'Reload Test Movie')
+
+        # Should have reloaded subtitle content
+        line_count = new_project.subtitles.linecount
+        expected_line_count = 2  # Modified content has 2 lines
+        log_input_expected_result("reloaded line count", expected_line_count, line_count)
+        self.assertEqual(line_count, expected_line_count)
+
+        # Should have subtitle text from reloaded file
+        if new_project.subtitles.originals:
+            first_line_text = new_project.subtitles.originals[0].text
+            log_input_expected_result("reloaded first line", "Modified subtitle line 1", first_line_text)
+            self.assertEqual(first_line_text, "Modified subtitle line 1")
+
+    def test_get_project_settings(self):
+        """Test GetProjectSettings method returns expected settings"""
+
+        project = SubtitleProject()
+
+        # Add mix of valid project settings and non-project settings using UpdateProjectSettings
+        # This should only store valid project settings
+        project.UpdateProjectSettings(SettingsType({
+            'target_language': 'Japanese',       # Valid and non-empty
+            'movie_name': 'Test Movie',          # Valid and non-empty
+            'provider': 'Test Provider',         # Valid and non-empty
+            'description': 'Valid Description',  # Valid and non-empty
+            'names': ['Character'],              # Valid list
+            'substitutions': None,               # Valid key but None value - should be excluded
+            'prompt': '',                        # Valid key but empty string - should be excluded
+            'invalid_setting': 'some_value',     # Invalid key - should be filtered by UpdateProjectSettings
+            'format': '.srt'                     # Valid and non-empty
+        }))
+
+        project_settings = project.GetProjectSettings()
+
+        expected_included = [
+            ('target_language', 'Japanese'),
+            ('movie_name', 'Test Movie'),
+            ('provider', 'Test Provider'),
+            ('description', 'Valid Description'),
+            ('names', ['Character']),
+            ('format', '.srt')
+        ]
+
+        for key, expected_value in expected_included:
+            actual_value = project_settings.get(key)
+            log_input_expected_result(f"includes '{key}'", expected_value, actual_value)
+            self.assertEqual(actual_value, expected_value, f"GetProjectSettings should include valid non-empty setting '{key}'")
+
+        # Test what SHOULD be excluded (None and empty strings)
+        excluded_none_empty = ['substitutions', 'prompt']
+        for key in excluded_none_empty:
+            log_input_expected_result(f"excludes '{key}' (None/empty)", False, key in project_settings)
+            self.assertNotIn(key, project_settings, f"GetProjectSettings should exclude None/empty setting '{key}'")
+
+        # CRITICAL: Test that invalid settings were filtered out by UpdateProjectSettings
+        # GetProjectSettings should only see valid project settings that passed through UpdateProjectSettings
+        invalid_in_result = project_settings.get('invalid_setting')
+        log_input_expected_result(invalid_in_result, None, invalid_in_result)
+        self.assertIsNone(invalid_in_result, "Invalid settings should have been filtered out by UpdateProjectSettings")
+
+    def test_get_project_filepath(self):
+        """Test GetProjectFilepath method"""
+
+        project = SubtitleProject()
+
+        # Test with SRT file (use os.path.normpath for Windows compatibility)
+        srt_path = "/path/to/movie.srt"
+        project_path = project.GetProjectFilepath(srt_path)
+        expected_path = os.path.normpath("/path/to/movie.subtrans")
+        actual_path = os.path.normpath(project_path)
+        log_input_expected_result("SRT to subtrans", expected_path, actual_path)
+        self.assertEqual(actual_path, expected_path)
+
+        # Test with already subtrans file
+        subtrans_path = "/path/to/movie.subtrans"
+        project_path = project.GetProjectFilepath(subtrans_path)
+        expected_path = os.path.normpath(subtrans_path)
+        actual_path = os.path.normpath(project_path)
+        log_input_expected_result("subtrans unchanged", expected_path, actual_path)
+        self.assertEqual(actual_path, expected_path)
+
+        # Test with no extension
+        no_ext_path = "/path/to/movie"
+        project_path = project.GetProjectFilepath(no_ext_path)
+        expected_path = os.path.normpath("/path/to/movie.subtrans")
+        actual_path = os.path.normpath(project_path)
+        log_input_expected_result("no extension to subtrans", expected_path, actual_path)
+        self.assertEqual(actual_path, expected_path)
+
+    def test_get_backup_filepath(self):
+        """Test GetBackupFilepath method"""
+
+        project = SubtitleProject()
+
+        filepath = "/path/to/movie.srt"
+        backup_path = project.GetBackupFilepath(filepath)
+        expected_backup = os.path.normpath("/path/to/movie.subtrans-backup")
+        actual_backup = os.path.normpath(backup_path)
+        log_input_expected_result("backup filepath", expected_backup, actual_backup)
+        self.assertEqual(actual_backup, expected_backup)
+
+    def test_properties(self):
+        """Test project properties"""
+
+        project = SubtitleProject()
+
+        # Test initial property values
+        log_input_expected_result("initial target_language", None, project.target_language)
+        log_input_expected_result("initial task_type", None, project.task_type)
+        log_input_expected_result("initial movie_name", None, project.movie_name)
+        log_input_expected_result("initial any_translated", False, project.any_translated)
+        log_input_expected_result("initial all_translated", False, project.all_translated)
+
+        self.assertIsNone(project.target_language)
+        self.assertIsNone(project.task_type)
+        self.assertIsNone(project.movie_name)
+        self.assertFalse(project.any_translated)
+        self.assertFalse(project.all_translated)
+
+        # Update settings and test properties reflect changes
+        settings = SettingsType({
+            'target_language': 'Russian',
+            'task_type': 'translation',
+            'movie_name': 'Property Test Movie'
+        })
+        project.UpdateProjectSettings(settings)
+
+        log_input_expected_result("updated target_language", 'Russian', project.target_language)
+        log_input_expected_result("updated task_type", 'translation', project.task_type)
+        log_input_expected_result("updated movie_name", 'Property Test Movie', project.movie_name)
+
+        self.assertEqual(project.target_language, 'Russian')
+        self.assertEqual(project.task_type, 'translation')
+        self.assertEqual(project.movie_name, 'Property Test Movie')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/PySubtrans/UnitTests/test_SubtitleProjectFormats.py
+++ b/PySubtrans/UnitTests/test_SubtitleProjectFormats.py
@@ -10,6 +10,7 @@ from PySubtrans.SubtitleFileHandler import SubtitleFileHandler
 from PySubtrans.SubtitleData import SubtitleData
 from PySubtrans.Formats.SrtFileHandler import SrtFileHandler
 from PySubtrans.Formats.SSAFileHandler import SSAFileHandler
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleSerialisation import SubtitleEncoder, SubtitleDecoder
 from PySubtrans.Subtitles import Subtitles
 from PySubtrans.Helpers.Color import Color
@@ -430,8 +431,9 @@ Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello ASS!
         log_input_expected_result("format after setting output path", ".srt", project.subtitles.file_format)
         self.assertEqual(project.subtitles.file_format, ".srt")
         
-        project.subtitles.AutoBatch(SubtitleBatcher(options))
-        project.subtitles._duplicate_originals_as_translations()
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.AutoBatch(SubtitleBatcher(options))
+            editor.DuplicateOriginalsAsTranslations()
         project.needs_writing = True
         project.SaveTranslation()
         
@@ -471,8 +473,9 @@ Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello ASS!
         log_input_expected_result("format after setting output path", ".ass", project.subtitles.file_format)
         self.assertEqual(project.subtitles.file_format, ".ass")
         
-        project.subtitles.AutoBatch(SubtitleBatcher(options))
-        project.subtitles._duplicate_originals_as_translations()
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.AutoBatch(SubtitleBatcher(options))
+            editor.DuplicateOriginalsAsTranslations()
         project.needs_writing = True
         project.SaveTranslation()
         
@@ -510,8 +513,9 @@ Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello ASS!
         log_input_expected_result("project.subtitles not None", True, project.subtitles is not None)
         self.assertIsNotNone(project.subtitles)
         
-        project.subtitles.AutoBatch(SubtitleBatcher(options))
-        project.subtitles._duplicate_originals_as_translations()
+        with SubtitleEditor(project.subtitles) as editor:
+            editor.AutoBatch(SubtitleBatcher(options))
+            editor.DuplicateOriginalsAsTranslations()
         project.needs_writing = True
         
         # Create and write project file

--- a/PySubtrans/UnitTests/test_Translator.py
+++ b/PySubtrans/UnitTests/test_Translator.py
@@ -5,6 +5,7 @@ from PySubtrans.Helpers.TestCases import DummyProvider, PrepareSubtitles, Subtit
 from PySubtrans.Helpers.Tests import log_info, log_input_expected_result, log_test_name
 from PySubtrans.SubtitleBatch import SubtitleBatch
 from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.Subtitles import Subtitles
 from PySubtrans.SubtitleScene import SubtitleScene
 from PySubtrans.SubtitleTranslator import SubtitleTranslator
@@ -33,8 +34,10 @@ class SubtitleTranslatorTests(SubtitleTestCase):
             self.assertEqual(originals.linecount, reference.linecount)
 
             batcher = SubtitleBatcher(self.options)
-            originals.AutoBatch(batcher)
-            reference.AutoBatch(batcher)
+            with SubtitleEditor(originals) as editor:
+                editor.AutoBatch(batcher)
+            with SubtitleEditor(reference) as editor:
+                editor.AutoBatch(batcher)
 
             self.assertEqual(len(originals.scenes), len(reference.scenes))
 
@@ -56,8 +59,8 @@ class SubtitleTranslatorTests(SubtitleTestCase):
         log_info(f"Scene: {batch.context.get('scene')}")
         self.assertIsNotNone(batch.context.get('scene'))
 
-        self.assertEqual(batch.context.get('movie_name'), original.movie_name)
-        self.assertEqual(batch.context.get('description'), original.settings.get('description'))
+        self.assertEqual(batch.context.get('movie_name'), original.settings.get_str('movie_name'))
+        self.assertEqual(batch.context.get('description'), original.settings.get_str('description'))
         batch_names = ParseNames(batch.context.get('names'))
         original_names = ParseNames(original.settings.get('names'))
         self.assertSequenceEqual(batch_names, original_names)
@@ -106,8 +109,10 @@ class SubtitleTranslatorTests(SubtitleTestCase):
             self.assertEqual(originals.linecount, reference.linecount)
 
             batcher = SubtitleBatcher(self.options)
-            originals.AutoBatch(batcher)
-            reference.AutoBatch(batcher)
+            with SubtitleEditor(originals) as editor:
+                editor.AutoBatch(batcher)
+            with SubtitleEditor(reference) as editor:
+                editor.AutoBatch(batcher)
 
             self.assertEqual(len(originals.scenes), len(reference.scenes))
 

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -50,9 +50,9 @@ def init_options(
     Parameters
     ----------
     provider : str or None, optional
-        The name of the translation provider to use (e.g., "openai", "google").
+        The name of the translation provider to use (e.g., "openai", "gemini").
     model : str or None, optional
-        The model identifier to use for translation (e.g., "gpt-3.5-turbo").
+        The model identifier to use for translation (e.g., "gpt-5-mini").
     api_key : str or None, optional
         API key for authenticating with the translation provider.
     prompt : str or None, optional
@@ -169,7 +169,7 @@ def init_translator(settings: Options|Mapping[str, SettingType]) -> SubtitleTran
 
     Create translator from dictionary:
 
-    >>> settings = {"provider": "google", "api_key": "your-key"}
+    >>> settings = {"provider": "gemini", "api_key": "your-key", "model": "gemini-2.5-flash"}
     >>> translator = init_translator(settings)
     """
     if not isinstance(settings, Options):

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from PySubtrans.Helpers import GetInputPath
+from PySubtrans.Options import Options
+from PySubtrans.SettingsType import SettingType, SettingsType
+from PySubtrans.SubtitleProject import SubtitleProject
+from PySubtrans.SubtitleTranslator import SubtitleTranslator
+from PySubtrans.TranslationProvider import TranslationProvider
+from PySubtrans.version import __version__
+
+
+def init_options(
+    provider: str|None = None,
+    model: str|None = None,
+    api_key: str|None = None,
+    instruction_file: str|None = None,
+    **settings: SettingType,
+) -> Options:
+    """
+    Create and return an :class:`Options` instance configured for a translation provider.
+
+    Parameters
+    ----------
+    provider : str or None, optional
+        The name of the translation provider to use (e.g., "openai", "google").
+    model : str or None, optional
+        The model identifier to use for translation (e.g., "gpt-3.5-turbo").
+    api_key : str or None, optional
+        API key for authenticating with the translation provider.
+    instruction_file : str or None, optional
+        Path to a file containing custom translation instructions.
+    **settings : SettingType
+        Additional keyword settings to configure the translation provider.
+
+    Returns
+    -------
+    Options
+        An Options instance with the specified configuration.
+
+    Examples
+    --------
+    >>> from PySubtrans import init_options
+    >>> opts = init_options(provider="openai", model="gpt-3.5-turbo", api_key="sk-...", custom_setting="value")
+    >>> print(opts.provider)
+    openai
+    """
+    combined_settings = SettingsType(settings)
+
+    explicit_settings = {
+        'provider': provider,
+        'model': model,
+        'api_key': api_key,
+        'instruction_file': instruction_file,
+    }
+    combined_settings.update({k: v for k, v in explicit_settings.items() if v is not None})
+
+    return Options(combined_settings)
+
+
+def init_project(filepath: str|None, persistent: bool = False) -> SubtitleProject:
+    """
+    Create a :class:`SubtitleProject` and optionally load subtitles from *filepath*.
+
+    Parameters
+    ----------
+    filepath : str or None
+        Path to the subtitle file to load into the project.
+    persistent : bool, optional
+        If True, enables persistent project state by creating and managing a
+        `.subtrans` project file in the working directory. This allows the project
+        to be saved and restored across sessions. If False (default), the project
+        is not persisted to disk.
+
+    Returns
+    -------
+    SubtitleProject
+        The initialized subtitle project.
+    """
+    project = SubtitleProject(persistent=persistent)
+    normalised_path = GetInputPath(filepath)
+
+    if normalised_path:
+        project.InitialiseProject(normalised_path)
+
+    return project
+
+
+def init_translator(project: SubtitleProject, settings: Options|Mapping[str, SettingType]) -> SubtitleTranslator:
+    """
+    Return a ready-to-use :class:`SubtitleTranslator` for the given subtitle project using the specified settings.
+
+    Parameters
+    ----------
+    project : SubtitleProject
+        The subtitle project to be translated. Must be an instance of :class:`SubtitleProject`.
+    settings : Options or Mapping[str, SettingType]
+        The translation settings. Can be an :class:`Options` instance or a mapping of option values.
+
+    Validation
+    ----------
+    - Checks that `project` is a :class:`SubtitleProject` instance.
+    - Checks that `settings` is either an :class:`Options` instance or a mapping; if a mapping, it is converted to :class:`Options`.
+    - Validates the settings for the translation provider.
+
+    Exceptions
+    ----------
+    TypeError
+        If `project` is not a :class:`SubtitleProject` instance, or if `settings` is not an :class:`Options` instance or a mapping.
+    ValueError
+        If the settings are invalid for the selected translation provider.
+
+    Returns
+    -------
+    SubtitleTranslator
+        A ready-to-use subtitle translator configured with the given settings.
+    """
+    if not isinstance(project, SubtitleProject):
+        raise TypeError("project must be a SubtitleProject instance")
+
+    if not isinstance(settings, Options):
+        if isinstance(settings, Mapping):
+            settings = Options(SettingsType(settings))
+        else:
+            raise TypeError("settings must be an Options instance or a mapping of option values")
+
+    project.UpdateProjectSettings(settings)
+
+    translation_provider = TranslationProvider.get_provider(settings)
+    if not translation_provider.ValidateSettings():
+        message = translation_provider.validation_message or f"Invalid settings for provider {settings.provider}"
+        raise ValueError(message)
+
+    settings.InitialiseInstructions()
+
+    return SubtitleTranslator(settings, translation_provider)
+
+
+__all__ = [
+    '__version__',
+    'Options',
+    'SubtitleProject',
+    'SubtitleTranslator',
+    'TranslationProvider',
+    'init_options',
+    'init_project',
+    'init_translator',
+]

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -28,6 +28,7 @@ from PySubtrans.Helpers import GetInputPath
 from PySubtrans.Options import Options
 from PySubtrans.SettingsType import SettingType, SettingsType
 from PySubtrans.SubtitleBuilder import SubtitleBuilder
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleFormatRegistry import SubtitleFormatRegistry
 from PySubtrans.Subtitles import Subtitles
 from PySubtrans.SubtitleScene import SubtitleScene
@@ -253,7 +254,8 @@ def preprocess_subtitles(subtitles: Subtitles, options: Options) -> None:
         raise ValueError("No subtitles to preprocess")
 
     preprocessor = SubtitleProcessor(options)
-    subtitles.PreProcess(preprocessor)
+    with SubtitleEditor(subtitles) as editor:
+        editor.PreProcess(preprocessor)
 
 __all__ = [
     '__version__',
@@ -261,6 +263,7 @@ __all__ = [
     'Subtitles',
     'SubtitleScene',
     'SubtitleBuilder',
+    'SubtitleEditor',
     'SubtitleProject',
     'SubtitleTranslator',
     'TranslationProvider',

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -187,7 +187,7 @@ def init_translator(settings: Options|Mapping[str, SettingType]) -> SubtitleTran
     return SubtitleTranslator(settings, translation_provider)
 
 
-def init_project(filepath: str|None, persistent: bool = False) -> SubtitleProject:
+def init_project(filepath: str|None, persistent: bool = False, translation_settings: Options|Mapping[str, SettingType]|None = None) -> SubtitleProject:
     """
     Create a :class:`SubtitleProject` and optionally load subtitles from *filepath*.
 
@@ -197,6 +197,8 @@ def init_project(filepath: str|None, persistent: bool = False) -> SubtitleProjec
         Path to the subtitle file to load into the project.
     persistent : bool, optional
         If True, enables persistent project state by creating a`.subtrans` project file for the job.
+    translation_settings : Options, Mapping[str, SettingType], or None, optional
+        Translation settings to configure the translator. If provided, the translator will be automatically initialized.
 
     Returns
     -------
@@ -210,6 +212,12 @@ def init_project(filepath: str|None, persistent: bool = False) -> SubtitleProjec
     >>> from PySubtrans import init_project
     >>> project = init_project("movie.srt")
 
+    Create a project with translator ready for translation:
+
+    >>> settings = {"provider": "OpenAI", "model": "gpt-4o", "target_language": "Spanish", "api_key": "your-key"}
+    >>> project = init_project("movie.srt", translation_settings=settings)
+    >>> project.TranslateSubtitles()
+
     Create a persistent project:
 
     >>> project = init_project("movie.srt", persistent=True)
@@ -220,6 +228,15 @@ def init_project(filepath: str|None, persistent: bool = False) -> SubtitleProjec
 
     if normalised_path:
         project.InitialiseProject(normalised_path)
+
+    if translation_settings:
+        if not isinstance(translation_settings, Options):
+            if isinstance(translation_settings, Mapping):
+                translation_settings = Options(SettingsType(translation_settings))
+            else:
+                raise TypeError("translation_settings must be an Options instance or a mapping of option values")
+
+        project.InitialiseTranslator(translation_settings)
 
     return project
 

--- a/PySubtrans/pyproject.toml
+++ b/PySubtrans/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pysubtrans"
+version = "1.4.0"
+description = "Core subtitle translation toolkit used by LLM-Subtrans"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+dependencies = [
+    "python-dotenv",
+    "srt",
+    "pysubs2",
+    "regex",
+    "babel",
+    "appdirs",
+    "events",
+    "requests",
+    "setuptools",
+    "httpx",
+    "httpx[socks]"
+]
+
+[project.optional-dependencies]
+openai = [
+    "openai"
+]
+azure = [
+    "openai"
+]
+gemini = [
+    "google-genai",
+    "google-api-core"
+]
+claude = [
+    "anthropic"
+]
+mistral = [
+    "mistralai"
+]
+bedrock = [
+    "boto3"
+]
+
+[project.urls]
+Homepage = "https://github.com/machinewrapped/llm-subtrans"
+Documentation = "https://github.com/machinewrapped/llm-subtrans/blob/main/PySubtrans/README.md"
+Source = "https://github.com/machinewrapped/llm-subtrans"
+Issues = "https://github.com/machinewrapped/llm-subtrans/issues"
+
+[tool.setuptools]
+package-dir = {"" = ".."}
+
+[tool.setuptools.packages.find]
+where = [".."]
+include = ["PySubtrans*"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,19 +26,21 @@ Contains all subtitle processing, translation logic, and project management. Thi
 - File format support and parsing
 
 **Key Classes:**
-- `SubtitleProject` – main orchestrator managing translation sessions
-- `Subtitles`, `SubtitleScene`, `SubtitleBatch` – hierarchical organization splitting files into manageable translation units
+- `Subtitles` – container for subtitle data with thread-safe access patterns
+- `SubtitleScene`, `SubtitleBatch` – hierarchical organization splitting files into manageable translation units
 - `SubtitleLine` – represents individual subtitles with timing, text, and translation data
+- `Options` – centralized settings management
+- `SubtitleProject` – orchestrator managing translation sessions and project persistence
 - `SubtitleTranslator` – executes translation jobs, handles retries and errors
 - `TranslationProvider` – base class for pluggable backends (OpenAI, Anthropic, etc.)
-- `Options` – centralized settings management
+- `SubtitleBuilder` – fluent API for programmatically building subtitle structures
+- `SubtitleEditor` – handles mutation operations on subtitle data with thread safety
 
 ### Subtitle Format Handling
 Subtitle files are processed through a pluggable system:
 - `SubtitleFileHandler` implementations read and write specific formats while exposing a common interface.
 - `SubtitleFormatRegistry` discovers handlers in `PySubtrans/Formats/` and maps file extensions to the appropriate handler based on priority.
 - `SubtitleProject` uses the registry to detect formats from filenames and can convert subtitles when the output extension differs from the source.
-CLI tools expose `--list-formats` to enumerate supported extensions.
 
 ### GuiSubtrans (User Interface)
 PySide6-based interface using MVVM pattern. Work here for UI features, dialogs, and user interactions.
@@ -51,13 +53,27 @@ PySide6-based interface using MVVM pattern. Work here for UI features, dialogs, 
 
 ## Data Organization
 
-**SubtitleProject** manages translation sessions, loading subtitle files and saving/loading `.subtrans` project files (JSON format containing subtitles, translations, and metadata).
-
 ### Data Hierarchy
-- `Subtitles` – top-level container with subtitle content and metadata
+- `Subtitles` – top-level container with subtitle content and metadata, provides thread-safe access to scenes and lines
 - `SubtitleScene` – a time-sliced section of subtitles, grouped into batches
 - `SubtitleBatch` – groups of lines within a scene, split into chunks for translation
 - `SubtitleLine` – individual subtitle with index, timing, text and metadata
+
+### SubtitleProject
+Manages translation sessions and project persistence. It orchestrates loading subtitle files, saving/loading `.subtrans` project files (JSON format containing subtitles, translations, and metadata), and coordinates project settings management.
+
+### SubtitleBatcher
+Pre-processes subtitles to divide them into scenes and batches ready for translation. Scene detection threshold and maximum batch size are configurable.
+
+### SubtitleBuilder
+The `SubtitleBuilder` class provides a fluent API for constructing `Subtitles`.
+- Automatic scene and batch organization based on configurable size limits
+- Integration with `SubtitleBatcher` for intelligent scene subdivision
+
+### SubtitleEditor
+Mutation operations on subtitle data should go through the `SubtitleEditor` class to ensure proper thread safety when adding/removing/merging/splitting scenes, batches and lines.
+
+Also provides methods for preprocessing, auto-batching and data sanitization.
 
 ## Translation Process
 
@@ -65,8 +81,7 @@ PySide6-based interface using MVVM pattern. Work here for UI features, dialogs, 
 - Splits `Subtitles` into scenes and batches for processing
 - Builds prompts with context for each batch
 - Delegates to `TranslationProvider` clients for API calls
-- Applies substitutions and merges results back into subtitle data
-- Handles retries, error management, and post-processing
+- Handles retries, error management and post-processing
 - Emits `TranslationEvents` with progress updates
 
 ### TranslationProvider System
@@ -105,17 +120,21 @@ These views are responsible for displaying the data from the `ProjectViewModel` 
 ### Command Queue
 GUI operations use the Command pattern for background execution and undo/redo support:
 
-- **`CommandQueue`** – executes commands on background `QThreadPool`, manages concurrency and synchronisation
+- **CommandQueue** – executes commands on background `QThreadPool`, manages concurrency and synchronisation
 - **Commands** – in `GuiSubtrans/Commands/`, encapsulate operations (translation, file I/O, etc.)
 - **Undo/Redo** – maintained via `undo_stack` and `redo_stack`
 
 ## Settings Management
-Application settings are managed by the `PySubtrans.Options` class. This class is responsible for:
+Application settings are managed through a layered system:
 
-- Loading settings from a `settings.json` file.
-- Loading settings from environment variables.
-- Providing default values for all settings.
+**`SettingsType`** - generic type-safe settings container
 - Provides typed getters (`get_str`, `get_int`, `get_bool`) and convenience properties
+
+**`PySubtrans.Options`** 
+- application-specific `SettingsType`
+- Provides default values for all application settings
+- Loads settings from a `settings.json` file
+- Import settings from environment variables and command line arguments
 - Supports project-specific and provider-specific settings
 
 ## GUI Widget Architecture
@@ -215,9 +234,11 @@ The specific format for translation requests can vary by provider and responses 
 ## Extending the System
 
 - **New file formats** → `PySubtrans/` (add file handler, extend `SubtitleFileHandler`)
-- **Translation providers** → `PySubtrans/Providers/` (subclass `TranslationProvider` and `TranslationClient`)  
+- **Translation providers** → `PySubtrans/Providers/` (subclass `TranslationProvider` and `TranslationClient`)
 - **GUI features** → `GuiSubtrans/Widgets/` (new views/dialogs), `GuiSubtrans/Commands/` (new operations)
 - **Settings** → update `Options` schema, add to `SettingsDialog.SECTIONS`
 - **Background operations** → implement `Command` pattern in `GuiSubtrans/Commands/` for thread safety and undo support
 
-**Key principle:** All operations that modify project data must go through the `CommandQueue` to maintain thread safety and undo/redo functionality.
+**Key principles:**
+- All operations that modify project data must go through the `CommandQueue` to maintain thread safety and undo/redo functionality.
+- All subtitle mutations should use a `SubtitleEditor` for lock management.

--- a/scripts/azure-subtrans.py
+++ b/scripts/azure-subtrans.py
@@ -8,7 +8,6 @@ from scripts.subtrans_common import (
     InitLogger,
     CreateArgParser,
     CreateOptions,
-    CreateTranslator,
     CreateProject,
 )
 from PySubtrans.Options import Options
@@ -44,11 +43,11 @@ try:
     # Create a project for the translation
     project : SubtitleProject = CreateProject(options, args)
 
-    # Create a translator with the provided options
-    translator : SubtitleTranslator = CreateTranslator(options)
+    # Initialize the translator with the provided options
+    project.InitialiseTranslator(options)
 
     # Translate the subtitles
-    project.TranslateSubtitles(translator)
+    project.TranslateSubtitles()
 
     if project.use_project_file:
         logging.info(f"Writing project data to {str(project.projectfile)}")

--- a/scripts/bedrock-subtrans.py
+++ b/scripts/bedrock-subtrans.py
@@ -8,7 +8,6 @@ from scripts.subtrans_common import (
     InitLogger,
     CreateArgParser,
     CreateOptions,
-    CreateTranslator,
     CreateProject,
 )
 from PySubtrans.Options import Options
@@ -48,11 +47,11 @@ try:
     # Create a project for the translation
     project: SubtitleProject = CreateProject(options, args)
 
-    # Create a translator with the provided options
-    translator: SubtitleTranslator = CreateTranslator(options)
+    # Initialize the translator with the provided options
+    project.InitialiseTranslator(options)
 
     # Translate the subtitles
-    project.TranslateSubtitles(translator)
+    project.TranslateSubtitles()
 
     if project.use_project_file:
         logging.info(f"Writing project data to {str(project.projectfile)}")

--- a/scripts/claude-subtrans.py
+++ b/scripts/claude-subtrans.py
@@ -8,7 +8,6 @@ from scripts.subtrans_common import (
     InitLogger,
     CreateArgParser,
     CreateOptions,
-    CreateTranslator,
     CreateProject,
 )
 
@@ -33,11 +32,11 @@ try:
     # Create a project for the translation
     project : SubtitleProject = CreateProject(options, args)
 
-    # Create a translator with the provided options
-    translator : SubtitleTranslator = CreateTranslator(options)
+    # Initialize the translator with the provided options
+    project.InitialiseTranslator(options)
 
     # Translate the subtitles
-    project.TranslateSubtitles(translator)
+    project.TranslateSubtitles()
 
     if project.use_project_file:
         logging.info(f"Writing project data to {str(project.projectfile)}")

--- a/scripts/deepseek-subtrans.py
+++ b/scripts/deepseek-subtrans.py
@@ -8,7 +8,6 @@ from scripts.subtrans_common import (
     InitLogger,
     CreateArgParser,
     CreateOptions,
-    CreateTranslator,
     CreateProject,
 )
 
@@ -38,11 +37,11 @@ try:
     # Create a project for the translation
     project : SubtitleProject = CreateProject(options, args)
 
-    # Create a translator with the provided options
-    translator : SubtitleTranslator = CreateTranslator(options)
+    # Initialize the translator with the provided options
+    project.InitialiseTranslator(options)
 
     # Translate the subtitles
-    project.TranslateSubtitles(translator)
+    project.TranslateSubtitles()
 
     if project.use_project_file:
         logging.info(f"Writing project data to {str(project.projectfile)}")

--- a/scripts/gemini-subtrans.py
+++ b/scripts/gemini-subtrans.py
@@ -8,7 +8,6 @@ from scripts.subtrans_common import (
     InitLogger,
     CreateArgParser,
     CreateOptions,
-    CreateTranslator,
     CreateProject,
 )
 
@@ -32,11 +31,11 @@ try:
     # Create a project for the translation
     project : SubtitleProject = CreateProject(options, args)
 
-    # Create a translator with the provided options
-    translator : SubtitleTranslator = CreateTranslator(options)
+    # Initialize the translator with the provided options
+    project.InitialiseTranslator(options)
 
     # Translate the subtitles
-    project.TranslateSubtitles(translator)
+    project.TranslateSubtitles()
 
     if project.use_project_file:
         logging.info(f"Writing project data to {str(project.projectfile)}")

--- a/scripts/gpt-subtrans.py
+++ b/scripts/gpt-subtrans.py
@@ -8,7 +8,6 @@ from scripts.subtrans_common import (
     InitLogger,
     CreateArgParser,
     CreateOptions,
-    CreateTranslator,
     CreateProject,
 )
 
@@ -43,11 +42,11 @@ try:
     # Create a project for the translation
     project : SubtitleProject = CreateProject(options, args)
 
-    # Create a translator with the provided options
-    translator : SubtitleTranslator = CreateTranslator(options)
+    # Initialize the translator with the provided options
+    project.InitialiseTranslator(options)
 
     # Translate the subtitles
-    project.TranslateSubtitles(translator)
+    project.TranslateSubtitles()
 
     if project.use_project_file:
         logging.info(f"Writing project data to {str(project.projectfile)}")

--- a/scripts/llm-subtrans.py
+++ b/scripts/llm-subtrans.py
@@ -7,7 +7,6 @@ from scripts.subtrans_common import (
     InitLogger,
     CreateArgParser,
     CreateOptions,
-    CreateTranslator,
     CreateProject,
 )
 
@@ -55,10 +54,10 @@ try:
     # Create a project for the translation
     project : SubtitleProject = CreateProject(options, args)
 
-    # Create a translator with the provided options
-    translator : SubtitleTranslator = CreateTranslator(options)
+    # Initialize the translator with the provided options
+    project.InitialiseTranslator(options)
 
-    project.TranslateSubtitles(translator)
+    project.TranslateSubtitles()
 
     if project.use_project_file:
         logging.info(f"Writing project data to {str(project.projectfile)}")

--- a/scripts/mistral-subtrans.py
+++ b/scripts/mistral-subtrans.py
@@ -8,7 +8,6 @@ from scripts.subtrans_common import (
     InitLogger,
     CreateArgParser,
     CreateOptions,
-    CreateTranslator,
     CreateProject,
 )
 
@@ -38,11 +37,11 @@ try:
     # Create a project for the translation
     project : SubtitleProject = CreateProject(options, args)
 
-    # Create a translator with the provided options
-    translator : SubtitleTranslator = CreateTranslator(options)
+    # Initialize the translator with the provided options
+    project.InitialiseTranslator(options)
 
     # Translate the subtitles
-    project.TranslateSubtitles(translator)
+    project.TranslateSubtitles()
 
     if project.use_project_file:
         logging.info(f"Writing project data to {str(project.projectfile)}")

--- a/scripts/publish_package.py
+++ b/scripts/publish_package.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib  # type: ignore
+
+PACKAGE_NAME = "pysubtrans"
+PACKAGE_DESCRIPTION = "Core subtitle translation toolkit used by LLM-Subtrans"
+HOMEPAGE_URL = "https://github.com/machinewrapped/llm-subtrans"
+DOCUMENTATION_URL = "https://github.com/machinewrapped/llm-subtrans/blob/main/PySubtrans/README.md"
+ISSUES_URL = "https://github.com/machinewrapped/llm-subtrans/issues"
+
+
+def ParseArguments() -> argparse.Namespace:
+    """Parse command line arguments for the publish workflow."""
+    parser = argparse.ArgumentParser(description="Build and publish the PySubtrans package")
+    parser.add_argument("--yes", action="store_true", help="Assume yes for all confirmation prompts")
+    parser.add_argument("--skip-upload", action="store_true", help="Skip the upload step")
+    parser.add_argument("--repository", type=str, default=None, help="Named repository configured in ~/.pypirc (e.g. testpypi)")
+    return parser.parse_args()
+
+
+def LoadToml(path: Path) -> dict[str, Any]:
+    """Load a TOML file into a dictionary."""
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def FormatTomlList(items: list[str], indent: int = 4) -> str:
+    """Format a list of strings as a TOML array."""
+    if not items:
+        return "[]"
+
+    indent_str = " " * indent
+    joined_items = ",\n".join(f'{indent_str}"{item}"' for item in items)
+    closing_indent = " " * max(indent - 4, 0)
+    return f"[\n{joined_items}\n{closing_indent}]"
+
+
+def WritePackageToml(
+    path: Path,
+    version: str,
+    dependencies: list[str],
+    optional_dependencies: dict[str, list[str]],
+    requires_python: str,
+) -> None:
+    """Write the dedicated PySubtrans pyproject file."""
+    dependencies_block = FormatTomlList(dependencies)
+
+    lines: list[str] = [
+        "[build-system]",
+        'requires = ["setuptools>=61.0"]',
+        'build-backend = "setuptools.build_meta"',
+        "",
+        "[project]",
+        f'name = "{PACKAGE_NAME}"',
+        f'version = "{version}"',
+        f'description = "{PACKAGE_DESCRIPTION}"',
+        'readme = "README.md"',
+        f'requires-python = "{requires_python}"',
+        'license = {file = "LICENSE"}',
+        f"dependencies = {dependencies_block}",
+        "",
+    ]
+
+    if optional_dependencies:
+        lines.append("[project.optional-dependencies]")
+        for extra, packages in optional_dependencies.items():
+            lines.append(f"{extra} = {FormatTomlList(packages)}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "[project.urls]",
+            f'Homepage = "{HOMEPAGE_URL}"',
+            f'Documentation = "{DOCUMENTATION_URL}"',
+            f'Source = "{HOMEPAGE_URL}"',
+            f'Issues = "{ISSUES_URL}"',
+            "",
+            "[tool.setuptools]",
+            'package-dir = {"" = ".."}',
+            "",
+            "[tool.setuptools.packages.find]",
+            'where = [".."]',
+            'include = ["PySubtrans*"]',
+            "",
+        ]
+    )
+
+    content = "\n".join(lines).rstrip() + "\n"
+    path.write_text(content, encoding="utf-8")
+
+
+def PrintSummary(version: str, dependencies: list[str], optional: dict[str, list[str]]) -> None:
+    """Display the key package metadata before building."""
+    print("PySubtrans package configuration")
+    print(f"  Version: {version}")
+    print("  Dependencies:")
+    for dependency in dependencies:
+        print(f"    - {dependency}")
+
+    if optional:
+        print("  Optional extras:")
+        for name, packages in optional.items():
+            package_list = ", ".join(packages)
+            print(f"    - {name}: {package_list}")
+
+
+def Confirm(prompt: str, assume_yes: bool = False) -> bool:
+    """Ask the user for confirmation."""
+    if assume_yes:
+        print(f"{prompt} [auto-yes]")
+        return True
+
+    try:
+        response = input(f"{prompt} [y/N]: ").strip().lower()
+    except EOFError:
+        return False
+
+    return response in {"y", "yes"}
+
+
+def EnsureBuildTools(upload_requested: bool) -> None:
+    """Validate that build and upload tooling is available."""
+    if importlib.util.find_spec("build") is None:
+        raise ModuleNotFoundError(
+            "The 'build' package is required. Install it with 'pip install build'."
+        )
+
+    if upload_requested and importlib.util.find_spec("twine") is None:
+        raise ModuleNotFoundError(
+            "The 'twine' package is required for uploads. Install it with 'pip install twine'."
+        )
+
+
+def CleanBuildArtifacts(package_dir: Path) -> None:
+    """Remove previous build artefacts to ensure a clean build."""
+    for folder_name in ("build", "dist"):
+        folder = package_dir / folder_name
+        if folder.exists():
+            shutil.rmtree(folder)
+
+    for egg_info in package_dir.glob("*.egg-info"):
+        if egg_info.is_dir():
+            shutil.rmtree(egg_info)
+        else:
+            egg_info.unlink()
+
+
+def BuildPackage(package_dir: Path) -> None:
+    """Build the wheel and source distribution for PySubtrans."""
+    command = [sys.executable, "-m", "build"]
+    subprocess.run(command, cwd=package_dir, check=True)
+
+
+def UploadPackage(dist_dir: Path, repository: str|None = None) -> None:
+    """Upload the built distributions using twine."""
+    if not dist_dir.exists():
+        raise FileNotFoundError(f"Distribution directory {dist_dir} does not exist")
+
+    distributions = sorted(dist_dir.glob("*"))
+    if not distributions:
+        raise FileNotFoundError("No distribution files found to upload")
+
+    command = [sys.executable, "-m", "twine", "upload"]
+    if repository:
+        command.extend(["--repository", repository])
+
+    command.extend(str(path) for path in distributions)
+    subprocess.run(command, check=True)
+
+
+def Main() -> None:
+    """Entrypoint for the publish helper."""
+    args = ParseArguments()
+
+    project_root = Path(__file__).resolve().parent.parent
+    root_pyproject = project_root / "pyproject.toml"
+    package_dir = project_root / "PySubtrans"
+    package_pyproject = package_dir / "pyproject.toml"
+
+    if not root_pyproject.exists():
+        raise FileNotFoundError("Unable to locate the root pyproject.toml")
+
+    if not package_dir.exists():
+        raise FileNotFoundError("PySubtrans directory does not exist")
+
+    root_config = LoadToml(root_pyproject)
+    project_config = root_config.get("project", {})
+
+    version = str(project_config.get("version", "0.0.0"))
+    requires_python = str(project_config.get("requires-python", ">=3.10"))
+    dependencies = list(project_config.get("dependencies", []))
+
+    optional = {
+        name: list(values)
+        for name, values in project_config.get("optional-dependencies", {}).items()
+        if name != "gui"
+    }
+
+    WritePackageToml(package_pyproject, version, dependencies, optional, requires_python)
+    PrintSummary(version, dependencies, optional)
+
+    try:
+        EnsureBuildTools(upload_requested=not args.skip_upload)
+    except ModuleNotFoundError as error:
+        print(error)
+        return
+
+    if not Confirm("Proceed with build?", assume_yes=args.yes):
+        print("Build cancelled")
+        return
+
+    CleanBuildArtifacts(package_dir)
+
+    try:
+        BuildPackage(package_dir)
+    except subprocess.CalledProcessError as error:
+        print(f"Build failed with exit code {error.returncode}")
+        raise
+
+    print(f"Build complete. Distributions written to {package_dir / 'dist'}")
+
+    if args.skip_upload:
+        print("Upload skipped as requested")
+        return
+
+    if Confirm("Upload package with twine?", assume_yes=args.yes):
+        try:
+            UploadPackage(package_dir / "dist", repository=args.repository)
+        except subprocess.CalledProcessError as error:
+            print(f"Upload failed with exit code {error.returncode}")
+            raise
+
+
+if __name__ == "__main__":
+    Main()

--- a/scripts/subtrans_common.py
+++ b/scripts/subtrans_common.py
@@ -190,3 +190,4 @@ def CreateProject(options : Options, args: Namespace) -> SubtitleProject:
     logging.info(f"Output path will be: {project.subtitles.outputpath}")
 
     return project
+


### PR DESCRIPTION
Incorporate a `SubtitleTranslator` into `SubtitleProject`. 

This simplifies usage and makes SubtitleProject more of a one-stop-shop for translation workflows.