### PR TITLE
Implement parent() method to fix NotImplementedError in SubtitleListModel

### DIFF
--- a/GuiSubtrans/SubtitleListModel.py
+++ b/GuiSubtrans/SubtitleListModel.py
@@ -157,6 +157,13 @@ class SubtitleListModel(QAbstractProxyModel):
 
         return self.createIndex(row, column, line)
 
+    def parent(self, index : QModelIndex|QPersistentModelIndex = QModelIndex()) -> QModelIndex:
+        """
+        Returns the parent of the model item with the given index.
+        Since this is a flat model (no hierarchy), all items have the root as parent.
+        """
+        return QModelIndex()
+
     def data(self, index, role : int = Qt.ItemDataRole.DisplayRole):
         """
         Fetch the data for an index in the proxy model from the source model


### PR DESCRIPTION
## Problem:
The SubtitleListModel class inherits from `QAbstractProxyModel` but did not implement the required pure virtual `parent()` method. This caused runtime crashes with:

```
NotImplementedError: pure virtual method `QAbstractProxyModel.parent not implemented.
```
Additionally, the missing implementation triggered `OverflowError` exceptions in the `index()` method when calling `hasIndex()`.

## Solution:
Implemented the `parent()` method to return `QModelIndex()` for all items, which is the correct behavior for a flat (non-hierarchical) model.

### example error from logs:
```
NotImplementedError: pure virtual method 'QAbstractProxyModel.parent' not implemented.
OverflowError
Error calling Python override of QAbstractProxyModel::index(): Traceback (most recent call last):
  File "/.../llm-subtrans/GuiSubtrans/SubtitleListModel.py", line 135, in index
    if not self.hasIndex(row, column, parent):
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
OverflowError
NotImplementedError: pure virtual method 'QAbstractProxyModel.parent' not implemented.
OverflowError
```