### PR TITLE
Add terminology map support to batch-translate script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,9 @@ Avoid Unicode characters (✓ ✗) in print/log messages as these trigger Window
   - Examples: 
     `def func(self, param : str) -> str|None:` ✅ 
     `def func(self, param: str) -> str | None:` ❌
+- **`# type: ignore` is forbidden** unless suppressing a known third-party library gap (e.g. missing stubs). Never use it to paper over a type mismatch in project code — fix the types instead.
+  - When assigning a `dict[str, str]` to a `SettingsType` field, wrap it: `SettingsType(my_dict)` — or add a typed property/method to `Options` or the relevant class.
+  - `SettingsType` has typed getters (`get_str`, `get_bool`, `get_int`, `get_dict`, etc.) — always prefer these over raw `.get()` when a specific type is expected.
 - **Docstrings**: Triple-quoted concise descriptions for classes and methods
 - **Error handling**: Custom exceptions, specific except blocks, input validation, logging.warning/error
   - User-facing error messages should be localizable, using _()

--- a/PySubtrans/Options.py
+++ b/PySubtrans/Options.py
@@ -181,6 +181,14 @@ class Options(SettingsType):
         return self.get_str('target_language') or str(default_settings['target_language'])
 
     @property
+    def terminology_map(self) -> SettingsType:
+        return self.get_dict('terminology_map', SettingsType())
+
+    @terminology_map.setter
+    def terminology_map(self, value : dict[str, str]) -> None:
+        self['terminology_map'] = SettingsType(value)
+
+    @property
     def use_project_file(self) -> bool:
         return self.get_bool('project_file', True)
 

--- a/scripts/batch-translate.py
+++ b/scripts/batch-translate.py
@@ -52,6 +52,7 @@ from PySubtrans import TranslationProvider
 from PySubtrans import SubtitleFormatRegistry
 
 from PySubtrans.Helpers import GetOutputPath
+from PySubtrans.Helpers.Parse import ParseKeyValuePairs
 from PySubtrans.SettingsType import redact_sensitive_values
 
 # Default configuration options for batch processing.
@@ -74,6 +75,8 @@ DEFAULT_OPTIONS = SettingsType({
     'postprocess_translation': True,                # Whether to apply postprocessing steps to the translated subtitles
     'log_path': './batch-translate.log',
     'preview': False,                               # Set to True to exercise the workflow without calling the API to execute translations.
+    'use_terminology_map': False,                   # Build a terminology map across files for consistent name/term translation
+    'terminology_file': None,                       # File to persist the terminology map between runs (key::value per line)
 })
 
 class BatchJobConfig:
@@ -95,6 +98,8 @@ class BatchJobConfig:
         self.provider = self.options.get_str('provider')
         self.model = self.options.get_str('model')
         self.instruction_file = self.options.get_str('instruction_file')
+        self.use_terminology_map = self.options.get_bool('use_terminology_map')
+        self.terminology_file = self.options.get_str('terminology_file')
 
 class BatchProcessor:
     """Coordinate discovery and translation of subtitle files."""
@@ -105,6 +110,12 @@ class BatchProcessor:
         self.logger = logging.getLogger(__name__)
         self.progress_display = ProgressDisplay()
         self.translation_provider = self._initialise_provider()
+        self._terminology_map : dict[str, str] = {}
+        if config.use_terminology_map and config.terminology_file:
+            self._terminology_map = self._load_terminology_file(config.terminology_file)
+            if self._terminology_map:
+                self.options.terminology_map = self._terminology_map
+                self.logger.info("Loaded %d term(s) from %s", len(self._terminology_map), config.terminology_file)
 
     def run(self) -> BatchStatistics:
         """Execute the batch translation workflow."""
@@ -185,11 +196,14 @@ class BatchProcessor:
             except SubtitleError as exc:
                 raise SubtitleError(f"Unable to initialise translator: {exc}") from exc
 
-            # ProgressDisplay.track hooks into SubtitleTranslator events to provide 
+            if self.config.use_terminology_map:
+                translator.events.terminology_updated.connect(self._on_terminology_updated)
+
+            # ProgressDisplay.track hooks into SubtitleTranslator events to provide
             # a concise console progress indicator while the batches are being processed.
             with self.progress_display.track(translator, source_file, translator.preview):
                 try:
-                    # TranslateSubtitles drives the end-to-end translation process, 
+                    # TranslateSubtitles drives the end-to-end translation process,
                     # raising SubtitleError if the provider reports a problem.
                     translator.TranslateSubtitles(subtitles)
 
@@ -201,6 +215,18 @@ class BatchProcessor:
                     self.logger.exception("Unexpected error translating %s", source_file)
                     stats.failed_files += 1
                     continue
+
+            if self.config.use_terminology_map and not translator.preview:
+                updated_map = subtitles.settings.get('terminology_map')
+                if isinstance(updated_map, dict) and updated_map:
+                    prev_count = len(self._terminology_map)
+                    self._terminology_map = {k: str(v) for k, v in updated_map.items()}
+                    self.options.terminology_map = self._terminology_map
+                    new_count = len(self._terminology_map)
+                    if new_count != prev_count:
+                        self.logger.info("Terminology map now has %d term(s) (+%d)", new_count, new_count - prev_count)
+                    if self.config.terminology_file:
+                        self._save_terminology_file(self.config.terminology_file, self._terminology_map)
 
             if translator.preview:
                 self.logger.info("Preview mode enabled - skipping save for %s", source_file)
