### PR TITLE
Fix split scene view corruption

### DIFF
--- a/GuiSubtrans/ViewModel/ViewModel.py
+++ b/GuiSubtrans/ViewModel/ViewModel.py
@@ -29,6 +29,7 @@ class ProjectViewModel(QStandardItemModel):
         self.update_lock = QRecursiveMutex()
         self.debug_view : bool = os.environ.get("DEBUG_MODE") == "1"
         self.task_type : str = DEFAULT_TASK_TYPE
+        self._needs_layout_changed : bool = False
 
     def getRootItem(self) -> QStandardItem:
         return self.invisibleRootItem()
@@ -212,6 +213,11 @@ class ProjectViewModel(QStandardItemModel):
 
                 batch_item.lines = { item.number: item for item in line_items }
 
+        # Emit layoutChanged if flagged during updates
+        if self._needs_layout_changed:
+            self._needs_layout_changed = False
+            self.layoutChanged.emit()
+
     #############################################################################
 
     def AddScene(self, scene : SubtitleScene):
@@ -244,6 +250,8 @@ class ProjectViewModel(QStandardItemModel):
         self.model = {item.number: item for item in scene_items}
 
         self.endInsertRows()
+
+        self._needs_layout_changed = True
 
     def ReplaceScene(self, scene : SubtitleScene):
         logging.debug(f"Replacing scene {scene.number}")


### PR DESCRIPTION
The old crash in native Qt code returned, specifically after splitting a scene and then selecting a batch or scene (triggering a refresh of the SubtitleListModel).

Various fixes, including ensuring that the visible batches in SubtitleListModel are valid after a split scene operation, but ultimately making sure we call beginResetModel and endResetModel when there are additions or deletions to the viewmodel seems to be the only thing that stops it crashing. Luckily these operations are rare.
