### PR TITLE
Fix viewmodel AddLine gap calculation

### DIFF
--- a/PySubtrans/Helpers/Time.py
+++ b/PySubtrans/Helpers/Time.py
@@ -68,8 +68,11 @@ def TimedeltaToText(time: datetime.timedelta|None, include_milliseconds : bool =
     if time is None:
         return ""
 
-    total_seconds = int(time.total_seconds())
-    milliseconds = time.microseconds // 1000
+    negative = time < datetime.timedelta()
+    absolute_time = abs(time)
+
+    total_seconds = int(absolute_time.total_seconds())
+    milliseconds = absolute_time.microseconds // 1000
 
     hours, remainder = divmod(total_seconds, 3600)
     minutes, seconds = divmod(remainder, 60)
@@ -83,6 +86,9 @@ def TimedeltaToText(time: datetime.timedelta|None, include_milliseconds : bool =
 
     if include_milliseconds:
         time_str += f",{milliseconds:03d}"
+
+    if negative and time_str:
+        time_str = f"-{time_str}"
 
     return time_str
 

--- a/PySubtrans/UnitTests/test_Time.py
+++ b/PySubtrans/UnitTests/test_Time.py
@@ -47,13 +47,28 @@ class TestTimeHelpers(unittest.TestCase):
         (timedelta(seconds=0), "00,000", True),
         (timedelta(microseconds=999000), "00,999", True),
         (timedelta(microseconds=999), "00,000", True),
+        (-timedelta(hours=2, minutes=34, seconds=56, microseconds=789000), "-2:34:56,789", True),
+        (-timedelta(minutes=4, seconds=5, microseconds=0), "-04:05,000", True),
+        (-timedelta(seconds=45, microseconds=200000), "-45,200", True),
+        (-timedelta(seconds=5, microseconds=100000), "-05,100", True),
+        (-timedelta(milliseconds=500), "-00,500", True),
+        (-timedelta(hours=13, minutes=0, seconds=0), "-13:00:00,000", True),
+        (-timedelta(minutes=59, seconds=59), "-59:59,000", True),
+        (-timedelta(seconds=1), "-01,000", True),
         (timedelta(hours=2, minutes=34, seconds=56, microseconds=789000), "2:34:56", False),
         (timedelta(minutes=4, seconds=5, microseconds=0), "04:05", False),
         (timedelta(seconds=45, microseconds=200000), "45", False),
         (timedelta(hours=13, minutes=0, seconds=0), "13:00:00", False),
         (timedelta(minutes=59, seconds=59), "59:59", False),
         (timedelta(seconds=1), "01", False),
-        (timedelta(seconds=0), "00", False)
+        (timedelta(seconds=0), "00", False),
+        (-timedelta(hours=2, minutes=34, seconds=56, microseconds=789000), "-2:34:56", False),
+        (-timedelta(minutes=4, seconds=5, microseconds=0), "-04:05", False),
+        (-timedelta(seconds=45, microseconds=200000), "-45", False),
+        (-timedelta(hours=13, minutes=0, seconds=0), "-13:00:00", False),
+        (-timedelta(minutes=59, seconds=59), "-59:59", False),
+        (-timedelta(seconds=1), "-01", False),
+        (-timedelta(milliseconds=500), "-00", False)
     ]
 
     def test_TimeDeltaToText(self):


### PR DESCRIPTION
## Summary
- compute the gap for new lines using the preceding line's end time or a zero timedelta
- ensure gap strings are generated via TimedeltaToText when adding lines to the view model

## Testing
- python tests/unit_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68ce5a8d94b483298e3190985cd9d93f