### PR TITLE
Aggregate line assertions in TestableViewModel

### DIFF
--- a/GuiSubtrans/ViewModel/TestableViewModel.py
+++ b/GuiSubtrans/ViewModel/TestableViewModel.py
@@ -7,7 +7,6 @@ from GuiSubtrans.ViewModel.LineItem import LineItem
 from GuiSubtrans.ViewModel.SceneItem import SceneItem
 from GuiSubtrans.ViewModel.ViewModel import ProjectViewModel
 from PySubtrans.Helpers.TestCases import SubtitleTestCase
-from PySubtrans.Helpers.Tests import log_input_expected_result
 from PySubtrans.Subtitles import Subtitles
 
 
@@ -31,14 +30,10 @@ class TestableViewModel(ProjectViewModel):
         Scene numbers are stable identifiers, not row positions.
         """
         scene_item = self.model.get(scene_number)
-
-        log_input_expected_result(f"scene {scene_number} exists", True, scene_item is not None)
-        self.test.assertIsNotNone(scene_item)
-
-        log_input_expected_result(f"scene {scene_number} type", SceneItem, type(scene_item))
-        self.test.assertEqual(type(scene_item), SceneItem)
-
-        return cast(SceneItem, scene_item)
+        self.test.assertLoggedIsNotNone(f"scene {scene_number} exists", scene_item)
+        scene_item = cast(SceneItem, scene_item)
+        self.test.assertLoggedIsInstance(f"scene {scene_number} type", scene_item, SceneItem)
+        return scene_item
 
     def test_get_batch_item(self, scene_number : int, batch_number : int) -> BatchItem:
         """
@@ -46,14 +41,14 @@ class TestableViewModel(ProjectViewModel):
         """
         scene_item = self.test_get_scene_item(scene_number)
         batch_item_qt = scene_item.child(batch_number - 1, 0)
-
-        log_input_expected_result(f"batch ({scene_number},{batch_number}) exists", True, batch_item_qt is not None)
-        self.test.assertIsNotNone(batch_item_qt)
-
-        log_input_expected_result(f"batch ({scene_number},{batch_number}) type", BatchItem, type(batch_item_qt))
-        self.test.assertEqual(type(batch_item_qt), BatchItem)
-
-        return cast(BatchItem, batch_item_qt)
+        self.test.assertLoggedIsNotNone(f"batch ({scene_number},{batch_number}) exists", batch_item_qt)
+        batch_item_qt = cast(BatchItem, batch_item_qt)
+        self.test.assertLoggedIsInstance(
+            f"batch ({scene_number},{batch_number}) type",
+            batch_item_qt,
+            BatchItem,
+        )
+        return batch_item_qt
 
     def get_line_numbers_in_batch(self, scene_number : int, batch_number : int) -> list[int]:
         """
@@ -82,14 +77,22 @@ class TestableViewModel(ProjectViewModel):
             expected_count: Expected number of times signal was emitted (None = at least once)
         """
         matching_signals = [s for s in self.signal_history if s['signal'] == signal_name]
-
         if expected_count is None:
-            log_input_expected_result(f"{signal_name} emitted", True, len(matching_signals) > 0)
-            self.test.assertGreater(len(matching_signals), 0, f"Expected {signal_name} to be emitted")
+            self.test.assertLoggedGreater(
+                f"{signal_name} emitted count",
+                len(matching_signals),
+                0,
+                msg=f"Expected {signal_name} to be emitted",
+            )
         else:
-            log_input_expected_result(f"{signal_name} count", expected_count, len(matching_signals))
-            self.test.assertEqual(len(matching_signals), expected_count,
-                                f"Expected {signal_name} to be emitted {expected_count} times, got {len(matching_signals)}")
+            self.test.assertLoggedEqual(
+                f"{signal_name} count",
+                expected_count,
+                len(matching_signals),
+                msg=(
+                    f"Expected {signal_name} to be emitted {expected_count} times, got {len(matching_signals)}"
+                ),
+            )
 
         return matching_signals
 
@@ -101,9 +104,14 @@ class TestableViewModel(ProjectViewModel):
             signal_name: Name of the signal ('dataChanged', 'layoutChanged', 'modelReset')
         """
         matching_signals = [s for s in self.signal_history if s['signal'] == signal_name]
-        log_input_expected_result(f"{signal_name} not emitted", 0, len(matching_signals))
-        self.test.assertEqual(len(matching_signals), 0,
-                            f"Expected {signal_name} to NOT be emitted, but it was emitted {len(matching_signals)} times")
+        self.test.assertLoggedEqual(
+            f"{signal_name} not emitted",
+            0,
+            len(matching_signals),
+            msg=(
+                f"Expected {signal_name} to NOT be emitted, but it was emitted {len(matching_signals)} times"
+            ),
+        )
 
     def assert_scene_fields(self, test_data : list[tuple[int, str, Any]]) -> None:
         """
@@ -113,8 +121,11 @@ class TestableViewModel(ProjectViewModel):
         for scene_num, field, expected in test_data:
             scene = self.test_get_scene_item(scene_num)
             actual = getattr(scene, field)
-            log_input_expected_result(f"scene {scene_num} {field}", expected, actual)
-            self.test.assertEqual(actual, expected)
+            self.test.assertLoggedEqual(
+                f"scene {scene_num} {field}",
+                expected,
+                actual,
+            )
 
     def assert_batch_fields(self, test_data : list[tuple[int, int, str, Any]]) -> None:
         """
@@ -124,8 +135,11 @@ class TestableViewModel(ProjectViewModel):
         for scene_num, batch_num, field, expected in test_data:
             batch = self.test_get_batch_item(scene_num, batch_num)
             actual = getattr(batch, field)
-            log_input_expected_result(f"batch ({scene_num},{batch_num}) {field}", expected, actual)
-            self.test.assertEqual(actual, expected)
+            self.test.assertLoggedEqual(
+                f"batch ({scene_num},{batch_num}) {field}",
+                expected,
+                actual,
+            )
 
     def assert_line_contents(self, test_data : list[tuple[int, int, int, int, str]]) -> None:
         """
@@ -138,8 +152,11 @@ class TestableViewModel(ProjectViewModel):
             # Handle negative indices manually since Qt doesn't support them
             actual_idx = line_idx if line_idx >= 0 else batch.line_count + line_idx
             line = cast(LineItem, batch.child(actual_idx, 0))
-            log_input_expected_result(f"line ({absolute_line_num}) text", expected_text, line.line_text)
-            self.test.assertEqual(line.line_text, expected_text)
+            self.test.assertLoggedEqual(
+                f"line ({absolute_line_num}) text",
+                expected_text,
+                line.line_text,
+            )
 
     def assert_viewmodel_matches_subtitles(self, subtitles: Subtitles) -> None:
         """ 
