### PR TITLE
Track expanded state and restore on layout changes

### DIFF
--- a/GuiSubtrans/ViewModel/SceneItem.py
+++ b/GuiSubtrans/ViewModel/SceneItem.py
@@ -29,6 +29,9 @@ class SceneItem(ViewModelItem):
         self._first_line_num: int|None = None
         self._last_line_num: int|None = None
 
+        # Track expansion state for persistence across model resets
+        self.expanded: bool = False
+
         self.setText(_("Scene {num}").format(num=scene.number))
         self.setData(self.scene_model, Qt.ItemDataRole.UserRole)
 

--- a/GuiSubtrans/Widgets/ScenesView.py
+++ b/GuiSubtrans/Widgets/ScenesView.py
@@ -50,8 +50,8 @@ class ScenesView(QTreeView):
         self.selectionModel().selectionChanged.connect(self._item_selected)
 
         # Track expansion state changes
-        self.expanded.connect(self._on_item_expanded)
-        self.collapsed.connect(self._on_item_collapsed)
+        self.expanded.connect(lambda index: self._set_item_expanded(index, True))
+        self.collapsed.connect(lambda index: self._set_item_expanded(index, False))
 
         # Connect to layout changes to restore expansion states
         model.layoutChanged.connect(self._restore_expanded_states)

--- a/GuiSubtrans/Widgets/ScenesView.py
+++ b/GuiSubtrans/Widgets/ScenesView.py
@@ -49,6 +49,13 @@ class ScenesView(QTreeView):
         self.setModel(model)
         self.selectionModel().selectionChanged.connect(self._item_selected)
 
+        # Track expansion state changes
+        self.expanded.connect(self._on_item_expanded)
+        self.collapsed.connect(self._on_item_collapsed)
+
+        # Connect to layout changes to restore expansion states
+        model.layoutChanged.connect(self._restore_expanded_states)
+
     def SelectAll(self):
         model = self.model()
         if not model:
@@ -151,3 +158,44 @@ class ScenesView(QTreeView):
 
     def UpdateUiLanguage(self):
         self.Populate(self.viewmodel)
+
+    def _on_item_expanded(self, index):
+        """ Track when an item is expanded """
+        model = self.model()
+        if not model:
+            return
+
+        scene_item = model.data(index, Qt.ItemDataRole.UserRole)
+        if isinstance(scene_item, SceneItem):
+            if not scene_item.expanded:
+                scene_item.expanded = True
+
+    def _on_item_collapsed(self, index):
+        """ Track when an item is collapsed """
+        model = self.model()
+        if not model:
+            return
+
+        scene_item = model.data(index, Qt.ItemDataRole.UserRole)
+        if isinstance(scene_item, SceneItem):
+            if scene_item.expanded:
+                scene_item.expanded = False
+
+    def _restore_expanded_states(self):
+        """ Restore the expanded states from SceneItem objects after layout changes """
+        model = self.model()
+        if not model:
+            return
+
+        try:
+            for row in range(model.rowCount()):
+                index = model.index(row, 0)
+                if not index.isValid():
+                    continue
+                scene_item = model.data(index, Qt.ItemDataRole.UserRole)
+                if isinstance(scene_item, SceneItem) and scene_item.expanded:
+                    self.expand(index)
+
+        except Exception as e:
+            logging.error(f"Error restoring expanded states: {e}")
+


### PR DESCRIPTION
The model resets in ViewModelUpdate cause ScenesView to collapse whenever scenes are split or merged, which results in a poor UX. Track the expanded state and manually restore it after a layout changed event to make the view more stable.