@@ -260,6 +286,32 @@ class BatchProcessor:
         destination_file.parent.mkdir(parents=True, exist_ok=True)
         return destination_file
 
+    def _on_terminology_updated(self, _sender, scene, batch, new_terms, conflict_terms, terminology_map, **_kwargs) -> None:
+        if new_terms:
+            sample = ', '.join(f"{k}::{v}" for k, v in list(new_terms.items())[:5])
+            self.logger.info("Scene %s batch %s: added %d new term(s): %s", scene, batch, len(new_terms), sample)
+        if conflict_terms:
+            self.logger.debug("Scene %s batch %s: %d conflicting term(s) skipped", scene, batch, len(conflict_terms))
+        self.progress_display.update_terminology_count(len(terminology_map))
+
+    def _load_terminology_file(self, path : str) -> dict[str, str]:
+        try:
+            content = pathlib.Path(path).read_text(encoding='utf-8')
+            return ParseKeyValuePairs(content)
+        except FileNotFoundError:
+            return {}
+        except OSError as exc:
+            self.logger.warning("Could not read terminology file %s: %s", path, exc)
+            return {}
+
+    def _save_terminology_file(self, path : str, terminology_map : dict[str, str]) -> None:
+        try:
+            content = '\n'.join(f"{k}::{v}" for k, v in sorted(terminology_map.items()))
+            pathlib.Path(path).write_text(content, encoding='utf-8')
+            self.logger.debug("Saved %d term(s) to %s", len(terminology_map), path)
+        except OSError as exc:
+            self.logger.warning("Could not save terminology file %s: %s", path, exc)
+
     def _initialise_provider(self) -> TranslationProvider:
         """
         Create and validate a translation provider instance based on the configured options
@@ -302,6 +354,10 @@ def build_config(args : argparse.Namespace) -> BatchJobConfig:
         settings['instruction_file'] = args.instruction_file
     if args.preview is not None:
         settings['preview'] = args.preview
+    if args.use_terminology_map is not None:
+        settings['use_terminology_map'] = args.use_terminology_map
+    if args.terminology_file is not None:
+        settings['terminology_file'] = args.terminology_file
 
     for override in args.option:
         if '=' not in override:
@@ -360,6 +416,7 @@ class ProgressDisplay:
         self._last_batch_summary : str = ""
         self._last_scene_label : str = ""
         self._last_scene_summary : str = ""
+        self._terminology_count : int = 0
 
     @contextmanager
     def track(self, translator : SubtitleTranslator, file_path : pathlib.Path, preview : bool):
@@ -384,6 +441,7 @@ class ProgressDisplay:
         self._last_batch_summary = ""
         self._last_scene_label = ""
         self._last_scene_summary = ""
+        self._terminology_count = 0
         translator.events.preprocessed.connect(self._on_preprocessed)
         translator.events.batch_translated.connect(self._on_batch_translated)
         translator.events.scene_translated.connect(self._on_scene_translated)
@@ -430,6 +488,8 @@ class ProgressDisplay:
         ]
         if self._total_lines:
             parts.append(f"lines {self._processed_lines}/{self._total_lines}")
+        if self._terminology_count:
+            parts.append(f"terms {self._terminology_count}")
         # if self._last_batch_summary:
         #     parts.append(f"last batch {self._last_batch_label}: {self._shorten(self._last_batch_summary)}")
         #if self._last_scene_summary:
@@ -444,6 +504,11 @@ class ProgressDisplay:
         self.stream.write(message + padding + end)
         self.stream.flush()
         self._last_message_length = len(message)
+
+    def update_terminology_count(self, count : int) -> None:
+        """Update the running term count and re-render the progress line."""
+        self._terminology_count = count
+        self._render()
 
     def _shorten(self, text : str, limit : int = 60) -> str:
         summary = text.strip()
@@ -496,9 +561,13 @@ def parse_args(argv : list[str]|None = None) -> argparse.Namespace:
     parser.add_argument("--log-file", dest="log_file", help="Path to write the detailed log file")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose console logging")
     parser.add_argument("--preview", dest="preview", action="store_true", help="Enable preview mode")
+    parser.add_argument("--use-terminology-map", dest="use_terminology_map", action="store_true",
+                        help="Build a shared terminology map across all files for consistent name/term translation")
+    parser.add_argument("--terminology-file", dest="terminology_file",
+                        help="File to persist the terminology map between runs (key::value per line)")
     parser.add_argument("--option", action="append", default=[], metavar="KEY=VALUE",
                         help="Override additional Options settings (repeatable)")
-    parser.set_defaults(preview=None)
+    parser.set_defaults(preview=None, use_terminology_map=None)
     return parser.parse_args(argv)
 
 


### PR DESCRIPTION
Accumulates a terminology map across all files in a batch so that character names and recurring terms stay consistent between episodes. Adds --use-terminology-map and --terminology-file CLI flags; the file persists the map between runs. Adds Options.terminology_map property to give SettingsType-safe access without type: ignore suppression. Also documents the type: ignore prohibition in CLAUDE.md.