@@ -149,38 +166,59 @@ class TestableViewModel(ProjectViewModel):
         """
         expected_scene_numbers = [scene.number for scene in subtitles.scenes]
         actual_scene_numbers = sorted(self.model.keys())
-        log_input_expected_result('scene numbers match project', expected_scene_numbers, actual_scene_numbers)
-        self.test.assertSequenceEqual(actual_scene_numbers, expected_scene_numbers)
+        self.test.assertLoggedSequenceEqual(
+            'scene numbers match project',
+            expected_scene_numbers,
+            actual_scene_numbers,
+        )
 
         for scene in subtitles.scenes:
             scene_item = self.test_get_scene_item(scene.number)
-            log_input_expected_result(f'scene {scene.number} summary', scene.summary, scene_item.summary)
-            self.test.assertEqual(scene_item.summary, scene.summary)
+            self.test.assertLoggedEqual(
+                f'scene {scene.number} summary',
+                scene.summary,
+                scene_item.summary,
+            )
 
             expected_batch_numbers = [batch.number for batch in scene.batches]
             actual_batch_numbers = sorted(scene_item.batches.keys())
-            log_input_expected_result(f'scene {scene.number} batch numbers', expected_batch_numbers, actual_batch_numbers)
-            self.test.assertSequenceEqual(actual_batch_numbers, expected_batch_numbers)
+            self.test.assertLoggedSequenceEqual(
+                f'scene {scene.number} batch numbers',
+                expected_batch_numbers,
+                actual_batch_numbers,
+            )
 
             for batch in scene.batches:
                 batch_item = self.test_get_batch_item(scene.number, batch.number)
-                log_input_expected_result(f'batch ({scene.number},{batch.number}) summary', batch.summary, batch_item.summary)
-                self.test.assertEqual(batch_item.summary, batch.summary)
+                self.test.assertLoggedEqual(
+                    f'batch ({scene.number},{batch.number}) summary',
+                    batch.summary,
+                    batch_item.summary,
+                )
 
                 expected_line_numbers = [line.number for line in batch.originals]
                 actual_line_numbers = self.get_line_numbers_in_batch(scene.number, batch.number)
-                log_input_expected_result(f'batch ({scene.number},{batch.number}) line numbers', expected_line_numbers, actual_line_numbers)
-                self.test.assertSequenceEqual(actual_line_numbers, expected_line_numbers)
+                self.test.assertLoggedSequenceEqual(
+                    f'batch ({scene.number},{batch.number}) line numbers',
+                    expected_line_numbers,
+                    actual_line_numbers,
+                )
 
-                for line in batch.originals:
-                    line_item = batch_item.lines.get(line.number)
-                    log_input_expected_result(f'line ({scene.number},{batch.number},{line.number}) exists', True, line_item is not None)
-                    self.test.assertIsNotNone(line_item)
-                    if line_item:
-                        log_input_expected_result(f'line ({scene.number},{batch.number},{line.number}) type', LineItem, type(line_item))
-                        self.test.assertEqual(type(line_item), LineItem)
-                        log_input_expected_result(f'line ({scene.number},{batch.number},{line.number}) text', line.text, line_item.line_text)
-                        self.test.assertEqual(line_item.line_text, line.text)
+                expected_line_texts = [line.text for line in batch.originals]
+                actual_line_items = [batch_item.lines.get(line.number) for line in batch.originals]
+                actual_line_types = [type(item) if item is not None else None for item in actual_line_items]
+                actual_line_texts = [item.line_text if isinstance(item, LineItem) else None for item in actual_line_items]
+
+                self.test.assertLoggedSequenceEqual(
+                    f'line ({scene.number},{batch.number}) item types',
+                    [LineItem]*len(actual_line_items),
+                    actual_line_types,
+                )
+                self.test.assertLoggedSequenceEqual(
+                    f'line ({scene.number},{batch.number}) texts',
+                    expected_line_texts,
+                    actual_line_texts,
+                )
 
     def assert_expected_structure(self, expected: dict) -> None:
         """
@@ -210,8 +248,11 @@ class TestableViewModel(ProjectViewModel):
         expected_scenes = expected.get('scenes', [])
         expected_scene_numbers = [scene_data['number'] for scene_data in expected_scenes]
         actual_scene_numbers = sorted(self.model.keys())
-        log_input_expected_result('expected scene numbers', expected_scene_numbers, actual_scene_numbers)
-        self.test.assertSequenceEqual(actual_scene_numbers, expected_scene_numbers)
+        self.test.assertLoggedSequenceEqual(
+            'expected scene numbers',
+            expected_scene_numbers,
+            actual_scene_numbers,
+        )
 
         for scene_data in expected_scenes:
             scene_number = scene_data['number']
@@ -219,14 +260,20 @@ class TestableViewModel(ProjectViewModel):
 
             if 'summary' in scene_data:
                 expected_summary = scene_data['summary']
-                log_input_expected_result(f'scene {scene_number} expected summary', expected_summary, scene_item.summary)
-                self.test.assertEqual(scene_item.summary, expected_summary)
+                self.test.assertLoggedEqual(
+                    f'scene {scene_number} expected summary',
+                    expected_summary,
+                    scene_item.summary,
+                )
 
             expected_batches = scene_data.get('batches', [])
             expected_batch_numbers = [batch_data['number'] for batch_data in expected_batches]
             actual_batch_numbers = sorted(scene_item.batches.keys())
-            log_input_expected_result(f'scene {scene_number} expected batches', expected_batch_numbers, actual_batch_numbers)
-            self.test.assertSequenceEqual(actual_batch_numbers, expected_batch_numbers)
+            self.test.assertLoggedSequenceEqual(
+                f'scene {scene_number} expected batches',
+                expected_batch_numbers,
+                actual_batch_numbers,
+            )
 
             for batch_data in expected_batches:
                 batch_number = batch_data['number']
@@ -234,27 +281,46 @@ class TestableViewModel(ProjectViewModel):
 
                 if 'summary' in batch_data:
                     expected_batch_summary = batch_data['summary']
-                    log_input_expected_result(f'batch ({scene_number},{batch_number}) expected summary', expected_batch_summary, batch_item.summary)
-                    self.test.assertEqual(batch_item.summary, expected_batch_summary)
+                    self.test.assertLoggedEqual(
+                        f'batch ({scene_number},{batch_number}) expected summary',
+                        expected_batch_summary,
+                        batch_item.summary,
+                    )
 
                 expected_line_count = batch_data.get('line_count')
                 if expected_line_count is not None:
-                    log_input_expected_result(f'batch ({scene_number},{batch_number}) expected line count', expected_line_count, batch_item.line_count)
-                    self.test.assertEqual(batch_item.line_count, expected_line_count)
+                    self.test.assertLoggedEqual(
+                        f'batch ({scene_number},{batch_number}) expected line count',
+                        expected_line_count,
+                        batch_item.line_count,
+                    )
 
                 expected_line_numbers = batch_data.get('line_numbers')
                 if expected_line_numbers is not None:
                     actual_line_numbers = self.get_line_numbers_in_batch(scene_number, batch_number)
-                    log_input_expected_result(f'batch ({scene_number},{batch_number}) expected line numbers', expected_line_numbers, actual_line_numbers)
-                    self.test.assertSequenceEqual(actual_line_numbers, expected_line_numbers)
+                    self.test.assertLoggedSequenceEqual(
+                        f'batch ({scene_number},{batch_number}) expected line numbers',
+                        expected_line_numbers,
+                        actual_line_numbers,
+                    )
 
                 expected_line_texts = batch_data.get('line_texts', {})
-                for line_number, expected_text in expected_line_texts.items():
-                    line_item = batch_item.lines.get(line_number)
-                    log_input_expected_result(f'line ({scene_number},{batch_number},{line_number}) expected text', expected_text, line_item.line_text if line_item else None)
-                    self.test.assertIsNotNone(line_item)
-                    if line_item:
-                        self.test.assertEqual(line_item.line_text, expected_text)
+                if expected_line_texts:
+                    expected_numbers = sorted(expected_line_texts.keys())
+                    actual_line_items = [batch_item.lines.get(number) for number in expected_numbers]
+                    actual_line_types = [type(item) if item is not None else None for item in actual_line_items]
+                    actual_texts = [item.line_text if isinstance(item, LineItem) else None for item in actual_line_items]
+
+                    self.test.assertLoggedSequenceEqual(
+                        f'batch ({scene_number},{batch_number}) expected line item types',
+                        [LineItem]*len(expected_numbers),
+                        actual_line_types,
+                    )
+                    self.test.assertLoggedSequenceEqual(
+                        f'batch ({scene_number},{batch_number}) expected line texts',
+                        [expected_line_texts[number] for number in expected_numbers],
+                        actual_texts,
+                    )
 
 
     def _track_data_changed(self, topLeft : QModelIndex, bottomRight : QModelIndex, roles : list[int]) -> None:

--- a/PySubtrans/Helpers/TestCases.py
+++ b/PySubtrans/Helpers/TestCases.py
@@ -4,7 +4,7 @@ import unittest
 from typing import Any
 
 import regex
-from PySubtrans.Helpers.Tests import log_test_name
+from PySubtrans.Helpers.Tests import log_input_expected_result, log_test_name
 from PySubtrans.Options import Options, SettingsType
 from PySubtrans.SettingsType import SettingsType
 from PySubtrans.SubtitleBatch import SubtitleBatch
