### PR TITLE
Refactor test helper datamodel creation

### DIFF
--- a/PySubtrans/Helpers/TestCases.py
+++ b/PySubtrans/Helpers/TestCases.py
@@ -1,10 +1,11 @@
 from copy import deepcopy
 from datetime import timedelta
 import unittest
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import regex
 
+from GuiSubtrans.ProjectDataModel import ProjectDataModel
 from PySubtrans.Helpers.Tests import log_test_name
 from PySubtrans.Options import Options, SettingsType
 from PySubtrans.SettingsType import SettingsType
@@ -20,6 +21,9 @@ from PySubtrans.TranslationClient import TranslationClient
 from PySubtrans.TranslationPrompt import TranslationPrompt
 from PySubtrans.TranslationRequest import TranslationRequest
 from PySubtrans.TranslationProvider import TranslationProvider
+
+if TYPE_CHECKING:
+    from PySubtrans.SubtitleProject import SubtitleProject
 
 class LoggedTestCase(unittest.TestCase):
     def setUp(self) -> None:
@@ -333,3 +337,8 @@ class DummyTranslationClient(TranslationClient):
             if user_prompt == request.prompt.user_prompt:
                 text = text.replace("\\n", "\n")
                 return Translation({'text': text})
+
+
+def create_project_datamodel(project : SubtitleProject|None = None, options : Options|SettingsType|None = None) -> ProjectDataModel:
+    """Create a ProjectDataModel for the given project and options."""
+    return ProjectDataModel(project, options)


### PR DESCRIPTION
## Summary
- import GuiSubtrans.ProjectDataModel at module scope for test helpers
- add a create_project_datamodel helper that instantiates ProjectDataModel directly

## Testing
- python tests/unit_tests.py *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68deda848e908329bd5e977fc0c90d51