@@ -25,6 +25,132 @@ class LoggedTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         log_test_name(self._testMethodName)
+
+    @staticmethod
+    def _format_type_name(expected_type : type|tuple[type, ...]) -> str:
+        if isinstance(expected_type, tuple):
+            return ", ".join(t.__name__ for t in expected_type)
+        return expected_type.__name__
+
+    def _log_expected_result(self, description : Any, expected : Any, result : Any, input_value : Any|None = None) -> None:
+        log_input_expected_result(input_value if input_value is not None else description, expected, result)
+
+    def assertLoggedEqual(self, description : Any, expected : Any, actual : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        self._log_expected_result(description, expected, actual, input_value=input_value)
+        if msg is None:
+            self.assertEqual(actual, expected)
+        else:
+            self.assertEqual(actual, expected, msg)
+
+    def assertLoggedSequenceEqual(self, description : Any, expected : Any, actual : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        self._log_expected_result(description, expected, actual, input_value=input_value)
+        if msg is None:
+            self.assertSequenceEqual(actual, expected)
+        else:
+            self.assertSequenceEqual(actual, expected, msg)
+
+    def assertLoggedIsNone(self, description : Any, value : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        self._log_expected_result(description, None, value, input_value=input_value)
+        if msg is None:
+            self.assertIsNone(value)
+        else:
+            self.assertIsNone(value, msg)
+
+    def assertLoggedIsNotNone(self, description : Any, value : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        context = input_value if input_value is not None else description
+        self._log_expected_result(description, True, value is not None, input_value=context)
+        if msg is None:
+            self.assertIsNotNone(value)
+        else:
+            self.assertIsNotNone(value, msg)
+
+    def assertLoggedTrue(self, description : Any, condition : bool, msg : str|None = None, input_value : Any|None = None) -> None:
+        self._log_expected_result(description, True, condition, input_value=input_value)
+        if msg is None:
+            self.assertTrue(condition)
+        else:
+            self.assertTrue(condition, msg)
+
+    def assertLoggedFalse(self, description : Any, condition : bool, msg : str|None = None, input_value : Any|None = None) -> None:
+        self._log_expected_result(description, False, condition, input_value=input_value)
+        if msg is None:
+            self.assertFalse(condition)
+        else:
+            self.assertFalse(condition, msg)
+
+    def assertLoggedIn(self, description : Any, member : Any, container : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        context = input_value if input_value is not None else f"{description} -> {member} in container"
+        self._log_expected_result(description, True, member in container, input_value=context)
+        if msg is None:
+            self.assertIn(member, container)
+        else:
+            self.assertIn(member, container, msg)
+
+    def assertLoggedNotIn(self, description : Any, member : Any, container : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        context = input_value if input_value is not None else f"{description} -> {member} not in container"
+        self._log_expected_result(description, False, member in container, input_value=context)
+        if msg is None:
+            self.assertNotIn(member, container)
+        else:
+            self.assertNotIn(member, container, msg)
+
+    def assertLoggedIs(self, description : Any, expected : Any, actual : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        context = input_value if input_value is not None else f"{description} -> expected id {id(expected)}"
+        self._log_expected_result(description, expected, actual, input_value=context)
+        if msg is None:
+            self.assertIs(actual, expected)
+        else:
+            self.assertIs(actual, expected, msg)
+
+    def assertLoggedIsNot(self, description : Any, unexpected : Any, actual : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        context = input_value if input_value is not None else f"{description} -> unexpected id {id(unexpected)}"
+        self._log_expected_result(description, unexpected, actual, input_value=context)
+        if msg is None:
+            self.assertIsNot(actual, unexpected)
+        else:
+            self.assertIsNot(actual, unexpected, msg)
+
+    def assertLoggedGreater(self, description : Any, first : Any, second : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        context = input_value if input_value is not None else f"{description} -> {first} > {second}"
+        self._log_expected_result(description, True, first > second, input_value=context)
+        if msg is None:
+            self.assertGreater(first, second)
+        else:
+            self.assertGreater(first, second, msg)
+
+    def assertLoggedGreaterEqual(self, description : Any, first : Any, second : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        context = input_value if input_value is not None else f"{description} -> {first} >= {second}"
+        self._log_expected_result(description, True, first >= second, input_value=context)
+        if msg is None:
+            self.assertGreaterEqual(first, second)
+        else:
+            self.assertGreaterEqual(first, second, msg)
+
+    def assertLoggedLess(self, description : Any, first : Any, second : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        context = input_value if input_value is not None else f"{description} -> {first} < {second}"
+        self._log_expected_result(description, True, first < second, input_value=context)
+        if msg is None:
+            self.assertLess(first, second)
+        else:
+            self.assertLess(first, second, msg)
+
+    def assertLoggedLessEqual(self, description : Any, first : Any, second : Any, msg : str|None = None, input_value : Any|None = None) -> None:
+        context = input_value if input_value is not None else f"{description} -> {first} <= {second}"
+        self._log_expected_result(description, True, first <= second, input_value=context)
+        if msg is None:
+            self.assertLessEqual(first, second)
+        else:
+            self.assertLessEqual(first, second, msg)
+
+    def assertLoggedIsInstance(self, description : Any, value : Any, expected_type : type|tuple[type, ...], msg : str|None = None, input_value : Any|None = None) -> None:
+        type_name = self._format_type_name(expected_type)
+        actual_type = type(value).__name__
+        context = input_value if input_value is not None else f"{description} ({actual_type} is {type_name})"
+        self._log_expected_result(description, True, isinstance(value, expected_type), input_value=context)
+        if msg is None:
+            self.assertIsInstance(value, expected_type)
+        else:
+            self.assertIsInstance(value, expected_type, msg)
 
 
 class SubtitleTestCase(LoggedTestCase):

--- a/tests/PySubtransTests/test_Options.py
+++ b/tests/PySubtransTests/test_Options.py
@@ -10,7 +10,6 @@ from PySubtrans.Instructions import Instructions
 from PySubtrans.Helpers.TestCases import LoggedTestCase
 from PySubtrans.Helpers.Tests import (
     log_input_expected_error,
-    log_input_expected_result,
     skip_if_debugger_attached,
 )
 from PySubtrans.SettingsType import SettingsType, SettingType, SettingsError
@@ -47,8 +46,7 @@ class TestOptions(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = options.get(key)
-                log_input_expected_result(f"options.get('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"options.get('{key}')", expected, result)
         
         # Test boolean defaults
         bool_test_cases = [
@@ -63,8 +61,7 @@ class TestOptions(LoggedTestCase):
         for key, expected in bool_test_cases:
             with self.subTest(key=key):
                 result = options.get(key)
-                log_input_expected_result(f"options.get('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"options.get('{key}')", expected, result)
         
         # Test None values
         none_test_cases = [ 'last_used_path' ]
@@ -72,8 +69,7 @@ class TestOptions(LoggedTestCase):
         for key in none_test_cases:
             with self.subTest(key=key):
                 result = options.get(key)
-                log_input_expected_result(f"options.get('{key}')", None, result)
-                self.assertIsNone(result)
+                self.assertLoggedIsNone(f"options.get('{key}')", result)
 
     def test_initialization_with_dict(self):
         """Test Options initialization with a dictionary"""
@@ -92,8 +88,7 @@ class TestOptions(LoggedTestCase):
         for key, expected in custom_test_cases:
             with self.subTest(key=key):
                 result = options.get(key)
-                log_input_expected_result(f"options.get('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"options.get('{key}')", expected, result)
         
         # Check that defaults are still present for unspecified options
         default_test_cases = [
@@ -104,8 +99,7 @@ class TestOptions(LoggedTestCase):
         for key, expected in default_test_cases:
             with self.subTest(key=key):
                 result = options.get(key)
-                log_input_expected_result(f"options.get('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"options.get('{key}')", expected, result)
 
     def test_initialization_with_options_object(self):
         """Test Options initialization with another Options object"""
@@ -123,8 +117,7 @@ class TestOptions(LoggedTestCase):
         for key, expected in copy_test_cases:
             with self.subTest(key=key):
                 result = copy_options.get(key)
-                log_input_expected_result(f"copy_options.get('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"copy_options.get('{key}')", expected, result)
         
         # Verify it's a deep copy - modifying one doesn't affect the other
         copy_options.set('provider', 'Different Provider')
@@ -132,11 +125,9 @@ class TestOptions(LoggedTestCase):
         original_result = original.get('provider')
         copy_result = copy_options.get('provider')
         
-        log_input_expected_result("original.get('provider') (original unchanged)", 'Test Provider', original_result)
-        self.assertEqual(original_result, 'Test Provider')
-        
-        log_input_expected_result("copy_options.get('provider') (copy modified)", 'Different Provider', copy_result)
-        self.assertEqual(copy_result, 'Different Provider')
+        self.assertLoggedEqual("original.get('provider') (original unchanged)", 'Test Provider', original_result)
+
+        self.assertLoggedEqual("copy_options.get('provider') (copy modified)", 'Different Provider', copy_result)
 
     def test_initialization_with_kwargs(self):
         """Test Options initialization with keyword arguments"""
@@ -156,8 +147,7 @@ class TestOptions(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = options.get(key)
-                log_input_expected_result(f"options.get('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"options.get('{key}')", expected, result)
 
     def test_initialization_dict_and_kwargs(self):
         """Test Options initialization with both dict and kwargs (kwargs should override)"""
@@ -177,8 +167,7 @@ class TestOptions(LoggedTestCase):
         for key, expected in override_test_cases:
             with self.subTest(key=key):
                 result = options.get(key)
-                log_input_expected_result(f"options.get('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"options.get('{key}')", expected, result)
         
         # Dict values should still be present where not overridden
         preserved_test_cases = [
@@ -189,8 +178,7 @@ class TestOptions(LoggedTestCase):
         for key, expected in preserved_test_cases:
             with self.subTest(key=key):
                 result = options.get(key)
-                log_input_expected_result(f"options.get('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"options.get('{key}')", expected, result)
 
     def test_none_values_filtered(self):
         """Test that None values in input options are filtered out"""
@@ -214,13 +202,11 @@ class TestOptions(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = options.get(key)
-                log_input_expected_result(f"options.get('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"options.get('{key}')", expected, result)
         
         # Custom setting with None should not be in options (not in defaults)
         custom_result = options.get('custom_setting')
-        log_input_expected_result("options.get('custom_setting') (None custom setting filtered)", None, custom_result)
-        self.assertIsNone(custom_result)
+        self.assertLoggedIsNone("options.get('custom_setting') (None custom setting filtered)", custom_result)
 
     def test_get_method(self):
         """Test the get method with default values"""
@@ -236,18 +222,15 @@ class TestOptions(LoggedTestCase):
         for key, expected in existing_test_cases:
             with self.subTest(key=key):
                 result = options.get(key)
-                log_input_expected_result(f"options.get('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"options.get('{key}')", expected, result)
         
         # Test getting non-existing values with default
         default_result = options.get('non_existing', 'default')
-        log_input_expected_result("options.get('non_existing', 'default') (with default)", 'default', default_result)
-        self.assertEqual(default_result, 'default')
+        self.assertLoggedEqual("options.get('non_existing', 'default') (with default)", 'default', default_result)
         
         # Test getting non-existing values without default
         none_result = options.get('non_existing')
-        log_input_expected_result("options.get('non_existing') (no default)", None, none_result)
-        self.assertIsNone(none_result)
+        self.assertLoggedIsNone("options.get('non_existing') (no default)", none_result)
 
     def test_add_method(self):
         """Test the add method"""
@@ -574,13 +557,11 @@ class TestSettingsType(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = self.test_settings.get_bool(key)
-                log_input_expected_result(f"get_bool('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"get_bool('{key}')", expected, result)
         
         # Test custom default
         result = self.test_settings.get_bool('missing_key', True)
-        log_input_expected_result("get_bool with custom default True", True, result)
-        self.assertTrue(result)
+        self.assertLoggedTrue("get_bool with custom default True", result)
 
     def test_get_int(self):
         """Test SettingsType.get_int method"""
@@ -595,13 +576,11 @@ class TestSettingsType(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = self.test_settings.get_int(key)
-                log_input_expected_result(f"get_int('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"get_int('{key}')", expected, result)
         
         # Test custom default
         result = self.test_settings.get_int('missing_key', 999)
-        log_input_expected_result("get_int with custom default", 999, result)
-        self.assertEqual(result, 999)
+        self.assertLoggedEqual("get_int with custom default", 999, result)
 
     def test_get_float(self):
         """Test SettingsType.get_float method"""
@@ -617,13 +596,11 @@ class TestSettingsType(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = self.test_settings.get_float(key)
-                log_input_expected_result(f"get_float('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"get_float('{key}')", expected, result)
         
         # Test custom default
         result = self.test_settings.get_float('missing_key', 1.23)
-        log_input_expected_result("get_float with custom default", 1.23, result)
-        self.assertEqual(result, 1.23)
+        self.assertLoggedEqual("get_float with custom default", 1.23, result)
 
     def test_get_str(self):
         """Test SettingsType.get_str method"""
@@ -638,13 +615,11 @@ class TestSettingsType(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = self.test_settings.get_str(key)
-                log_input_expected_result(f"get_str('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"get_str('{key}')", expected, result)
         
         # Test custom default
         result = self.test_settings.get_str('missing_key', 'default_string')
-        log_input_expected_result("get_str with custom default", 'default_string', result)
-        self.assertEqual(result, 'default_string')
+        self.assertLoggedEqual("get_str with custom default", 'default_string', result)
 
     def test_get_timedelta(self):
         """Test SettingsType.get_timedelta method"""
@@ -654,13 +629,11 @@ class TestSettingsType(LoggedTestCase):
         # Test with valid seconds value
         result = self.test_settings.get_timedelta('timedelta_seconds', default_td)
         expected = timedelta(seconds=30.5)
-        log_input_expected_result("get_timedelta with float seconds", expected, result)
-        self.assertEqual(result, expected)
+        self.assertLoggedEqual("get_timedelta with float seconds", expected, result)
         
         # Test with missing key
         result = self.test_settings.get_timedelta('missing_key', default_td)
-        log_input_expected_result("get_timedelta with missing key", default_td, result)
-        self.assertEqual(result, default_td)
+        self.assertLoggedEqual("get_timedelta with missing key", default_td, result)
 
     def test_get_str_list(self):
         """Test SettingsType.get_str_list method"""
@@ -674,14 +647,12 @@ class TestSettingsType(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = self.test_settings.get_str_list(key)
-                log_input_expected_result(f"get_str_list('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"get_str_list('{key}')", expected, result)
         
         # Test custom default
         custom_default = ['default1', 'default2']
         result = self.test_settings.get_str_list('missing_key', custom_default)
-        log_input_expected_result("get_str_list with custom default", custom_default, result)
-        self.assertSequenceEqual(result, custom_default)
+        self.assertLoggedSequenceEqual("get_str_list with custom default", custom_default, result)
 
     def test_get_list(self):
         """Test SettingsType.get_list method"""
@@ -695,14 +666,12 @@ class TestSettingsType(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = self.test_settings.get_list(key)
-                log_input_expected_result(f"get_list('{key}')", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"get_list('{key}')", expected, result)
         
         # Test custom default
         custom_default = ['default', 123, True]
         result = self.test_settings.get_list('missing_key', custom_default)
-        log_input_expected_result("get_list with custom default", custom_default, result)
-        self.assertEqual(result, custom_default)
+        self.assertLoggedEqual("get_list with custom default", custom_default, result)
 
     def test_get_dict(self):
         """Test SettingsType.get_dict method and nested dict functionality"""
@@ -710,19 +679,16 @@ class TestSettingsType(LoggedTestCase):
         # Test getting nested dict
         result = self.test_settings.get_dict('nested_dict')
         expected = {'inner_str': 'nested_value', 'inner_int': 100, 'inner_bool': True}
-        log_input_expected_result("get_dict('nested_dict')", expected, result)
-        self.assertEqual(result, expected)
+        self.assertLoggedEqual("get_dict('nested_dict')", expected, result)
         
         # Test missing key returns empty dict
         result = self.test_settings.get_dict('missing_key')
-        log_input_expected_result("get_dict with missing key", {}, result)
-        self.assertEqual(result, {})
+        self.assertLoggedEqual("get_dict with missing key", {}, result)
         
         # Test custom default
         custom_default = SettingsType({'default_key': 'default_value'})
         result = self.test_settings.get_dict('missing_key', custom_default)
-        log_input_expected_result("get_dict with custom default", custom_default, result)
-        self.assertDictEqual(result, custom_default)
+        self.assertLoggedEqual("get_dict with custom default", custom_default, result)
         
         # Test that get_dict returns a mutable reference to nested dictionaries
         nested_dict = self.test_settings.get_dict('nested_dict')
@@ -733,15 +699,13 @@ class TestSettingsType(LoggedTestCase):
         # Verify the parent was updated
         updated_nested = self.test_settings.get_dict('nested_dict')
         self.assertIn('new_key', updated_nested)
-        log_input_expected_result("nested dict update propagated", 'new_value', updated_nested['new_key'])
-        self.assertEqual(updated_nested['new_key'], 'new_value')
+        self.assertLoggedEqual("nested dict update propagated", 'new_value', updated_nested['new_key'])
         
         # Also verify through direct access
         direct_nested = self.test_settings['nested_dict']
         if isinstance(direct_nested, SettingsType):
             self.assertIn('new_key', direct_nested)
-            log_input_expected_result("nested update visible in direct access", 'new_value', direct_nested['new_key'])
-            self.assertEqual(direct_nested['new_key'], 'new_value')
+            self.assertLoggedEqual("nested update visible in direct access", 'new_value', direct_nested['new_key'])
 
     def test_provider_settings_nested_updates(self):
         """Test that provider_settings properly handles nested updates"""
@@ -764,26 +728,20 @@ class TestSettingsType(LoggedTestCase):
         
         # Test that provider_settings returns a mutable mapping
         provider_settings = options.provider_settings
-        self.assertIsInstance(provider_settings, MutableMapping)
-        log_input_expected_result("provider_settings is MutableMapping", True, isinstance(provider_settings, MutableMapping))
-        
+        self.assertLoggedIsInstance("provider_settings is MutableMapping", provider_settings, MutableMapping)
+
         # Test accessing existing provider settings
         test_provider_settings = provider_settings['Test Provider']
-        self.assertIsInstance(test_provider_settings, SettingsType)
-        log_input_expected_result("provider settings is SettingsType", True, isinstance(test_provider_settings, SettingsType))
+        self.assertLoggedIsInstance("provider settings is SettingsType", test_provider_settings, SettingsType)
         
         # Test accessing values through typed getters
         model = test_provider_settings.get_str('model')
         temperature = test_provider_settings.get_float('temperature')
         api_key = test_provider_settings.get_str('api_key')
         
-        log_input_expected_result("provider model", 'test-model', model)
-        log_input_expected_result("provider temperature", 0.7, temperature)
-        log_input_expected_result("provider api_key", 'test-key', api_key)
-        
-        self.assertEqual(model, 'test-model')
-        self.assertEqual(temperature, 0.7)
-        self.assertEqual(api_key, 'test-key')
+        self.assertLoggedEqual("provider model", 'test-model', model)
+        self.assertLoggedEqual("provider temperature", 0.7, temperature)
+        self.assertLoggedEqual("provider api_key", 'test-key', api_key)
         
         # Test modifying provider settings updates the parent Options
         test_provider_settings['new_setting'] = 'new_value'
@@ -791,8 +749,7 @@ class TestSettingsType(LoggedTestCase):
         # Verify the change is reflected in the main options
         updated_provider_settings = options.provider_settings['Test Provider']
         self.assertIn('new_setting', updated_provider_settings)
-        log_input_expected_result("nested provider update propagated", 'new_value', updated_provider_settings['new_setting'])
-        self.assertEqual(updated_provider_settings['new_setting'], 'new_value')
+        self.assertLoggedEqual("nested provider update propagated", 'new_value', updated_provider_settings['new_setting'])
         
         # Test adding a new provider through the mutable mapping
         new_provider_settings = SettingsType({
@@ -804,16 +761,14 @@ class TestSettingsType(LoggedTestCase):
         # Verify the new provider is accessible
         self.assertIn('New Provider', options.provider_settings)
         new_settings = options.provider_settings['New Provider']
-        log_input_expected_result("new provider model", 'new-provider-model', new_settings.get_str('model'))
-        self.assertEqual(new_settings.get_str('model'), 'new-provider-model')
+        self.assertLoggedEqual("new provider model", 'new-provider-model', new_settings.get_str('model'))
         
         # Test current_provider_settings property
         current_settings = options.current_provider_settings
-        self.assertIsNotNone(current_settings)
+        self.assertLoggedIsNotNone("current provider settings", current_settings)
         if current_settings:
             current_model = current_settings.get_str('model')
-            log_input_expected_result("current provider model", 'test-model', current_model)
-            self.assertEqual(current_model, 'test-model')
+            self.assertLoggedEqual("current provider model", 'test-model', current_model)
             
             # Test that modifying current_provider_settings updates the main options
             current_settings['current_test'] = 'current_value'
@@ -825,8 +780,7 @@ class TestSettingsType(LoggedTestCase):
             if provider is not None:
                 updated_current : SettingsType = options.provider_settings[provider]
                 self.assertIn('current_test', updated_current)
-                log_input_expected_result("current provider update propagated", 'current_value', updated_current['current_test'])
-                self.assertEqual(updated_current['current_test'], 'current_value')
+                self.assertLoggedEqual("current provider update propagated", 'current_value', updated_current['current_test'])
 
 class TestSettingsHelpers(LoggedTestCase):
     """Unit tests for Settings helper functions"""
@@ -878,23 +832,19 @@ class TestSettingsHelpers(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = self.test_dict_settings.get_bool(key)
-                log_input_expected_result(f"dict['{key}']", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"dict['{key}']", expected, result)
                 result_opts = self.test_options_obj.get_bool(key)
-                log_input_expected_result(f"Options['{key}']", expected, result_opts)
-                self.assertEqual(result_opts, expected)
+                self.assertLoggedEqual(f"Options['{key}']", expected, result_opts)
         
         # Test custom default
         result = self.test_dict_settings.get_bool('missing_key', True)
-        log_input_expected_result("missing key with default True", True, result)
-        self.assertTrue(result)
+        self.assertLoggedTrue("missing key with default True", result)
         
         # Test None value
         settings_with_none = {'none_value': None}
         settings_with_none_obj = SettingsType(settings_with_none)
         result = settings_with_none_obj.get_bool('none_value')
-        log_input_expected_result("None value", False, result)
-        self.assertFalse(result)
+        self.assertLoggedFalse("None value", result)
 
     @skip_if_debugger_attached
     def test_get_bool_setting_errors(self):
@@ -920,14 +870,12 @@ class TestSettingsHelpers(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = self.test_dict_settings.get_int(key)
-                log_input_expected_result(key, expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(key, expected, result)
         
         # Test None handling
         settings_with_none = SettingsType({'none_value': None})
         result = settings_with_none.get_int('none_value')
-        log_input_expected_result("None value", None, result)
-        self.assertIsNone(result)
+        self.assertLoggedIsNone("None value", result)
 
     @skip_if_debugger_attached
     def test_get_int_setting_errors(self):
@@ -949,13 +897,11 @@ class TestSettingsHelpers(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = self.test_dict_settings.get_float(key)
-                log_input_expected_result(key, expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(key, expected, result)
         
         # Test None handling
         result = self.test_dict_settings.get_float('missing_key')
-        log_input_expected_result("missing key", None, result)
-        self.assertIsNone(result)
+        self.assertLoggedIsNone("missing key", result)
 
     @skip_if_debugger_attached
     def test_get_float_setting_errors(self):
@@ -978,13 +924,11 @@ class TestSettingsHelpers(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = self.test_dict_settings.get_str(key)
-                log_input_expected_result(key, expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(key, expected, result)
         
         # Test None handling
         result = self.test_dict_settings.get_str('missing_key')
-        log_input_expected_result("missing key", None, result)
-        self.assertIsNone(result)
+        self.assertLoggedIsNone("missing key", result)
 
     def test_get_list_setting(self):
         """Test GetListSetting with various input types"""
@@ -998,13 +942,11 @@ class TestSettingsHelpers(LoggedTestCase):
         for key, expected in test_cases:
             with self.subTest(key=key):
                 result = self.test_dict_settings.get_list(key)
-                log_input_expected_result(key, expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(key, expected, result)
         
         # Test missing key returns empty list
         result = self.test_dict_settings.get_list('missing_key')
-        log_input_expected_result("missing key", [], result)
-        self.assertEqual(result, [])
+        self.assertLoggedEqual("missing key", [], result)
         
     @skip_if_debugger_attached
     def test_get_list_setting_errors(self):
@@ -1020,16 +962,14 @@ class TestSettingsHelpers(LoggedTestCase):
         # Test with valid string list
         result = self.test_dict_settings.get_str_list('list_value')
         expected = ['apple', 'banana', 'cherry']
-        log_input_expected_result("valid string list", expected, result)
-        self.assertEqual(result, expected)
+        self.assertLoggedEqual("valid string list", expected, result)
         
         # Test with mixed types (should convert to strings)
         mixed_settings = {'mixed_list': [1, 'two', True, None]}
         mixed_settings_obj = SettingsType(mixed_settings)
         result = mixed_settings_obj.get_str_list('mixed_list')
         expected = ['1', 'two', 'True']
-        log_input_expected_result("mixed types", expected, result)
-        self.assertEqual(result, expected)
+        self.assertLoggedEqual("mixed types", expected, result)
 
     def test_get_timedelta_setting(self):
         """Test GetTimeDeltaSetting function"""
@@ -1044,14 +984,12 @@ class TestSettingsHelpers(LoggedTestCase):
             with self.subTest(key=key):
                 default = timedelta(minutes=1)  # Use a different default to distinguish from expected
                 result = self.test_dict_settings.get_timedelta(key, default)
-                log_input_expected_result(key, expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(key, expected, result)
         
         # Test default value
         default = timedelta(minutes=5)
         result = self.test_dict_settings.get_timedelta('missing_key', default)
-        log_input_expected_result("missing key with default", default, result)
-        self.assertEqual(result, default)
+        self.assertLoggedEqual("missing key with default", default, result)
 
     @skip_if_debugger_attached
     def test_get_timedelta_setting_errors(self):
@@ -1075,18 +1013,15 @@ class TestSettingsHelpers(LoggedTestCase):
         for key, setting_type, expected in test_cases:
             with self.subTest(key=key):
                 result = get_optional_setting(self.test_dict_settings, key, setting_type)
-                log_input_expected_result(key, expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(key, expected, result)
         
         # Test missing key returns None
         result = get_optional_setting(self.test_dict_settings, 'missing_key', str)
-        log_input_expected_result("missing key", None, result)
-        self.assertIsNone(result)
+        self.assertLoggedIsNone("missing key", result)
         
         # Test with Options object
         result = get_optional_setting(self.test_options_obj, 'bool_true', bool)
-        log_input_expected_result("Options object", True, result)
-        self.assertTrue(result)
+        self.assertLoggedTrue("Options object", result)
 
     @skip_if_debugger_attached
     def test_get_optional_setting_errors(self):
@@ -1108,8 +1043,7 @@ class TestSettingsHelpers(LoggedTestCase):
         for key, setting_type, expected in valid_cases:
             with self.subTest(key=key):
                 result = validate_setting_type(self.test_dict_settings, key, setting_type)
-                log_input_expected_result(f"'{key}' as {setting_type.__name__}", expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(f"'{key}' as {setting_type.__name__}", expected, result)
         
     @skip_if_debugger_attached
     def test_validate_setting_type_errors(self):
@@ -1117,13 +1051,11 @@ class TestSettingsHelpers(LoggedTestCase):
         
         # Test missing optional setting
         result = validate_setting_type(self.test_dict_settings, 'missing_key', str, required=False)
-        log_input_expected_result("missing optional setting", True, result)
-        self.assertTrue(result)
+        self.assertLoggedTrue("missing optional setting", result)
         
         # Test invalid type
         result = validate_setting_type(self.test_dict_settings, 'bool_str_invalid', bool)
-        log_input_expected_result("invalid type conversion", False, result)
-        self.assertFalse(result)
+        self.assertLoggedFalse("invalid type conversion", result)
 
         # Test required missing setting
         with self.assertRaises(SettingsError) as cm:

--- a/tests/PySubtransTests/test_Substitutions.py
+++ b/tests/PySubtransTests/test_Substitutions.py
@@ -1,10 +1,11 @@
 import unittest
 from PySubtrans.Substitutions import Substitutions
-from PySubtrans.Helpers.Tests import log_test_name, log_input_expected_result
+from PySubtrans.Helpers.TestCases import LoggedTestCase
 
-class TestSubstitutions(unittest.TestCase):
+
+class TestSubstitutions(LoggedTestCase):
     def setUp(self) -> None:
-        log_test_name(self._testMethodName)
+        super().setUp()
     parse_cases = [
         ([], {}),
         ("", {}),
@@ -17,8 +18,11 @@ class TestSubstitutions(unittest.TestCase):
         for value, expected in self.parse_cases:
             with self.subTest(value=value):
                 result = Substitutions.Parse(value)
-                log_input_expected_result(value, expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(
+                    f"ParseSubstitutions({value!r})",
+                    expected,
+                    result,
+                )
 
     perform_cases = [
         (["before::after", "hello::world"], "before hello", "after world", Substitutions.Mode.WholeWords),
@@ -38,16 +42,22 @@ class TestSubstitutions(unittest.TestCase):
             with self.subTest(value=value):
                 helper = Substitutions(substitutions, mode)
                 result = helper.PerformSubstitutions(value)
-                log_input_expected_result((value, substitutions), expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(
+                    f"PerformSubstitutions({value!r}, mode={mode.name}) using {substitutions!r}",
+                    expected,
+                    result,
+                )
 
     def test_PerformSubstitutionsAuto(self):
         for substitutions, value, expected, _ in self.perform_cases:
             with self.subTest(value=value):
                 helper = Substitutions(substitutions, Substitutions.Mode.Auto)
                 result = helper.PerformSubstitutions(value)
-                log_input_expected_result((value, substitutions), expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(
+                    f"PerformSubstitutionsAuto({value!r}) using {substitutions!r}",
+                    expected,
+                    result,
+                )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/PySubtransTests/test_SubtitleBuilder.py
+++ b/tests/PySubtransTests/test_SubtitleBuilder.py
@@ -4,25 +4,23 @@ from datetime import timedelta
 from PySubtrans.SubtitleBuilder import SubtitleBuilder
 from PySubtrans.SubtitleLine import SubtitleLine
 from PySubtrans.Subtitles import Subtitles
-from PySubtrans.Helpers.Tests import log_input_expected_result, log_test_name
+from PySubtrans.Helpers.TestCases import LoggedTestCase
 
 
-class TestSubtitleBuilder(unittest.TestCase):
+class TestSubtitleBuilder(LoggedTestCase):
 
     def setUp(self):
         """Set up test cases."""
-        log_test_name(self._testMethodName)
+        super().setUp()
 
     def test_empty_builder_initialization(self):
         """Test creating an empty SubtitleBuilder."""
         builder = SubtitleBuilder()
         subtitles = builder.Build()
 
-        log_input_expected_result("subtitles type", Subtitles, type(subtitles))
-        self.assertEqual(type(subtitles), Subtitles)
+        self.assertLoggedIsInstance("subtitles type", subtitles, Subtitles)
 
-        log_input_expected_result("subtitles.scenes length", 0, len(subtitles.scenes))
-        self.assertEqual(len(subtitles.scenes), 0)
+        self.assertLoggedEqual("subtitles.scenes length", 0, len(subtitles.scenes))
 
     def test_add_scene_creation(self):
         """Test adding a new scene."""
@@ -30,18 +28,14 @@ class TestSubtitleBuilder(unittest.TestCase):
         result = builder.AddScene(summary="Test scene")
         subtitles = builder.Build()
 
-        log_input_expected_result("AddScene return type", SubtitleBuilder, type(result))
-        self.assertEqual(type(result), SubtitleBuilder)
+        self.assertLoggedIsInstance("AddScene return type", result, SubtitleBuilder)
 
-        log_input_expected_result("scenes count", 1, len(subtitles.scenes))
-        self.assertEqual(len(subtitles.scenes), 1)
+        self.assertLoggedEqual("scenes count", 1, len(subtitles.scenes))
 
         scene = subtitles.scenes[0]
-        log_input_expected_result("scene number", 1, scene.number)
-        self.assertEqual(scene.number, 1)
+        self.assertLoggedEqual("scene number", 1, scene.number)
 
-        log_input_expected_result("scene summary", "Test scene", scene.summary)
-        self.assertEqual(scene.summary, "Test scene")
+        self.assertLoggedEqual("scene summary", "Test scene", scene.summary)
 
     def test_automatic_batch_creation(self):
         """Test that batches are created automatically when scene is finalized."""
@@ -49,21 +43,17 @@ class TestSubtitleBuilder(unittest.TestCase):
         builder.AddScene()
         result = builder.BuildLine(timedelta(seconds=1), timedelta(seconds=3), "Test line")
 
-        log_input_expected_result("AddLine return type", SubtitleBuilder, type(result))
-        self.assertEqual(type(result), SubtitleBuilder)
+        self.assertLoggedIsInstance("AddLine return type", result, SubtitleBuilder)
 
         # Batches are created when scene is finalized
         subtitles = builder.Build()
         scene = subtitles.scenes[0]
-        log_input_expected_result("batches created automatically", 1, len(scene.batches))
-        self.assertEqual(len(scene.batches), 1)
+        self.assertLoggedEqual("batches created automatically", 1, len(scene.batches))
 
         batch = scene.batches[0]
-        log_input_expected_result("batch number", 1, batch.number)
-        self.assertEqual(batch.number, 1)
+        self.assertLoggedEqual("batch number", 1, batch.number)
 
-        log_input_expected_result("batch has line", 1, len(batch.originals))
-        self.assertEqual(len(batch.originals), 1)
+        self.assertLoggedEqual("batch has line", 1, len(batch.originals))
 
     def test_add_line_without_scene(self):
         """Test that adding a line without a scene automatically adds the scene."""
@@ -72,8 +62,7 @@ class TestSubtitleBuilder(unittest.TestCase):
         builder.BuildLine(timedelta(seconds=1), timedelta(seconds=3), "Test")
 
         subtitles = builder.Build()
-        log_input_expected_result("scenes count", 1, len(subtitles.scenes))
-        self.assertEqual(len(subtitles.scenes), 1)
+        self.assertLoggedEqual("scenes count", 1, len(subtitles.scenes))
 
     def test_add_line(self):
         """Test adding a subtitle line."""
@@ -82,27 +71,21 @@ class TestSubtitleBuilder(unittest.TestCase):
 
         result = builder.BuildLine(timedelta(seconds=1), timedelta(seconds=3), "Test line")
 
-        log_input_expected_result("AddLine return type", SubtitleBuilder, type(result))
-        self.assertEqual(type(result), SubtitleBuilder)
+        self.assertLoggedIsInstance("AddLine return type", result, SubtitleBuilder)
 
         subtitles = builder.Build()
 
-        log_input_expected_result("scenes count", 1, len(subtitles.scenes))
-        self.assertEqual(len(subtitles.scenes), 1)
+        self.assertLoggedEqual("scenes count", 1, len(subtitles.scenes))
 
-        log_input_expected_result("batches count", 1, len(subtitles.scenes[0].batches))
-        self.assertEqual(len(subtitles.scenes[0].batches), 1)
+        self.assertLoggedEqual("batches count", 1, len(subtitles.scenes[0].batches))
 
         batch = subtitles.scenes[0].batches[0]
-        log_input_expected_result("batch originals count", 1, len(batch.originals))
-        self.assertEqual(len(batch.originals), 1)
+        self.assertLoggedEqual("batch originals count", 1, len(batch.originals))
 
         line = batch.originals[0]
-        log_input_expected_result("line number", 1, line.number)
-        self.assertEqual(line.number, 1)
+        self.assertLoggedEqual("line number", 1, line.number)
 
-        log_input_expected_result("line text", "Test line", line.text)
-        self.assertEqual(line.text, "Test line")
+        self.assertLoggedEqual("line text", "Test line", line.text)
 
     def test_add_lines_with_subtitle_line_objects(self):
         """Test adding multiple SubtitleLine objects."""
@@ -116,14 +99,12 @@ class TestSubtitleBuilder(unittest.TestCase):
 
         result = builder.AddLines(lines)
 
-        log_input_expected_result("AddLines return type", SubtitleBuilder, type(result))
-        self.assertEqual(type(result), SubtitleBuilder)
+        self.assertLoggedIsInstance("AddLines return type", result, SubtitleBuilder)
 
         # Batches are created when scene is finalized
         subtitles = builder.Build()
         batch = subtitles.scenes[0].batches[0]
-        log_input_expected_result("batch originals count", 2, len(batch.originals))
-        self.assertEqual(len(batch.originals), 2)
+        self.assertLoggedEqual("batch originals count", 2, len(batch.originals))
 
     def test_add_lines_with_tuples(self):
         """Test adding multiple lines as tuples."""
@@ -140,11 +121,9 @@ class TestSubtitleBuilder(unittest.TestCase):
         # Batches are created when scene is finalized
         subtitles = builder.Build()
         batch = subtitles.scenes[0].batches[0]
-        log_input_expected_result("batch originals count", 2, len(batch.originals))
-        self.assertEqual(len(batch.originals), 2)
+        self.assertLoggedEqual("batch originals count", 2, len(batch.originals))
 
-        log_input_expected_result("first line text", "Line 1", batch.originals[0].text)
-        self.assertEqual(batch.originals[0].text, "Line 1")
+        self.assertLoggedEqual("first line text", "Line 1", batch.originals[0].text)
 
     def test_multiple_scenes_and_batches(self):
         """Test creating multiple scenes and batches."""
@@ -160,14 +139,11 @@ class TestSubtitleBuilder(unittest.TestCase):
 
         # Finalize to create batches
         subtitles = builder.Build()
-        log_input_expected_result("scenes count", 2, len(subtitles.scenes))
-        self.assertEqual(len(subtitles.scenes), 2)
+        self.assertLoggedEqual("scenes count", 2, len(subtitles.scenes))
 
-        log_input_expected_result("scene 1 batches count", 1, len(subtitles.scenes[0].batches))
-        self.assertEqual(len(subtitles.scenes[0].batches), 1)
+        self.assertLoggedEqual("scene 1 batches count", 1, len(subtitles.scenes[0].batches))
 
-        log_input_expected_result("scene 2 batches count", 1, len(subtitles.scenes[1].batches))
-        self.assertEqual(len(subtitles.scenes[1].batches), 1)
+        self.assertLoggedEqual("scene 2 batches count", 1, len(subtitles.scenes[1].batches))
 
     def test_automatic_batch_splitting(self):
         """Test that batches are automatically split when they exceed max_batch_size."""
@@ -183,13 +159,15 @@ class TestSubtitleBuilder(unittest.TestCase):
         scene = subtitles.scenes[0]
 
         # Should have multiple batches due to intelligent splitting
-        log_input_expected_result("batches created", True, len(scene.batches) > 1)
-        self.assertTrue(len(scene.batches) > 1)
+        self.assertLoggedGreater("batches created", len(scene.batches), 1)
 
         # Verify all batches are within size limit
         for batch in scene.batches:
-            log_input_expected_result(f"batch {batch.number} size <= 5", True, len(batch.originals) <= 5)
-            self.assertTrue(len(batch.originals) <= 5)
+            self.assertLoggedLessEqual(
+                f"batch {batch.number} size",
+                len(batch.originals),
+                5,
+            )
 
     def test_no_split_when_within_limit(self):
         """Test that batches are not split when within max_batch_size."""
@@ -204,11 +182,9 @@ class TestSubtitleBuilder(unittest.TestCase):
         subtitles = builder.Build()
         scene = subtitles.scenes[0]
 
-        log_input_expected_result("single batch count", 1, len(scene.batches))
-        self.assertEqual(len(scene.batches), 1)
+        self.assertLoggedEqual("single batch count", 1, len(scene.batches))
 
-        log_input_expected_result("batch size", 5, len(scene.batches[0].originals))
-        self.assertEqual(len(scene.batches[0].originals), 5)
+        self.assertLoggedEqual("batch size", 5, len(scene.batches[0].originals))
 
     def test_build_finalizes_subtitles(self):
         """Test that Build() properly finalizes the subtitles structure."""
@@ -220,16 +196,13 @@ class TestSubtitleBuilder(unittest.TestCase):
                     .Build()
         )
 
-        log_input_expected_result("built subtitles type", Subtitles, type(subtitles))
-        self.assertEqual(type(subtitles), Subtitles)
+        self.assertLoggedIsInstance("built subtitles type", subtitles, Subtitles)
 
         # Check that flattened originals are properly set
-        log_input_expected_result("originals is not None", True, subtitles.originals is not None)
-        self.assertIsNotNone(subtitles.originals)
+        self.assertLoggedIsNotNone("originals is not None", subtitles.originals)
 
         if subtitles.originals:
-            log_input_expected_result("originals count", 1, len(subtitles.originals))
-            self.assertEqual(len(subtitles.originals), 1)
+            self.assertLoggedEqual("originals count", 1, len(subtitles.originals))
 
     def test_fluent_api_chaining(self):
         """Test that all methods support fluent API chaining."""
@@ -242,26 +215,21 @@ class TestSubtitleBuilder(unittest.TestCase):
                  .BuildLine(timedelta(seconds=4), timedelta(seconds=6), "World")
         )
 
-        log_input_expected_result("fluent API result type", SubtitleBuilder, type(result))
-        self.assertEqual(type(result), SubtitleBuilder)
+        self.assertLoggedIsInstance("fluent API result type", result, SubtitleBuilder)
 
         # Verify the structure was built correctly
         subtitles = result.Build()
 
-        log_input_expected_result("scenes count", 1, len(subtitles.scenes))
-        self.assertEqual(len(subtitles.scenes), 1)
+        self.assertLoggedEqual("scenes count", 1, len(subtitles.scenes))
         scene = subtitles.scenes[0]
 
-        log_input_expected_result("batches count", 1, len(scene.batches))
-        self.assertEqual(len(scene.batches), 1)
+        self.assertLoggedEqual("batches count", 1, len(scene.batches))
         batch = scene.batches[0]
 
-        log_input_expected_result("batch lines count", 2, len(batch.originals))
-        self.assertEqual(len(batch.originals), 2)
+        self.assertLoggedEqual("batch lines count", 2, len(batch.originals))
 
         batch_line_numbers = [line.number for line in batch.originals]
-        log_input_expected_result("batch line numbers", [1, 2], batch_line_numbers)
-        self.assertSequenceEqual(batch_line_numbers, [1, 2])
+        self.assertLoggedSequenceEqual("batch line numbers", [1, 2], batch_line_numbers)
 
     def test_build_line_with_metadata(self):
         """Test BuildLine with metadata parameter."""
@@ -273,8 +241,7 @@ class TestSubtitleBuilder(unittest.TestCase):
         subtitles = builder.Build()
         line = subtitles.scenes[0].batches[0].originals[0]
 
-        log_input_expected_result("line metadata", metadata, line.metadata)
-        self.assertEqual(line.metadata, metadata)
+        self.assertLoggedEqual("line metadata", metadata, line.metadata)
 
     def test_add_lines_with_metadata_tuples(self):
         """Test AddLines with 4-tuple format including metadata."""
@@ -292,11 +259,9 @@ class TestSubtitleBuilder(unittest.TestCase):
         subtitles = builder.Build()
         batch = subtitles.scenes[0].batches[0]
 
-        log_input_expected_result("first line metadata", metadata1, batch.originals[0].metadata)
-        self.assertEqual(batch.originals[0].metadata, metadata1)
+        self.assertLoggedEqual("first line metadata", metadata1, batch.originals[0].metadata)
 
-        log_input_expected_result("second line metadata", metadata2, batch.originals[1].metadata)
-        self.assertEqual(batch.originals[1].metadata, metadata2)
+        self.assertLoggedEqual("second line metadata", metadata2, batch.originals[1].metadata)
 
     def test_edge_case_batch_sizes(self):
         """Test builder with edge case batch sizes."""
@@ -307,13 +272,15 @@ class TestSubtitleBuilder(unittest.TestCase):
         subtitles = builder.Build()
         scene = subtitles.scenes[0]
 
-        log_input_expected_result("batches count with max_batch_size=1", True, len(scene.batches) >= 2)
-        self.assertTrue(len(scene.batches) >= 2)
+        self.assertLoggedGreaterEqual("batches count with max_batch_size=1", len(scene.batches), 2)
 
         # Each batch should have at most 1 line
         for i, batch in enumerate(scene.batches):
-            log_input_expected_result(f"batch {i+1} size <= 1", True, len(batch.originals) <= 1)
-            self.assertTrue(len(batch.originals) <= 1)
+            self.assertLoggedLessEqual(
+                f"batch {i+1} size",
+                len(batch.originals),
+                1,
+            )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/PySubtransTests/test_Time.py
+++ b/tests/PySubtransTests/test_Time.py
@@ -1,11 +1,12 @@
 import unittest
 from datetime import timedelta
-from PySubtrans.Helpers.Tests import log_input_expected_error, log_input_expected_result, log_test_name
+from PySubtrans.Helpers.TestCases import LoggedTestCase
 from PySubtrans.Helpers.Time import GetTimeDelta, TimedeltaToText
 
-class TestTimeHelpers(unittest.TestCase):
+
+class TestTimeHelpers(LoggedTestCase):
     def setUp(self) -> None:
-        log_test_name(self._testMethodName)
+        super().setUp()
     get_timedelta_cases = [
         (timedelta(hours=1, minutes=30, seconds=45), timedelta(hours=1, minutes=30, seconds=45)),
         ("01:30:45,000", timedelta(hours=1, minutes=30, seconds=45)),
@@ -29,11 +30,17 @@ class TestTimeHelpers(unittest.TestCase):
                 error_expected = (expected == ValueError)
                 result = GetTimeDelta(value, raise_exception = not error_expected)
                 if error_expected:
-                    log_input_expected_error(value, expected, result)
-                    self.assertIsInstance(result, ValueError)
+                    self.assertLoggedIsInstance(
+                        f"GetTimeDelta({value!r}) error",
+                        result,
+                        ValueError,
+                    )
                 else:
-                    log_input_expected_result(value, expected, result)
-                    self.assertEqual(result, expected)
+                    self.assertLoggedEqual(
+                        f"GetTimeDelta({value!r})",
+                        expected,
+                        result,
+                    )
 
     timedelta_to_text_cases = [
         (timedelta(hours=2, minutes=34, seconds=56, microseconds=789000), "2:34:56,789", True),
@@ -76,8 +83,11 @@ class TestTimeHelpers(unittest.TestCase):
         for value, expected, include_milliseconds in self.timedelta_to_text_cases:
             with self.subTest(value=value):
                 result = TimedeltaToText(value, include_milliseconds=include_milliseconds)
-                log_input_expected_result((value, include_milliseconds), expected, result)
-                self.assertEqual(result, expected)
+                self.assertLoggedEqual(
+                    f"TimedeltaToText({value}, include_milliseconds={include_milliseconds})",
+                    expected,
+                    result,
+                )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/PySubtransTests/test_Translator.py
+++ b/tests/PySubtransTests/test_Translator.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 
 from PySubtrans.Helpers.Parse import ParseNames
 from PySubtrans.Helpers.TestCases import DummyProvider, PrepareSubtitles, SubtitleTestCase
-from PySubtrans.Helpers.Tests import log_info, log_input_expected_result, log_test_name
+from PySubtrans.Helpers.Tests import log_info, log_test_name
 from PySubtrans.SubtitleBatch import SubtitleBatch
 from PySubtrans.SubtitleBatcher import SubtitleBatcher
 from PySubtrans.SubtitleEditor import SubtitleEditor
@@ -70,9 +70,8 @@ class SubtitleTranslatorTests(SubtitleTestCase):
 
         reference_batch = reference.GetBatch(batch.scene, batch.number)
 
-        log_input_expected_result("Line count", reference_batch.size, batch.size)
-        self.assertEqual(reference_batch.size, batch.size)
-
+        self.assertLoggedEqual("Line count", reference_batch.size, batch.size)
+        
         self.assertEqual(batch.first_line_number, reference_batch.first_line_number)
         self.assertEqual(batch.last_line_number, reference_batch.last_line_number)
         self.assertEqual(batch.start, reference_batch.start)
@@ -89,11 +88,8 @@ class SubtitleTranslatorTests(SubtitleTestCase):
         self.assertIsNotNone(scene.summary)
 
         reference_scene = reference.GetScene(scene.number)
-        log_input_expected_result("Batch count", reference_scene.size, scene.size)
-        log_input_expected_result("Line count", reference_scene.linecount, scene.linecount)
-
-        self.assertEqual(reference_scene.size, scene.size)
-        self.assertEqual(reference_scene.linecount, scene.linecount)
+        self.assertLoggedEqual("Batch count", reference_scene.size, scene.size)
+        self.assertLoggedEqual("Line count", reference_scene.linecount, scene.linecount)
 
 
     def test_PostProcessTranslation(self):
@@ -136,10 +132,8 @@ class SubtitleTranslatorTests(SubtitleTestCase):
             expected_differences = data['expected_postprocess_differences']
             expected_unchanged = data['expected_postprocess_unchanged']
 
-            log_input_expected_result("Differences", expected_differences, differences)
-            self.assertEqual(differences, expected_differences)
+            self.assertLoggedEqual("Differences", expected_differences, differences)
 
-            log_input_expected_result("Unchanged", expected_unchanged, unchanged)
-            self.assertEqual(unchanged, expected_unchanged)
+            self.assertLoggedEqual("Unchanged", expected_unchanged, unchanged)
 
 


### PR DESCRIPTION
## Summary
- collapse per-line existence/type/text logging in `TestableViewModel` into aggregated sequence checks for each batch
- align structure assertions with the logged helpers by comparing grouped line types and texts rather than emitting redundant entries

## Testing
- python tests/unit_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e00af50e988329aee09804857edc01