### PR TITLE
Refactor terminology_map 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,9 @@ Avoid Unicode characters (✓ ✗) in print/log messages as these trigger Window
   - Examples: 
     `def func(self, param : str) -> str|None:` ✅ 
     `def func(self, param: str) -> str | None:` ❌
+- **`# type: ignore` is forbidden** unless suppressing a known third-party library gap (e.g. missing stubs). Never use it to paper over a type mismatch in project code — fix the types instead.
+  - When assigning a `dict[str, str]` to a `SettingsType` field, wrap it: `SettingsType(my_dict)` — or add a typed property/method to `Options` or the relevant class.
+  - `SettingsType` has typed getters (`get_str`, `get_bool`, `get_int`, `get_dict`, etc.) — always prefer these over raw `.get()` when a specific type is expected.
 - **Docstrings**: Triple-quoted concise descriptions for classes and methods
 - **Error handling**: Custom exceptions, specific except blocks, input validation, logging.warning/error
   - User-facing error messages should be localizable, using _()

--- a/GuiSubtrans/Commands/TranslateSceneCommand.py
+++ b/GuiSubtrans/Commands/TranslateSceneCommand.py
@@ -55,7 +55,7 @@ class TranslateSceneCommand(Command):
         if not translation_provider.ValidateSettings():
             raise CommandError(_("Translation provider settings are invalid"), command=self)
 
-        self.translator = SubtitleTranslator(options, translation_provider, resume=self.resume)
+        self.translator = SubtitleTranslator(options, translation_provider, resume=self.resume, terminology_map=project.subtitles.terminology_map)
 
         self.translator.events.batch_translated.connect(self._on_batch_translated)
         self.translator.events.batch_updated.connect(self._on_batch_updated)

--- a/GuiSubtrans/SettingsDialog.py
+++ b/GuiSubtrans/SettingsDialog.py
@@ -31,7 +31,7 @@ class SettingsDialog(QDialog):
             'ui_language': (str, _("The language of the application interface")),
             'theme': [],
             'target_language': (str, _("The default language to translate the subtitles to")),
-            'use_terminology_map': (bool, _("Build a terminology map during translation and use it to keep terminology consistent")),
+            'build_terminology_map': (bool, _("Build a terminology map during translation to keep terminology consistent")),
             'include_original': (bool, _("Include original text in translated subtitles")),
             'add_right_to_left_markers': (bool, _("Add RTL markers around translated lines that contain primarily right-to-left script on save")),
             'instruction_file': (str, _("Instructions for the translation provider to follow")),

--- a/GuiSubtrans/Widgets/ProjectSettings.py
+++ b/GuiSubtrans/Widgets/ProjectSettings.py
@@ -95,8 +95,8 @@ class ProjectSettings(QGroupBox):
                 logging.error(f"Error updating UI language in ProjectSettings: {e}")
 
     def SetDataModel(self, datamodel : ProjectDataModel|None):
-        if self.datamodel is not None and self.datamodel.project is not None:
-            self.datamodel.project.events.terminology_updated.disconnect(self._blinker_terminology_updated)
+        if self.datamodel is not None:
+            self._disconnect_from_datamodel()
 
         self.datamodel = datamodel
         if datamodel is None:
@@ -327,6 +327,10 @@ class ProjectSettings(QGroupBox):
                 logging.error(f"Error updating model list: {e}")
             finally:
                 self.updating_model_list = False
+
+    def _disconnect_from_datamodel(self):
+        if self.datamodel is not None and self.datamodel.project is not None:
+            self.datamodel.project.events.terminology_updated.disconnect(self._blinker_terminology_updated)
 
     def _edit_instructions(self):
         # Commit the settings

--- a/GuiSubtrans/Widgets/ProjectSettings.py
+++ b/GuiSubtrans/Widgets/ProjectSettings.py
@@ -119,9 +119,7 @@ class ProjectSettings(QGroupBox):
             self.settings['model'] = datamodel.selected_model
             self.settings['provider'] = datamodel.provider
             self.settings['project_path'] = os.path.dirname(datamodel.project.projectfile or "project.subtrans")
-            terminology = self.settings.get('terminology_map')
-            if isinstance(terminology, dict):
-                self.settings['terminology_map'] = FormatKeyValuePairs(terminology)
+            self.settings['terminology_map'] = FormatKeyValuePairs(datamodel.project.subtitles.terminology_map)
             datamodel.project.events.terminology_updated.connect(self._blinker_terminology_updated)
             self.BuildForm(self.settings)
 
@@ -393,6 +391,8 @@ class ProjectSettings(QGroupBox):
                 subtitles.settings.pop('instruction_file', None)
 
                 self.settings.update(subtitles.settings)
+                if subtitles.terminology_map:
+                    self.settings['terminology_map'] = FormatKeyValuePairs(subtitles.terminology_map)
                 self.Populate()
 
             except Exception as e:

--- a/GuiSubtrans/Widgets/ProjectSettings.py
+++ b/GuiSubtrans/Widgets/ProjectSettings.py
@@ -65,7 +65,7 @@ class ProjectSettings(QGroupBox):
             'include_original': self._getcheckboxvalue('include_original'),
             'description': self._gettextvalue('description'),
             'names': ParseNames(self._gettextvalue('names')),
-            'use_terminology_map': self._getcheckboxvalue('use_terminology_map'),
+            'build_terminology_map': self._getcheckboxvalue('build_terminology_map'),
             'substitutions': Substitutions.Parse(self._gettextvalue('substitutions')),
             'substitution_mode': self._gettextvalue('substitution_mode'),
             'terminology_map': self._gettextvalue('terminology_map') if 'terminology_map' in self.widgets else self.settings.get('terminology_map'),
@@ -138,8 +138,8 @@ class ProjectSettings(QGroupBox):
             self.AddCheckboxOption(_("Add RTL Markers"), settings, 'add_right_to_left_markers')
             self.AddMultiLineOption(_("Description"), settings, 'description')
             self.AddMultiLineOption(_("Names"), settings, 'names')
-            self.AddCheckboxOption(_("Use Terminology Map"), settings, 'use_terminology_map')
-            if settings.get('use_terminology_map'):
+            self.AddCheckboxOption(_("Build Terminology Map"), settings, 'build_terminology_map')
+            if settings.get('build_terminology_map'):
                 self.AddMultiLineOption(_("Terminology Map"), settings, 'terminology_map')
 
             self.AddMultiLineOption(_("Substitutions"), settings, 'substitutions')
@@ -289,8 +289,8 @@ class ProjectSettings(QGroupBox):
                     self.datamodel.UpdateProjectSettings({ "model": value })
                     self.settings['model'] = self.datamodel.selected_model
 
-            elif key == 'use_terminology_map':
-                self.settings['use_terminology_map'] = bool(value)
+            elif key == 'build_terminology_map':
+                self.settings['build_terminology_map'] = bool(value)
                 self.BuildForm(self.settings)
 
     def _update_provider_settings(self, provider : str):

--- a/PySubtrans/Helpers/ContextHelpers.py
+++ b/PySubtrans/Helpers/ContextHelpers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
-from PySubtrans.Helpers.Parse import FormatKeyValuePairs, ParseNames
+from PySubtrans.Helpers.Parse import ParseNames
 from PySubtrans.SubtitleError import SubtitleError
 
 if TYPE_CHECKING:
@@ -38,10 +38,6 @@ def GetBatchContext(subtitles: Subtitles, scene_number: int, batch_number: int, 
 
         if 'names' in subtitles.settings:
             context['names'] = ParseNames(subtitles.settings.get('names', []))
-
-        terminology_map = subtitles.settings.get('terminology_map')
-        if isinstance(terminology_map, dict) and terminology_map:
-            context['terminology'] = FormatKeyValuePairs(terminology_map)
 
         history_lines = GetHistory(subtitles, scene_number, batch_number, max_lines)
 

--- a/PySubtrans/Options.py
+++ b/PySubtrans/Options.py
@@ -181,6 +181,14 @@ class Options(SettingsType):
         return self.get_str('target_language') or str(default_settings['target_language'])
 
     @property
+    def terminology_map(self) -> SettingsType:
+        return self.get_dict('terminology_map', SettingsType())
+
+    @terminology_map.setter
+    def terminology_map(self, value : dict[str, str]) -> None:
+        self['terminology_map'] = SettingsType(value)
+
+    @property
     def use_project_file(self) -> bool:
         return self.get_bool('project_file', True)
 

--- a/PySubtrans/Options.py
+++ b/PySubtrans/Options.py
@@ -181,14 +181,6 @@ class Options(SettingsType):
         return self.get_str('target_language') or str(default_settings['target_language'])
 
     @property
-    def terminology_map(self) -> SettingsType:
-        return self.get_dict('terminology_map', SettingsType())
-
-    @terminology_map.setter
-    def terminology_map(self, value : dict[str, str]) -> None:
-        self['terminology_map'] = SettingsType(value)
-
-    @property
     def use_project_file(self) -> bool:
         return self.get_bool('project_file', True)
 

--- a/PySubtrans/Options.py
+++ b/PySubtrans/Options.py
@@ -81,7 +81,7 @@ default_settings = {
     'whitespaces_to_newline' : env_bool('WHITESPACES_TO_NEWLINE', False),
     'full_width_punctuation': env_bool('FULL_WIDTH_PUNCTUATION', False),
     'convert_wide_dashes': env_bool('CONVERT_WIDE_DASHES', True),
-    'use_terminology_map': env_bool('USE_TERMINOLOGY_MAP', False),
+    'build_terminology_map': env_bool('BUILD_TERMINOLOGY_MAP', False),
     'retry_on_error': env_bool('RETRY_ON_ERROR', True),
     'autosplit_on_error': env_bool('AUTOSPLIT_ON_ERROR', False),
     'max_lines': env_int('MAX_LINES', None),

--- a/PySubtrans/README.md
+++ b/PySubtrans/README.md
@@ -226,7 +226,7 @@ Note that there are a number of options which are only used by the GUI-Subtrans 
 
 ### Terminology map
 
-`use_terminology_map`: When enabled, PySubtrans instructs the model to report any names, titles or technical terms with the translation it used, and accumulates them into a terminology map that is injected into each subsequent batch's context, so the same translations are used consistently throughout the file.
+`build_terminology_map`: When enabled, PySubtrans instructs the model to report any names, titles or technical terms with the translation it used, and accumulates them into a terminology map that is injected into each subsequent batch's context, so the same translations are used consistently throughout the file.
 
 The map can also be seeded with translations by passing a `terminology_map` in the options.
 
@@ -241,7 +241,7 @@ from PySubtrans.Helpers.Parse import FormatKeyValuePairs
 
 options = init_options(
     prompt="Translate these subtitles into Japanese",
-    use_terminology_map=True,
+    build_terminology_map=True,
     terminology_map=["Alice::アリス", "Wonderland::ワンダーランド"],  # seed from episode 1
 )
 
@@ -252,7 +252,7 @@ translator.events.terminology_updated.connect(on_terminology_updated)
 translator.TranslateSubtitles(subtitles)
 ```
 
-Note: `use_terminology_map` controls whether the seed is injected into the prompt context **and** whether new terms are added to it - it is not currently possible to use only a pre-seeded terminology map.
+Note: `build_terminology_map` controls whether the model is asked to report new terms after each batch. A seed `terminology_map` passed to `init_translator` is always injected into the prompt context regardless of this setting.
 
 ## Advanced workflows
 

--- a/PySubtrans/README.md
+++ b/PySubtrans/README.md
@@ -228,7 +228,7 @@ Note that there are a number of options which are only used by the GUI-Subtrans 
 
 `build_terminology_map`: When enabled, PySubtrans instructs the model to report any names, titles or technical terms with the translation it used, and accumulates them into a terminology map that is injected into each subsequent batch's context, so the same translations are used consistently throughout the file.
 
-The map can also be seeded with translations by passing a `terminology_map` in the options.
+The map can be seeded with known translations by passing a `terminology_map` to `init_translator`. Accepted forms:
 
 - `dict`: `{"Alice": "アリス", "Wonderland": "ワンダーランド"}`
 - `list[str]`: `["Alice::アリス", "Wonderland::ワンダーランド"]`
@@ -237,19 +237,24 @@ The map can also be seeded with translations by passing a `terminology_map` in t
 
 ```python
 from PySubtrans import init_options, init_subtitles, init_translator
-from PySubtrans.Helpers.Parse import FormatKeyValuePairs
 
 options = init_options(
     prompt="Translate these subtitles into Japanese",
     build_terminology_map=True,
-    terminology_map=["Alice::アリス", "Wonderland::ワンダーランド"],  # seed from episode 1
 )
+
+subtitles = init_subtitles("episode2.srt", options=options)
+
+translator = init_translator(options, terminology_map={"Alice": "アリス", "Wonderland": "ワンダーランド"})
 
 def on_terminology_updated(sender, new_terms=None, terminology_map=None, **_):
     print(f"New terminology: {new_terms}")
 
 translator.events.terminology_updated.connect(on_terminology_updated)
 translator.TranslateSubtitles(subtitles)
+
+# Accumulated map is available on the translator after translation
+print(translator.terminology_map)
 ```
 
 Note: `build_terminology_map` controls whether the model is asked to report new terms after each batch. A seed `terminology_map` passed to `init_translator` is always injected into the prompt context regardless of this setting.

--- a/PySubtrans/SubtitleProject.py
+++ b/PySubtrans/SubtitleProject.py
@@ -5,7 +5,8 @@ import threading
 
 from PySubtrans.Helpers import GetOutputPath
 from PySubtrans.Helpers.Localization import _
-from PySubtrans.Helpers.Parse import ParseKeyValuePairs
+from PySubtrans.Helpers.Parse import ParseKeyValuePairs, ParseNames
+from PySubtrans.Substitutions import Substitutions
 from PySubtrans.Options import Options, SettingsType
 from PySubtrans.SettingsType import SettingsType
 from PySubtrans.SubtitleEditor import SubtitleEditor
@@ -193,12 +194,26 @@ class SubtitleProject:
             # Update obsolete settings to maintain compatibility
             self._update_compatibility(settings)
 
-            # Route terminology_map to the dedicated top-level attribute
-            if 'terminology_map' in settings:
-                parsed = ParseKeyValuePairs(settings.get('terminology_map', {}))
-                self.subtitles.terminology_map = parsed
+            # Filter to known project settings only
+            filtered = SettingsType({key: settings[key] for key in settings if key in self.DEFAULT_PROJECT_SETTINGS})
 
-            if self.subtitles.UpdateSettings(settings, keys=list(self.DEFAULT_PROJECT_SETTINGS.keys())):
+            # Route terminology_map to the dedicated top-level attribute; exclude from settings dict
+            terminology_changed = self._parse_terminology_map(filtered)
+
+            # Parse names and substitutions into standard formats
+            self._standardise_settings_format(filtered)
+
+            # Detect changes and update
+            common_keys = filtered.keys() & self.subtitles.settings.keys()
+            new_keys = filtered.keys() - self.subtitles.settings.keys()
+            settings_changed = bool(new_keys) or not all(
+                filtered.get(k) == self.subtitles.settings.get(k) for k in common_keys
+            )
+
+            if settings_changed:
+                self.subtitles.UpdateSettings(filtered)
+
+            if settings_changed or terminology_changed:
                 self.needs_writing = self.use_project_file and bool(self.subtitles.scenes)
 
     def UpdateOutputPath(self, path: str|None = None, extension: str|None = None) -> None:
@@ -483,6 +498,25 @@ class SubtitleProject:
             if self.subtitles.settings.get_str(setting_name) != value:
                 self.subtitles.settings[setting_name] = value
                 self.needs_writing = self.use_project_file
+
+    def _standardise_settings_format(self, filtered):
+        if 'names' in filtered:
+            filtered['names'] = ParseNames(filtered.get('names', []))
+
+        if 'substitutions' in filtered:
+            subs = filtered.get('substitutions', [])
+            if subs:
+                filtered['substitutions'] = Substitutions.Parse(subs)
+
+    def _parse_terminology_map(self, filtered):
+        terminology_changed = False
+        if 'terminology_map' in filtered:
+            parsed = ParseKeyValuePairs(filtered.get('terminology_map', {}))
+            if parsed != self.subtitles.terminology_map:
+                self.subtitles.terminology_map = parsed
+                terminology_changed = True
+            del filtered['terminology_map']
+        return terminology_changed
 
     def _update_compatibility(self, settings: SettingsType) -> None:
         """

--- a/PySubtrans/SubtitleProject.py
+++ b/PySubtrans/SubtitleProject.py
@@ -5,6 +5,7 @@ import threading
 
 from PySubtrans.Helpers import GetOutputPath
 from PySubtrans.Helpers.Localization import _
+from PySubtrans.Helpers.Parse import ParseKeyValuePairs
 from PySubtrans.Options import Options, SettingsType
 from PySubtrans.SettingsType import SettingsType
 from PySubtrans.SubtitleEditor import SubtitleEditor
@@ -42,7 +43,6 @@ class SubtitleProject:
         'add_right_to_left_markers': None,
         'instruction_file': None,
         'format': None,
-        'terminology_map': None
     })
    
     def __init__(self, persistent : bool = False):
@@ -192,6 +192,11 @@ class SubtitleProject:
 
             # Update obsolete settings to maintain compatibility
             self._update_compatibility(settings)
+
+            # Route terminology_map to the dedicated top-level attribute
+            if 'terminology_map' in settings:
+                parsed = ParseKeyValuePairs(settings.get('terminology_map', {}))
+                self.subtitles.terminology_map = parsed
 
             if self.subtitles.UpdateSettings(settings, keys=list(self.DEFAULT_PROJECT_SETTINGS.keys())):
                 self.needs_writing = self.use_project_file and bool(self.subtitles.scenes)
@@ -519,6 +524,8 @@ class SubtitleProject:
         self.events.scene_translated.send(self, scene=scene)
 
     def _on_terminology_updated(self, sender, scene, batch, returned_terms, new_terms, conflict_terms, terminology_map) -> None:
+        with self.subtitles.lock:
+            self.subtitles.terminology_map = dict(terminology_map)
         self.needs_writing = self.use_project_file
         self.events.terminology_updated.send(
             self,

--- a/PySubtrans/SubtitleProject.py
+++ b/PySubtrans/SubtitleProject.py
@@ -33,7 +33,7 @@ class SubtitleProject:
         'instructions': None,
         'retry_instructions': None,
         'terminology_instructions': None,
-        'use_terminology_map': None,
+        'build_terminology_map': None,
         'movie_name': None,
         'description': None,
         'names': None,

--- a/PySubtrans/SubtitleSerialisation.py
+++ b/PySubtrans/SubtitleSerialisation.py
@@ -40,7 +40,7 @@ class SubtitleEncoder(json.JSONEncoder):
             return None
 
         if isinstance(obj, Subtitles):
-            return {
+            result = {
                 "sourcepath": obj.sourcepath,
                 "outputpath": obj.outputpath,
                 "scenecount": len(obj.scenes),
@@ -49,6 +49,9 @@ class SubtitleEncoder(json.JSONEncoder):
                 "format": obj.file_format,
                 "scenes": obj.scenes,
             }
+            if obj.terminology_map:
+                result["terminology_map"] = obj.terminology_map
+            return result
         elif isinstance(obj, SubtitleScene):
             return {
                 "scene": getattr(obj, 'number'),
@@ -123,6 +126,8 @@ def _object_hook(dct):
             obj.settings = SettingsType(dct.get('settings', dct.get('context', {})))
             obj.metadata = dct.get('metadata', {})
             obj.file_format = dct.get('format', '.srt')
+            terminology = dct.get('terminology_map', {})
+            obj.terminology_map = {str(k): str(v) for k, v in terminology.items()} if isinstance(terminology, dict) else {}
             obj.scenes = dct.get('scenes', [])
             return obj
         elif class_name == classname(SubtitleScene):

--- a/PySubtrans/SubtitleSerialisation.py
+++ b/PySubtrans/SubtitleSerialisation.py
@@ -40,18 +40,16 @@ class SubtitleEncoder(json.JSONEncoder):
             return None
 
         if isinstance(obj, Subtitles):
-            result = {
+            return {
                 "sourcepath": obj.sourcepath,
                 "outputpath": obj.outputpath,
                 "scenecount": len(obj.scenes),
                 "settings": getattr(obj, 'settings', {}),
                 "metadata": getattr(obj, 'metadata', {}),
+                "terminology_map": obj.terminology_map,
                 "format": obj.file_format,
                 "scenes": obj.scenes,
             }
-            if obj.terminology_map:
-                result["terminology_map"] = obj.terminology_map
-            return result
         elif isinstance(obj, SubtitleScene):
             return {
                 "scene": getattr(obj, 'number'),

--- a/PySubtrans/SubtitleTranslator.py
+++ b/PySubtrans/SubtitleTranslator.py
@@ -32,7 +32,7 @@ class SubtitleTranslator:
     """
     Processes subtitles into scenes and batches and sends them for translation
     """
-    def __init__(self, settings: Options, translation_provider: TranslationProvider, resume: bool = False, terminology_map: dict[str,str]|None = None):
+    def __init__(self, settings : Options, translation_provider : TranslationProvider, resume : bool = False, terminology_map : dict[str,str]|None = None):
         """
         Initialise a SubtitleTranslator with translation options
         """

--- a/PySubtrans/SubtitleTranslator.py
+++ b/PySubtrans/SubtitleTranslator.py
@@ -4,11 +4,11 @@ import threading
 from typing import Any
 
 from PySubtrans.Helpers.ContextHelpers import GetBatchContext
+from PySubtrans.Helpers.Parse import FormatKeyValuePairs
 from PySubtrans.Helpers.SubtitleHelpers import FindBestSplitIndex, MergeTranslations
 from PySubtrans.Helpers.Localization import _
 from PySubtrans.Helpers.Text import Linearise, SanitiseSummary
 from PySubtrans.Instructions import DEFAULT_TASK_TYPE, Instructions
-from PySubtrans.SettingsType import SettingsType
 from PySubtrans.Substitutions import Substitutions
 from PySubtrans.SubtitleLine import SubtitleLine
 from PySubtrans.SubtitleProcessor import SubtitleProcessor
@@ -32,7 +32,7 @@ class SubtitleTranslator:
     """
     Processes subtitles into scenes and batches and sends them for translation
     """
-    def __init__(self, settings: Options, translation_provider: TranslationProvider, resume: bool = False):
+    def __init__(self, settings: Options, translation_provider: TranslationProvider, resume: bool = False, terminology_map: dict[str,str]|None = None):
         """
         Initialise a SubtitleTranslator with translation options
         """
@@ -48,6 +48,7 @@ class SubtitleTranslator:
         self.retry_on_error = settings.get_bool('retry_on_error')
         self.split_on_error = settings.get_bool('autosplit_on_error')
         self.use_terminology_map = settings.get_bool('use_terminology_map')
+        self.terminology_map : dict[str, str] = dict(terminology_map) if terminology_map else {}
         self.max_summary_length = settings.get_int('max_summary_length')
         self.retranslate = settings.get_bool('retranslate')
         self.reparse = settings.get_bool('reparse')
@@ -170,10 +171,12 @@ class SubtitleTranslator:
             for batch in batches:
                 context = GetBatchContext(subtitles, scene.number, batch.number, self.max_history)
 
-                # Store the terminology that will be injected into this batch's prompt so that
-                # batch_translated observers can read it from batch.context['terminology'].
-                if self.use_terminology_map and context.get('terminology'):
-                    batch.AddContext('terminology', context['terminology'])
+                # Inject terminology into the context so it appears in the batch prompt.
+                # Store it on the batch so batch_translated observers can read batch.context['terminology'].
+                if self.use_terminology_map and self.terminology_map:
+                    formatted = FormatKeyValuePairs(self.terminology_map)
+                    context['terminology'] = formatted
+                    batch.AddContext('terminology', formatted)
 
                 try:
                     self.TranslateBatch(batch, line_numbers, context)
@@ -195,7 +198,7 @@ class SubtitleTranslator:
                 self.events.batch_translated.send(self, batch=batch)
 
                 if self.use_terminology_map:
-                    self._update_terminology_map(subtitles, batch)
+                    self._update_terminology_map(batch)
 
                 if batch.errors:
                     self._emit_warning(_("Errors encountered translating scene {scene} batch {batch}").format(scene=batch.scene, batch=batch.number))
@@ -566,9 +569,9 @@ class SubtitleTranslator:
         except Exception:
             pass
 
-    def _update_terminology_map(self, subtitles : Subtitles, batch : SubtitleBatch):
+    def _update_terminology_map(self, batch : SubtitleBatch):
         """
-        Merge terminology returned by a batch translation into the shared terminology map.
+        Merge terminology returned by a batch translation into self.terminology_map.
         Only new terms are added; existing entries are preserved to avoid data loss.
         """
         if not batch.translation or not batch.translation.terminology:
@@ -581,9 +584,7 @@ class SubtitleTranslator:
         original_text = ' '.join(line.text or '' for line in batch.originals)
         translated_text = ' '.join(line.text or '' for line in batch.translated)
 
-        with subtitles.lock:
-            existing_map = subtitles.settings.get_dict('terminology_map', SettingsType())
-
+        with self.lock:
             for term, proposed in returned_terms.items():
                 term_norm = str(term).strip()
                 proposed_norm = str(proposed).strip()
@@ -606,16 +607,14 @@ class SubtitleTranslator:
                 if proposed_norm not in translated_text:
                     continue
 
-                existing = existing_map.get_str(term)
+                existing = self.terminology_map.get(term)
                 if existing is None:
                     new_terms[term] = proposed
                 elif existing != proposed:
                     conflict_terms[term] = (existing, proposed)
 
-            existing_map.update(new_terms)
-            subtitles.settings['terminology_map'] = existing_map
-
-            snapshot : dict[str, str] = {k: str(v) for k, v in existing_map.items()}
+            self.terminology_map.update(new_terms)
+            snapshot : dict[str, str] = dict(self.terminology_map)
 
         self.events.terminology_updated.send(
             self,

--- a/PySubtrans/SubtitleTranslator.py
+++ b/PySubtrans/SubtitleTranslator.py
@@ -171,9 +171,7 @@ class SubtitleTranslator:
             for batch in batches:
                 context = GetBatchContext(subtitles, scene.number, batch.number, self.max_history)
 
-                # Inject terminology into the context so it appears in the batch prompt.
-                # Store it on the batch so batch_translated observers can read batch.context['terminology'].
-                if self.use_terminology_map and self.terminology_map:
+                if self.terminology_map:
                     formatted = FormatKeyValuePairs(self.terminology_map)
                     context['terminology'] = formatted
                     batch.AddContext('terminology', formatted)

--- a/PySubtrans/SubtitleTranslator.py
+++ b/PySubtrans/SubtitleTranslator.py
@@ -47,7 +47,7 @@ class SubtitleTranslator:
         self.stop_on_error = settings.get_bool('stop_on_error')
         self.retry_on_error = settings.get_bool('retry_on_error')
         self.split_on_error = settings.get_bool('autosplit_on_error')
-        self.use_terminology_map = settings.get_bool('use_terminology_map')
+        self.build_terminology_map = settings.get_bool('build_terminology_map')
         self.terminology_map : dict[str, str] = dict(terminology_map) if terminology_map else {}
         self.max_summary_length = settings.get_int('max_summary_length')
         self.retranslate = settings.get_bool('retranslate')
@@ -62,7 +62,7 @@ class SubtitleTranslator:
         self.user_prompt : str = settings.BuildUserPrompt()
 
         base_instructions = self.instructions.instructions or ''
-        if self.use_terminology_map and self.instructions.terminology_instructions:
+        if self.build_terminology_map and self.instructions.terminology_instructions:
             self.system_instructions : str = '\n\n'.join(filter(None, [base_instructions, self.instructions.terminology_instructions]))
         else:
             self.system_instructions : str = base_instructions
@@ -195,7 +195,7 @@ class SubtitleTranslator:
                 # Notify observers the batch was translated
                 self.events.batch_translated.send(self, batch=batch)
 
-                if self.use_terminology_map:
+                if self.build_terminology_map:
                     self._update_terminology_map(batch)
 
                 if batch.errors:

--- a/PySubtrans/Subtitles.py
+++ b/PySubtrans/Subtitles.py
@@ -6,7 +6,7 @@ import logging
 import threading
 from typing import Any
 from PySubtrans.Helpers.Localization import _
-from PySubtrans.Helpers.Parse import ParseKeyValuePairs, ParseNames
+from PySubtrans.Helpers.Parse import ParseNames
 from PySubtrans.Options import Options
 from PySubtrans.Substitutions import Substitutions
 
@@ -37,6 +37,7 @@ class Subtitles:
 
         self.metadata : dict[str, Any] = {}
         self.file_format : str|None = None
+        self.terminology_map : dict[str, str] = {}
 
         self.settings : SettingsType = SettingsType(deepcopy(settings)) if settings else SettingsType()
 
@@ -319,9 +320,6 @@ class Subtitles:
             subs = filtered.get('substitutions', [])
             if subs:
                 filtered['substitutions'] = Substitutions.Parse(subs)
-
-        if 'terminology_map' in filtered:
-            filtered.set('terminology_map', ParseKeyValuePairs(filtered['terminology_map']))
 
         with self.lock:
             common_keys = filtered.keys() & self.settings.keys()

--- a/PySubtrans/Subtitles.py
+++ b/PySubtrans/Subtitles.py
@@ -6,9 +6,7 @@ import logging
 import threading
 from typing import Any
 from PySubtrans.Helpers.Localization import _
-from PySubtrans.Helpers.Parse import ParseNames
 from PySubtrans.Options import Options
-from PySubtrans.Substitutions import Substitutions
 
 from PySubtrans.SettingsType import SettingsType
 from PySubtrans.SubtitleBatch import SubtitleBatch
@@ -301,36 +299,15 @@ class Subtitles:
             self.translated = translated
             self.outputpath = outputpath
 
-    def UpdateSettings(self, settings : SettingsType|Options, keys : list[str]|None = None) -> bool:
+    def UpdateSettings(self, settings : SettingsType|Options) -> None:
         """
-        Apply per-key parsing and merge settings into self.settings.
-
-        If *keys* is provided, only those keys are considered (others are ignored).
-        Returns True if any setting value actually changed.
+        Merge settings into self.settings.
         """
         if isinstance(settings, Options):
             settings = SettingsType(settings)
 
-        filtered = SettingsType({k: settings[k] for k in settings if keys is None or k in keys})
-
-        if 'names' in filtered:
-            filtered['names'] = ParseNames(filtered.get('names', []))
-
-        if 'substitutions' in filtered:
-            subs = filtered.get('substitutions', [])
-            if subs:
-                filtered['substitutions'] = Substitutions.Parse(subs)
-
         with self.lock:
-            common_keys = filtered.keys() & self.settings.keys()
-            new_keys = filtered.keys() - self.settings.keys()
-            changed = bool(new_keys) or not all(
-                filtered.get(k) == self.settings.get(k) for k in common_keys
-            )
-            if changed:
-                self.settings.update(filtered)
-
-        return changed
+            self.settings.update(settings)
 
     def _renumber_if_needed(self, lines : list[SubtitleLine]|None) -> None:
         """

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -75,7 +75,7 @@ def init_options(**settings: SettingType) -> Options:
         target_language = "French",
         instruction_file = "instructions.txt",
         postprocess_translation = True,
-        use_terminology_map = True,
+        build_terminology_map = True,
 
         See :class:`Options` for available settings. 
         Options that are not specified will be assigned default values.
@@ -288,7 +288,7 @@ def init_translator(
 
     # Subscribe to events (see TranslationEvents for full list):
     #   batch_translated, scene_translated, batch_updated, preprocessed
-    #   terminology_updated  -- fired after each batch when use_terminology_map=True
+    #   terminology_updated  -- fired after each batch when build_terminology_map=True
     #   error, warning, info
     """
     options = Options(settings)

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -113,7 +113,6 @@ def init_subtitles(
     *,
     options: Options|SettingsType|None = None,
     auto_batch: bool = True,
-    persistent_keys : list[str]|None = None,
 ) -> Subtitles:
     """
     Initialise a :class:`Subtitles` instance and optionally load content from a file or string.
@@ -128,14 +127,9 @@ def init_subtitles(
 
     options : Options or SettingsType, optional
         Settings for pre-processing and batching subtitles, e.g. `scene_threshold`, `min_batch_size`, `max_batch_size`.
-        Also accepts settings such as `terminology_map`, `names`, and `substitutions` which are
-        stored in the returned :class:`Subtitles` instance, so that they are available during translation.
 
     auto_batch : bool, optional
         If True (default), automatically divide the subtitles into scenes and batches ready for translation.
-
-    persistent_keys : list of str, optional
-        List of settings keys to store in the returned :class:`Subtitles` instance (by default all provided settings are stored). 
 
     Returns
     -------
@@ -169,7 +163,6 @@ def init_subtitles(
         raise SubtitleError("No subtitle lines were loaded from the supplied input")
 
     options = Options(options)
-    subtitles.UpdateSettings(options, keys=persistent_keys)
 
     if options.get_bool('preprocess_subtitles'):
         preprocess_subtitles(subtitles, options)

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -275,6 +275,9 @@ def init_translator(
     opts = init_options(provider="OpenAI", model="gpt-5-mini", api_key="sk-   ", prompt="Translate these subtitles into Spanish")
     translator = init_translator(opts)
 
+    # Create translator from a plain dictionary
+    translator = init_translator({"provider": "gemini", "api_key": "your-key", "model": "gemini-2.5-flash"})
+
     # Create translator with a terminology seed
     translator = init_translator(opts, terminology_map={"Dragon": "Drache", "Hero": "Held"})
 

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -76,7 +76,6 @@ def init_options(**settings: SettingType) -> Options:
         instruction_file = "instructions.txt",
         postprocess_translation = True,
         use_terminology_map = True,
-        terminology_map = ["the Watch::la Garde", "Kingslayer::Régicide"]
 
         See :class:`Options` for available settings. 
         Options that are not specified will be assigned default values.
@@ -244,6 +243,7 @@ def init_translation_provider(
 def init_translator(
     settings : Options|SettingsType,
     translation_provider : TranslationProvider|None = None,
+    terminology_map : dict[str,str]|None = None,
 ) -> SubtitleTranslator:
     """
     Return a ready-to-use :class:`SubtitleTranslator` using the specified settings.
@@ -254,6 +254,9 @@ def init_translator(
         The translator settings. This should specify the provider and model to use, along with extra configuration options as needed.
     translation_provider : TranslationProvider or None, optional
         An pre-configured :class:`TranslationProvider` instance (if not specified a provider is created automatically based on the settings).
+    terminology_map : dict[str, str] or None, optional
+        Seed terminology map used to guide consistent term translation.  The translator builds on this map as translation proceeds;
+        subscribe to the ``terminology_updated`` event to receive snapshots after each batch.
 
     Exceptions
     ----------
@@ -272,8 +275,8 @@ def init_translator(
     opts = init_options(provider="OpenAI", model="gpt-5-mini", api_key="sk-   ", prompt="Translate these subtitles into Spanish")
     translator = init_translator(opts)
 
-    # Create translator from dictionary
-    translator = init_translator({"provider": "gemini", "api_key": "your-key", "model": "gemini-2.5-flash"})
+    # Create translator with a terminology seed
+    translator = init_translator(opts, terminology_map={"Dragon": "Drache", "Hero": "Held"})
 
     # Create translator with a pre-initialised TranslationProvider
     provider = init_translation_provider("OpenAI", {"model": "gpt-5-mini", "api_key": "sk-..."})
@@ -295,7 +298,7 @@ def init_translator(
 
     options.provider = translation_provider.name
 
-    return SubtitleTranslator(options, translation_provider)
+    return SubtitleTranslator(options, translation_provider, terminology_map=terminology_map)
 
 
 def init_project(

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -113,7 +113,7 @@ def init_subtitles(
     *,
     options: Options|SettingsType|None = None,
     auto_batch: bool = True,
-    persistent_keys: list[str] | None = None,
+    persistent_keys : list[str]|None = None,
 ) -> Subtitles:
     """
     Initialise a :class:`Subtitles` instance and optionally load content from a file or string.

--- a/readme.md
+++ b/readme.md
@@ -201,9 +201,9 @@ llm-subtrans -l <language> -o output.srt input.ass
 llm-subtrans -s <server_address> -e <endpoint> -k <api_key> -l <language> <path_to_subtitle_file>
 
 # Use specific providers
-gpt-subtrans --model gpt-5-mini --target_language <target_language> <path_to_subtitle_file>
-gemini-subtrans --model gemini-2.5-flash-latest --target_language <target_language> <path_to_subtitle_file>
-claude-subtrans --model claude-3-5-haiku-latest --target_language <target_language> <path_to_subtitle_file>
+gpt-subtrans --model gpt-5-mini --target-language <target_language> <path_to_subtitle_file>
+gemini-subtrans --model gemini-2.5-flash-latest --target-language <target_language> <path_to_subtitle_file>
+claude-subtrans --model claude-3-5-haiku-latest --target-language <target_language> <path_to_subtitle_file>
 
 # List supported subtitle formats
 llm-subtrans --list-formats
@@ -255,7 +255,7 @@ llm-subtrans path/to/my/subtitles.srt --moviename "My Awesome Movie" --ratelimit
 
 Default values for many settings can be set in the .env file, using a NAME_IN_CAPS format. See Options.py and the various Provider_XXX files for the full list.
 
-- `-l`, `--target_language`:
+- `-l`, `--target-language`:
   The language to translate the subtitles to.
 
 - `-o`, `--output`:
@@ -279,7 +279,7 @@ Default values for many settings can be set in the .env file, using a NAME_IN_CA
 - `--substitution`:
   A pair of strings separated by `::`, to substitute in either source or translation, or the name of a file containing a list of such pairs.
 
-- `--build_terminology_map`:
+- `--build-terminology-map`:
   Accumulates names, titles and technical terms into a terminology map that is provided to subsequent batches so that consistent translations can be used throughout.
 
 - `--terminology`:

--- a/readme.md
+++ b/readme.md
@@ -283,8 +283,8 @@ Default values for many settings can be set in the .env file, using a NAME_IN_CA
   Accumulates names, titles and technical terms into a terminology map that is provided to subsequent batches so that consistent translations can be used throughout.
 
 - `--terminology`:
-  Seed the terminology map with a `SOURCE::TRANSLATION` pair, or a path to a text file of such pairs. Repeatable. Implies `--build_terminology_map`.
-  Example: `--terminology "Alice::アリス" --terminology wonderland_names.txt`
+  Seed the terminology map with a `SOURCE::TRANSLATION` pair, or a path to a text file of such pairs. Repeatable.
+  Example: `--terminology "Alice::アリス" --terminology wonderland_locations.txt`
 
 - `--scenethreshold`:
   Number of seconds between lines to consider it a new scene.

--- a/scripts/batch-translate.py
+++ b/scripts/batch-translate.py
@@ -75,7 +75,7 @@ DEFAULT_OPTIONS = SettingsType({
     'postprocess_translation': True,                # Whether to apply postprocessing steps to the translated subtitles
     'log_path': './batch-translate.log',
     'preview': False,                               # Set to True to exercise the workflow without calling the API to execute translations.
-    'use_terminology_map': False,                   # Build a terminology map across files for consistent name/term translation
+    'build_terminology_map': False,                 # Build a terminology map across files for consistent name/term translation
     'terminology_file': None,                       # File to persist the terminology map between runs (key::value per line)
 })
 
@@ -98,7 +98,7 @@ class BatchJobConfig:
         self.provider = self.options.get_str('provider')
         self.model = self.options.get_str('model')
         self.instruction_file = self.options.get_str('instruction_file')
-        self.use_terminology_map = self.options.get_bool('use_terminology_map')
+        self.build_terminology_map = self.options.get_bool('build_terminology_map')
         self.terminology_file = self.options.get_str('terminology_file')
 
 class BatchProcessor:
@@ -111,7 +111,7 @@ class BatchProcessor:
         self.progress_display = ProgressDisplay()
         self.translation_provider = self._initialise_provider()
         self._terminology_map : dict[str, str] = {}
-        if config.use_terminology_map and config.terminology_file:
+        if config.build_terminology_map and config.terminology_file:
             self._terminology_map = self._load_terminology_file(config.terminology_file)
             if self._terminology_map:
                 self.logger.info("Loaded %d term(s) from %s", len(self._terminology_map), config.terminology_file)
@@ -161,7 +161,7 @@ class BatchProcessor:
 
             try:
                 subtitles = init_subtitles(filepath=str(source_file), options=self.options)
-                if self.config.use_terminology_map:
+                if self.config.build_terminology_map:
                     subtitles.terminology_map = dict(self._terminology_map)
 
             except SubtitleError as exc:
@@ -189,7 +189,7 @@ class BatchProcessor:
                 translator : SubtitleTranslator = init_translator(
                     self.options,
                     translation_provider=self.translation_provider,
-                    terminology_map=self._terminology_map if self.config.use_terminology_map else None,
+                    terminology_map=self._terminology_map if self.config.build_terminology_map else None,
                 )
 
                 # Connect the batch script logger to translation events
@@ -198,7 +198,7 @@ class BatchProcessor:
             except SubtitleError as exc:
                 raise SubtitleError(f"Unable to initialise translator: {exc}") from exc
 
-            if self.config.use_terminology_map:
+            if self.config.build_terminology_map:
                 translator.events.terminology_updated.connect(self._on_terminology_updated)
 
             # ProgressDisplay.track hooks into SubtitleTranslator events to provide
@@ -218,7 +218,7 @@ class BatchProcessor:
                     stats.failed_files += 1
                     continue
 
-            if self.config.use_terminology_map and not translator.preview:
+            if self.config.build_terminology_map and not translator.preview:
                 updated_map = subtitles.terminology_map
                 if updated_map:
                     prev_count = len(self._terminology_map)
@@ -355,8 +355,8 @@ def build_config(args : argparse.Namespace) -> BatchJobConfig:
         settings['instruction_file'] = args.instruction_file
     if args.preview is not None:
         settings['preview'] = args.preview
-    if args.use_terminology_map is not None:
-        settings['use_terminology_map'] = args.use_terminology_map
+    if args.build_terminology_map is not None:
+        settings['build_terminology_map'] = args.build_terminology_map
     if args.terminology_file is not None:
         settings['terminology_file'] = args.terminology_file
 
@@ -562,13 +562,13 @@ def parse_args(argv : list[str]|None = None) -> argparse.Namespace:
     parser.add_argument("--log-file", dest="log_file", help="Path to write the detailed log file")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose console logging")
     parser.add_argument("--preview", dest="preview", action="store_true", help="Enable preview mode")
-    parser.add_argument("--use-terminology-map", dest="use_terminology_map", action="store_true",
+    parser.add_argument("--build-terminology-map", dest="build_terminology_map", action="store_true",
                         help="Build a shared terminology map across all files for consistent name/term translation")
     parser.add_argument("--terminology-file", dest="terminology_file",
                         help="File to persist the terminology map between runs (key::value per line)")
     parser.add_argument("--option", action="append", default=[], metavar="KEY=VALUE",
                         help="Override additional Options settings (repeatable)")
-    parser.set_defaults(preview=None, use_terminology_map=None)
+    parser.set_defaults(preview=None, build_terminology_map=None)
     return parser.parse_args(argv)
 
 

--- a/scripts/batch-translate.py
+++ b/scripts/batch-translate.py
@@ -114,7 +114,6 @@ class BatchProcessor:
         if config.use_terminology_map and config.terminology_file:
             self._terminology_map = self._load_terminology_file(config.terminology_file)
             if self._terminology_map:
-                self.options.terminology_map = self._terminology_map
                 self.logger.info("Loaded %d term(s) from %s", len(self._terminology_map), config.terminology_file)
 
     def run(self) -> BatchStatistics:
@@ -161,8 +160,9 @@ class BatchProcessor:
             self.logger.info("[%d/%d] Loading %s", index, len(files), source_file)
 
             try:
-                # init_subtitles loads and batches the file using the Options we prepared earlier.
                 subtitles = init_subtitles(filepath=str(source_file), options=self.options)
+                if self.config.use_terminology_map:
+                    subtitles.terminology_map = dict(self._terminology_map)
 
             except SubtitleError as exc:
                 self.logger.error("Failed to load %s: %s", source_file, exc)
@@ -186,9 +186,11 @@ class BatchProcessor:
                 continue
 
             try:
-                # init_translator builds a ready-to-use SubtitleTranslator
-                # configured with our provider and processing settings.
-                translator : SubtitleTranslator = init_translator(self.options, translation_provider=self.translation_provider)
+                translator : SubtitleTranslator = init_translator(
+                    self.options,
+                    translation_provider=self.translation_provider,
+                    terminology_map=self._terminology_map if self.config.use_terminology_map else None,
+                )
 
                 # Connect the batch script logger to translation events
                 translator.events.connect_logger(self.logger)
@@ -217,11 +219,10 @@ class BatchProcessor:
                     continue
 
             if self.config.use_terminology_map and not translator.preview:
-                updated_map = subtitles.settings.get('terminology_map')
-                if isinstance(updated_map, dict) and updated_map:
+                updated_map = subtitles.terminology_map
+                if updated_map:
                     prev_count = len(self._terminology_map)
-                    self._terminology_map = {k: str(v) for k, v in updated_map.items()}
-                    self.options.terminology_map = self._terminology_map
+                    self._terminology_map = dict(updated_map)
                     new_count = len(self._terminology_map)
                     if new_count != prev_count:
                         self.logger.info("Terminology map now has %d term(s) (+%d)", new_count, new_count - prev_count)

--- a/scripts/batch-translate.py
+++ b/scripts/batch-translate.py
@@ -219,15 +219,13 @@ class BatchProcessor:
                     continue
 
             if self.config.build_terminology_map and not translator.preview:
-                updated_map = subtitles.terminology_map
-                if updated_map:
-                    prev_count = len(self._terminology_map)
-                    self._terminology_map = dict(updated_map)
-                    new_count = len(self._terminology_map)
-                    if new_count != prev_count:
-                        self.logger.info("Terminology map now has %d term(s) (+%d)", new_count, new_count - prev_count)
-                    if self.config.terminology_file:
-                        self._save_terminology_file(self.config.terminology_file, self._terminology_map)
+                prev_count = len(self._terminology_map)
+                self._terminology_map = dict(translator.terminology_map)
+                new_count = len(self._terminology_map)
+                if new_count != prev_count:
+                    self.logger.info("Terminology map now has %d term(s) (+%d)", new_count, new_count - prev_count)
+                if self._terminology_map and self.config.terminology_file:
+                    self._save_terminology_file(self.config.terminology_file, self._terminology_map)
 
             if translator.preview:
                 self.logger.info("Preview mode enabled - skipping save for %s", source_file)
@@ -288,6 +286,7 @@ class BatchProcessor:
         return destination_file
 
     def _on_terminology_updated(self, _sender, scene, batch, new_terms, conflict_terms, terminology_map, **_kwargs) -> None:
+        self._terminology_map = dict(terminology_map)
         if new_terms:
             sample = ', '.join(f"{k}::{v}" for k, v in list(new_terms.items())[:5])
             self.logger.info("Scene %s batch %s: added %d new term(s): %s", scene, batch, len(new_terms), sample)

--- a/scripts/batch-translate.py
+++ b/scripts/batch-translate.py
@@ -52,6 +52,7 @@ from PySubtrans import TranslationProvider
 from PySubtrans import SubtitleFormatRegistry
 
 from PySubtrans.Helpers import GetOutputPath
+from PySubtrans.Helpers.Parse import ParseKeyValuePairs
 from PySubtrans.SettingsType import redact_sensitive_values
 
 # Default configuration options for batch processing.
@@ -74,6 +75,8 @@ DEFAULT_OPTIONS = SettingsType({
     'postprocess_translation': True,                # Whether to apply postprocessing steps to the translated subtitles
     'log_path': './batch-translate.log',
     'preview': False,                               # Set to True to exercise the workflow without calling the API to execute translations.
+    'use_terminology_map': False,                   # Build a terminology map across files for consistent name/term translation
+    'terminology_file': None,                       # File to persist the terminology map between runs (key::value per line)
 })
 
 class BatchJobConfig:
@@ -95,6 +98,8 @@ class BatchJobConfig:
         self.provider = self.options.get_str('provider')
         self.model = self.options.get_str('model')
         self.instruction_file = self.options.get_str('instruction_file')
+        self.use_terminology_map = self.options.get_bool('use_terminology_map')
+        self.terminology_file = self.options.get_str('terminology_file')
 
 class BatchProcessor:
     """Coordinate discovery and translation of subtitle files."""
@@ -105,6 +110,12 @@ class BatchProcessor:
         self.logger = logging.getLogger(__name__)
         self.progress_display = ProgressDisplay()
         self.translation_provider = self._initialise_provider()
+        self._terminology_map : dict[str, str] = {}
+        if config.use_terminology_map and config.terminology_file:
+            self._terminology_map = self._load_terminology_file(config.terminology_file)
+            if self._terminology_map:
+                self.options.terminology_map = self._terminology_map
+                self.logger.info("Loaded %d term(s) from %s", len(self._terminology_map), config.terminology_file)
 
     def run(self) -> BatchStatistics:
         """Execute the batch translation workflow."""
@@ -185,11 +196,14 @@ class BatchProcessor:
             except SubtitleError as exc:
                 raise SubtitleError(f"Unable to initialise translator: {exc}") from exc
 
-            # ProgressDisplay.track hooks into SubtitleTranslator events to provide 
+            if self.config.use_terminology_map:
+                translator.events.terminology_updated.connect(self._on_terminology_updated)
+
+            # ProgressDisplay.track hooks into SubtitleTranslator events to provide
             # a concise console progress indicator while the batches are being processed.
             with self.progress_display.track(translator, source_file, translator.preview):
                 try:
-                    # TranslateSubtitles drives the end-to-end translation process, 
+                    # TranslateSubtitles drives the end-to-end translation process,
                     # raising SubtitleError if the provider reports a problem.
                     translator.TranslateSubtitles(subtitles)
 
@@ -201,6 +215,18 @@ class BatchProcessor:
                     self.logger.exception("Unexpected error translating %s", source_file)
                     stats.failed_files += 1
                     continue
+
+            if self.config.use_terminology_map and not translator.preview:
+                updated_map = subtitles.settings.get('terminology_map')
+                if isinstance(updated_map, dict) and updated_map:
+                    prev_count = len(self._terminology_map)
+                    self._terminology_map = {k: str(v) for k, v in updated_map.items()}
+                    self.options.terminology_map = self._terminology_map
+                    new_count = len(self._terminology_map)
+                    if new_count != prev_count:
+                        self.logger.info("Terminology map now has %d term(s) (+%d)", new_count, new_count - prev_count)
+                    if self.config.terminology_file:
+                        self._save_terminology_file(self.config.terminology_file, self._terminology_map)
 
             if translator.preview:
                 self.logger.info("Preview mode enabled - skipping save for %s", source_file)
@@ -260,6 +286,32 @@ class BatchProcessor:
         destination_file.parent.mkdir(parents=True, exist_ok=True)
         return destination_file
 
+    def _on_terminology_updated(self, _sender, scene, batch, new_terms, conflict_terms, terminology_map, **_kwargs) -> None:
+        if new_terms:
+            sample = ', '.join(f"{k}::{v}" for k, v in list(new_terms.items())[:5])
+            self.logger.info("Scene %s batch %s: added %d new term(s): %s", scene, batch, len(new_terms), sample)
+        if conflict_terms:
+            self.logger.debug("Scene %s batch %s: %d conflicting term(s) skipped", scene, batch, len(conflict_terms))
+        self.progress_display.update_terminology_count(len(terminology_map))
+
+    def _load_terminology_file(self, path : str) -> dict[str, str]:
+        try:
+            content = pathlib.Path(path).read_text(encoding='utf-8')
+            return ParseKeyValuePairs(content)
+        except FileNotFoundError:
+            return {}
+        except OSError as exc:
+            self.logger.warning("Could not read terminology file %s: %s", path, exc)
+            return {}
+
+    def _save_terminology_file(self, path : str, terminology_map : dict[str, str]) -> None:
+        try:
+            content = '\n'.join(f"{k}::{v}" for k, v in sorted(terminology_map.items()))
+            pathlib.Path(path).write_text(content, encoding='utf-8')
+            self.logger.debug("Saved %d term(s) to %s", len(terminology_map), path)
+        except OSError as exc:
+            self.logger.warning("Could not save terminology file %s: %s", path, exc)
+
     def _initialise_provider(self) -> TranslationProvider:
         """
         Create and validate a translation provider instance based on the configured options
@@ -302,6 +354,10 @@ def build_config(args : argparse.Namespace) -> BatchJobConfig:
         settings['instruction_file'] = args.instruction_file
     if args.preview is not None:
         settings['preview'] = args.preview
+    if args.use_terminology_map is not None:
+        settings['use_terminology_map'] = args.use_terminology_map
+    if args.terminology_file is not None:
+        settings['terminology_file'] = args.terminology_file
 
     for override in args.option:
         if '=' not in override:
@@ -360,6 +416,7 @@ class ProgressDisplay:
         self._last_batch_summary : str = ""
         self._last_scene_label : str = ""
         self._last_scene_summary : str = ""
+        self._terminology_count : int = 0
 
     @contextmanager
     def track(self, translator : SubtitleTranslator, file_path : pathlib.Path, preview : bool):
@@ -384,6 +441,7 @@ class ProgressDisplay:
         self._last_batch_summary = ""
         self._last_scene_label = ""
         self._last_scene_summary = ""
+        self._terminology_count = 0
         translator.events.preprocessed.connect(self._on_preprocessed)
         translator.events.batch_translated.connect(self._on_batch_translated)
         translator.events.scene_translated.connect(self._on_scene_translated)
@@ -430,6 +488,8 @@ class ProgressDisplay:
         ]
         if self._total_lines:
             parts.append(f"lines {self._processed_lines}/{self._total_lines}")
+        if self._terminology_count:
+            parts.append(f"terms {self._terminology_count}")
         # if self._last_batch_summary:
         #     parts.append(f"last batch {self._last_batch_label}: {self._shorten(self._last_batch_summary)}")
         #if self._last_scene_summary:
@@ -444,6 +504,11 @@ class ProgressDisplay:
         self.stream.write(message + padding + end)
         self.stream.flush()
         self._last_message_length = len(message)
+
+    def update_terminology_count(self, count : int) -> None:
+        """Update the running term count and re-render the progress line."""
+        self._terminology_count = count
+        self._render()
 
     def _shorten(self, text : str, limit : int = 60) -> str:
         summary = text.strip()
@@ -496,9 +561,13 @@ def parse_args(argv : list[str]|None = None) -> argparse.Namespace:
     parser.add_argument("--log-file", dest="log_file", help="Path to write the detailed log file")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose console logging")
     parser.add_argument("--preview", dest="preview", action="store_true", help="Enable preview mode")
+    parser.add_argument("--use-terminology-map", dest="use_terminology_map", action="store_true",
+                        help="Build a shared terminology map across all files for consistent name/term translation")
+    parser.add_argument("--terminology-file", dest="terminology_file",
+                        help="File to persist the terminology map between runs (key::value per line)")
     parser.add_argument("--option", action="append", default=[], metavar="KEY=VALUE",
                         help="Override additional Options settings (repeatable)")
-    parser.set_defaults(preview=None)
+    parser.set_defaults(preview=None, use_terminology_map=None)
     return parser.parse_args(argv)
 
 

--- a/scripts/gui-subtrans.py
+++ b/scripts/gui-subtrans.py
@@ -20,7 +20,7 @@ def parse_arguments():
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='Translates subtitles using an AI service')
     parser.add_argument('filepath', nargs='?', help="Optional file to load on startup")
-    parser.add_argument('-l', '--target_language', type=str, default=None, help="The target language for the translation")
+    parser.add_argument('-l', '--target-language', type=str, default=None, help="The target language for the translation")
     parser.add_argument('-p', '--provider', type=str, default=None, help="The translation provider to use")
     parser.add_argument('-m', '--model', type=str, default=None, help="The model to use for translation")
     parser.add_argument('--batchthreshold', type=float, default=None, help="Number of seconds between lines to consider for batching")

--- a/scripts/subtrans_common.py
+++ b/scripts/subtrans_common.py
@@ -148,10 +148,24 @@ def InitLogger(logfilename: str, debug: bool = False) -> LoggerOptions:
 
     return LoggerOptions(file_handler=file_handler, log_path=log_path)
 
+_RENAMED_ARGS = {
+    '--target_language': '--target-language',
+}
+
+def _warn_renamed_args() -> None:
+    """Warn and correct any legacy underscore-form arg names passed on the command line."""
+    for i, arg in enumerate(sys.argv):
+        name = arg.split('=', 1)[0]
+        if name in _RENAMED_ARGS:
+            new_name = _RENAMED_ARGS[name]
+            print(f"Warning: {name} is deprecated, use {new_name}", file=sys.stderr)
+            sys.argv[i] = arg.replace(name, new_name, 1)
+
 def CreateArgParser(description : str) -> ArgumentParser:
     """
     Create new arg parser and parse shared command line arguments between models
     """
+    _warn_renamed_args()
     pre_parser = ArgumentParser(add_help=False)
     pre_parser.add_argument('--list-formats', action='store_true')
     pre_args, _ = pre_parser.parse_known_args()
@@ -163,7 +177,7 @@ def CreateArgParser(description : str) -> ArgumentParser:
     parser.add_argument('input', help=input_help)
     parser.add_argument('-o', '--output', help="Output subtitle file path; format inferred from extension")
     parser.add_argument('--list-formats', action='store_true', help="List supported subtitle formats and exit")
-    parser.add_argument('-l', '--target_language', type=str, default=None, help="The target language for the translation")
+    parser.add_argument('-l', '--target-language', type=str, default=None, help="The target language for the translation")
     parser.add_argument('--batchthreshold', type=float, default=None, help="Number of seconds between lines to consider for batching")
     parser.add_argument('--debug', action='store_true', help="Run with DEBUG log level")
     parser.add_argument('--verbose', action='store_true', help="Log detailed progress and token usage for each batch")
@@ -194,8 +208,9 @@ def CreateArgParser(description : str) -> ArgumentParser:
     parser.add_argument('--substitution', action='append', type=str, default=None, help="A pair of strings separated by ::, to subsitute in source or translation")
     parser.add_argument('--temperature', type=float, default=0.0, help="A higher temperature increases the random variance of translations.")
     parser.add_argument('--autosplit', action='store_true', default=None, help="Split batches that fail validation in half and retry each half separately")
-    parser.add_argument('--build_terminology_map', action='store_true', default=None, help="Build and use a terminology map during translation")
+    parser.add_argument('--build-terminology-map', action='store_true', default=None, help="Build and use a terminology map during translation")
     parser.add_argument('--terminology', action='append', type=str, default=None, help="Seed entry for the terminology map as SOURCE::TRANSLATION, or a path to a file of such pairs.")
+    parser.add_argument('--terminology-file', dest='terminology_file', type=str, default=None, help="Path to a key::value file to seed from and save the terminology map to after translation")
     parser.add_argument('--writebackup', action='store_true', help="Write a backup of the project file when it is loaded (if it exists)")
     return parser
 
@@ -243,7 +258,8 @@ def CreateOptions(args: Namespace, provider: str, **kwargs) -> Options:
         'target_language': args.target_language,
         'temperature': args.temperature,
         'autosplit_on_error': args.autosplit,
-        'build_terminology_map': args.build_terminology_map or bool(args.terminology),
+        'build_terminology_map': args.build_terminology_map or bool(getattr(args, 'terminology_file', None)),
+        'terminology_file': getattr(args, 'terminology_file', None),
         'write_backup': args.writebackup,
     }
 
@@ -266,6 +282,13 @@ def CreateProject(options : Options, args: Namespace) -> SubtitleProject:
         project.SaveBackupFile()
 
     project.UpdateProjectSettings(options)
+
+    terminology_file = getattr(args, 'terminology_file', None)
+    if terminology_file and os.path.exists(terminology_file):
+        file_seed = ParseKeyValuePairsOrFiles([terminology_file])
+        if file_seed:
+            logging.info(f"Loaded {len(file_seed)} term(s) from {terminology_file}")
+            project.subtitles.terminology_map = {**file_seed, **project.subtitles.terminology_map}
 
     if getattr(args, 'terminology', None):
         cli_seed = ParseKeyValuePairsOrFiles(args.terminology)
@@ -352,6 +375,15 @@ def LogTranslationStatus(project : SubtitleProject, preview : bool = False, has_
     if token_usage and token_usage.has_data:
         logging.info(f"Token usage: {token_usage.prompt_tokens} in / {token_usage.output_tokens} out ({token_usage.total_tokens} total)")
 
+def _save_terminology_file(path : str, terminology_map : dict[str, str]) -> None:
+    """Write terminology map to a key::value text file."""
+    try:
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write("\n".join(f"{k}::{v}" for k, v in terminology_map.items()))
+        logging.info(f"Saved {len(terminology_map)} term(s) to {path}")
+    except Exception as e:
+        logging.warning(f"Unable to save terminology file '{path}': {e}")
+
 def TranslateProject(project : SubtitleProject, options : Options, verbose : bool = False, preview : bool = False) -> None:
     """
     Translate a prepared project, logging progress and final status.
@@ -369,6 +401,10 @@ def TranslateProject(project : SubtitleProject, options : Options, verbose : boo
 
         if project.use_project_file:
             project.UpdateProjectFile()
+
+        terminology_file = options.get_str('terminology_file')
+        if terminology_file and project.subtitles and project.subtitles.terminology_map:
+            _save_terminology_file(terminology_file, project.subtitles.terminology_map)
 
         LogTranslationStatus(project, preview=preview, token_usage=progress_logger.token_usage)
 

--- a/scripts/subtrans_common.py
+++ b/scripts/subtrans_common.py
@@ -243,7 +243,7 @@ def CreateOptions(args: Namespace, provider: str, **kwargs) -> Options:
         'target_language': args.target_language,
         'temperature': args.temperature,
         'autosplit_on_error': args.autosplit,
-        'use_terminology_map': args.build_terminology_map or bool(args.terminology),
+        'build_terminology_map': args.build_terminology_map or bool(args.terminology),
         'write_backup': args.writebackup,
     }
 

--- a/scripts/subtrans_common.py
+++ b/scripts/subtrans_common.py
@@ -244,7 +244,6 @@ def CreateOptions(args: Namespace, provider: str, **kwargs) -> Options:
         'temperature': args.temperature,
         'autosplit_on_error': args.autosplit,
         'use_terminology_map': args.build_terminology_map or bool(args.terminology),
-        'terminology_map': ParseKeyValuePairsOrFiles(args.terminology) if args.terminology else None,
         'write_backup': args.writebackup,
     }
 
@@ -267,6 +266,10 @@ def CreateProject(options : Options, args: Namespace) -> SubtitleProject:
         project.SaveBackupFile()
 
     project.UpdateProjectSettings(options)
+
+    if getattr(args, 'terminology', None):
+        cli_seed = ParseKeyValuePairsOrFiles(args.terminology)
+        project.subtitles.terminology_map = {**project.subtitles.terminology_map, **cli_seed}
 
     subtitles = project.subtitles
 
@@ -358,7 +361,7 @@ def TranslateProject(project : SubtitleProject, options : Options, verbose : boo
     Callers only need to handle errors raised before the project is ready.
     """
     progress_logger : TranslationProgressLogger = TranslationProgressLogger(verbose=verbose)
-    translator : SubtitleTranslator = init_translator(options)
+    translator : SubtitleTranslator = init_translator(options, terminology_map=project.subtitles.terminology_map)
 
     try:
         with progress_logger.Track(translator):

--- a/scripts/test_terminology.py
+++ b/scripts/test_terminology.py
@@ -1,7 +1,7 @@
 """
 Terminology map test script.
 
-Translates a subtitle file with use_terminology_map=True and collects per-batch
+Translates a subtitle file with build_terminology_map=True and collects per-batch
 data about which terms are extracted, which are genuinely new, and whether the
 model ever tries to override an existing translation.  Use this to evaluate and
 iterate on the terminology prompt.
@@ -617,7 +617,7 @@ def run(args : argparse.Namespace) -> int:
         api_key=args.api_key or None,
         target_language=args.language,
         instruction_file=args.instruction_file or 'instructions.txt',
-        use_terminology_map=True,
+        build_terminology_map=True,
         max_batch_size=args.max_batch_size,
         scene_threshold=args.scene_threshold,
         preprocess_subtitles=True,

--- a/scripts/test_terminology.py
+++ b/scripts/test_terminology.py
@@ -522,7 +522,8 @@ def _make_batch_handler(records : list[BatchRecord], state : RunState):
 
         # batch.context['terminology'] was stored before translation; it holds
         # exactly what was injected into the prompt for this batch.
-        injected = _parse_terminology_context(batch.context.get('terminology'))  # type: ignore[arg-type]
+        raw_terminology = batch.context.get('terminology')
+        injected = _parse_terminology_context(raw_terminology if isinstance(raw_terminology, str) else None)
 
         record = BatchRecord(
             scene=batch.scene,
@@ -642,7 +643,7 @@ def run(args : argparse.Namespace) -> int:
     provider   = init_translation_provider(args.provider, options)
     translator : SubtitleTranslator = init_translator(options, translation_provider=provider)
 
-    initial_map : dict[str, str] = {k: str(v) for k, v in subtitles.settings.get_dict('terminology_map').items()}
+    initial_map : dict[str, str] = dict(subtitles.terminology_map)
 
     state = RunState(total_lines=total_lines, total_batches=total_batches)
     for term, value in initial_map.items():
@@ -661,7 +662,7 @@ def run(args : argparse.Namespace) -> int:
         logging.error("Translation failed: %s", exc)
         return 1
 
-    final_map : dict[str, str] = {k: str(v) for k, v in subtitles.settings.get_dict('terminology_map').items()}
+    final_map : dict[str, str] = dict(translator.terminology_map)
 
     _print_report(args, source, total_lines, total_scenes, records, initial_map, final_map, state)
 

--- a/tests/PySubtransTests/test_SubtitleProject.py
+++ b/tests/PySubtransTests/test_SubtitleProject.py
@@ -654,5 +654,30 @@ Modified subtitle line 2
             self.assertLoggedTrue("project file exists after failure", os.path.exists(project_path))
 
 
+    def test_terminology_map_round_trips_as_top_level_attribute(self):
+        """terminology_map is serialised as a top-level key and restored on load"""
+        project = SubtitleProject(persistent=True)
+        project.InitialiseProject(self.test_srt_file)
+
+        batcher = SubtitleBatcher(self.options)
+        with project.GetEditor() as editor:
+            editor.AutoBatch(batcher)
+
+        project.subtitles.terminology_map = {"Dragon": "Drache", "Hero": "Held"}
+        project.SaveProjectFile(self.test_project_file)
+
+        new_project = SubtitleProject()
+        new_project.ReadProjectFile(self.test_project_file)
+
+        loaded_map = new_project.subtitles.terminology_map
+        self.assertLoggedEqual("Dragon round-trips", "Drache", loaded_map.get("Dragon"))
+        self.assertLoggedEqual("Hero round-trips", "Held", loaded_map.get("Hero"))
+        self.assertLoggedNotIn(
+            "terminology_map absent from settings",
+            "terminology_map",
+            new_project.subtitles.settings,
+        )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/PySubtransTests/test_Translator.py
+++ b/tests/PySubtransTests/test_Translator.py
@@ -427,7 +427,7 @@ class TerminologyMapContextTests(SubtitleTestCase):
     def __init__(self, methodName):
         super().__init__(methodName, custom_options={
             'max_batch_size': 100,
-            'use_terminology_map': True,
+            'build_terminology_map': True,
         })
 
     def _setup(self, terminology_map : dict|None = None) -> tuple[Subtitles, SubtitleTranslator]:
@@ -483,7 +483,7 @@ class TerminologyMapAccumulationTests(SubtitleTestCase):
     def __init__(self, methodName):
         super().__init__(methodName, custom_options={
             'max_batch_size': 100,
-            'use_terminology_map': True,
+            'build_terminology_map': True,
         })
 
     def _make_data_with_terminology(self, batch_key : str, terminology : dict) -> dict:
@@ -542,12 +542,12 @@ class TerminologyMapAccumulationTests(SubtitleTestCase):
         self.assertLoggedIn("食事 was added", "食事", terminology_map)
 
     def test_no_accumulation_when_disabled(self):
-        """Terminology is not accumulated when use_terminology_map is False"""
+        """Terminology is not accumulated when build_terminology_map is False"""
         expected = {"星野": "Hoshino"}
         data = self._make_data_with_terminology('Translate scene 1 batch 1', expected)
 
         options = deepcopy(self.options)
-        options.add('use_terminology_map', False)
+        options.add('build_terminology_map', False)
         provider = DummyProvider(data=data)
         originals = PrepareSubtitles(data, 'original')
         batcher = SubtitleBatcher(options)

--- a/tests/PySubtransTests/test_Translator.py
+++ b/tests/PySubtransTests/test_Translator.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from PySubtrans.Helpers.ContextHelpers import GetBatchContext
 from PySubtrans.Helpers.Parse import ParseNames
-from PySubtrans.Helpers.TestCases import BuildSubtitlesFromLineCounts, LoggedTestCase
+from PySubtrans.Helpers.TestCases import LoggedTestCase
 from PySubtrans.Translation import Translation
 from PySubtrans.Helpers.SubtitleHelpers import FindBestSplitIndex
 from PySubtrans.Helpers.TestCases import DummyProvider, PrepareSubtitles, SubtitleTestCase
@@ -422,25 +422,38 @@ class TerminologyMapParsingTests(LoggedTestCase):
 
 
 class TerminologyMapContextTests(SubtitleTestCase):
-    """Tests for GetBatchContext including/excluding the terminology key"""
+    """Tests that SubtitleTranslator injects terminology into batch context"""
 
-    def _make_subtitles(self, terminology_map : dict|None = None) -> Subtitles:
-        subtitles = BuildSubtitlesFromLineCounts([[5]])
-        subtitles.UpdateSettings(SettingsType({
-            'movie_name': 'Test Movie',
-            'description': 'A test movie',
-            'names': ['Alice', 'Bob'],
-        }))
-        if terminology_map is not None:
-            subtitles.settings['terminology_map'] = terminology_map
-        return subtitles
+    def __init__(self, methodName):
+        super().__init__(methodName, custom_options={
+            'max_batch_size': 100,
+            'use_terminology_map': True,
+        })
 
-    def test_terminology_included_when_map_set(self):
-        """GetBatchContext includes 'terminology' key when terminology_map is populated"""
+    def _setup(self, terminology_map : dict|None = None) -> tuple[Subtitles, SubtitleTranslator]:
+        provider = DummyProvider(data=chinese_dinner_data)
+        originals = PrepareSubtitles(chinese_dinner_data, 'original')
+        batcher = SubtitleBatcher(self.options)
+        with SubtitleEditor(originals) as editor:
+            editor.AutoBatch(batcher)
+        translator = SubtitleTranslator(self.options, translation_provider=provider, terminology_map=terminology_map)
+        return originals, translator
+
+    def _translate_and_capture_context(self, translator : SubtitleTranslator, originals : Subtitles) -> dict:
+        captured : dict = {}
+        def on_batch_translated(_sender, batch):
+            captured.update(batch.context)
+        translator.events.batch_translated.connect(on_batch_translated)
+        scene = originals.GetScene(1)
+        translator.TranslateScene(originals, scene, batch_numbers=[1])
+        return captured
+
+    def test_terminology_injected_into_batch_context(self):
+        """Translator injects terminology into batch context when map is populated"""
         terminology_map = {"Dragon": "Drache", "Hero": "Held"}
-        subtitles = self._make_subtitles(terminology_map)
+        originals, translator = self._setup(terminology_map)
 
-        context = GetBatchContext(subtitles, 1, 1)
+        context = self._translate_and_capture_context(translator, originals)
 
         self.assertLoggedIn("terminology key present", 'terminology', context)
         terminology = context.get('terminology', '')
@@ -448,24 +461,24 @@ class TerminologyMapContextTests(SubtitleTestCase):
         self.assertLoggedIn("Hero entry in terminology", "Hero::Held", terminology)
 
     def test_terminology_absent_when_map_not_set(self):
-        """GetBatchContext omits 'terminology' key when no terminology_map in settings"""
-        subtitles = self._make_subtitles()
+        """Translator does not inject terminology when no map was provided"""
+        originals, translator = self._setup()
 
-        context = GetBatchContext(subtitles, 1, 1)
+        context = self._translate_and_capture_context(translator, originals)
 
         self.assertLoggedNotIn("terminology key absent", 'terminology', context)
 
     def test_terminology_absent_when_map_empty(self):
-        """GetBatchContext omits 'terminology' key when terminology_map is an empty dict"""
-        subtitles = self._make_subtitles(terminology_map={})
+        """Translator does not inject terminology when map is an empty dict"""
+        originals, translator = self._setup(terminology_map={})
 
-        context = GetBatchContext(subtitles, 1, 1)
+        context = self._translate_and_capture_context(translator, originals)
 
         self.assertLoggedNotIn("terminology key absent for empty map", 'terminology', context)
 
 
 class TerminologyMapAccumulationTests(SubtitleTestCase):
-    """Tests for SubtitleTranslator accumulating terminology into subtitles.settings"""
+    """Tests for SubtitleTranslator accumulating terminology into translator.terminology_map"""
 
     def __init__(self, methodName):
         super().__init__(methodName, custom_options={
@@ -481,17 +494,17 @@ class TerminologyMapAccumulationTests(SubtitleTestCase):
         response_map.add(batch_key, (response_map.get_str(batch_key) or '') + term_block)
         return data
 
-    def _setup(self, data : dict) -> tuple[Subtitles, SubtitleTranslator]:
+    def _setup(self, data : dict, seed : dict[str,str]|None = None) -> tuple[Subtitles, SubtitleTranslator]:
         provider = DummyProvider(data=data)
         originals = PrepareSubtitles(data, 'original')
         batcher = SubtitleBatcher(self.options)
         with SubtitleEditor(originals) as editor:
             editor.AutoBatch(batcher)
-        translator = SubtitleTranslator(self.options, translation_provider=provider)
+        translator = SubtitleTranslator(self.options, translation_provider=provider, terminology_map=seed)
         return originals, translator
 
     def test_terminology_accumulated_after_batch(self):
-        """TranslateScene merges terminology into subtitles.settings['terminology_map']"""
+        """TranslateScene merges returned terminology into translator.terminology_map"""
         # Terms must appear in the actual batch content to pass content validation.
         # 星野 appears in the Japanese originals; Hoshino and meal appear in the translations.
         expected = {"星野": "Hoshino", "食事": "meal"}
@@ -505,10 +518,8 @@ class TerminologyMapAccumulationTests(SubtitleTestCase):
 
         translator.TranslateScene(originals, scene, batch_numbers=[1])
 
-        terminology_map = originals.settings.get('terminology_map')
+        terminology_map = translator.terminology_map
         self.assertLoggedIsInstance("terminology_map is a dict", terminology_map, dict)
-        if not isinstance(terminology_map, dict):
-            return
         for term, translation in expected.items():
             self.assertLoggedIn(f"term '{term}' present", term, terminology_map)
             self.assertLoggedEqual(f"translation for '{term}'", translation, terminology_map.get(term))
@@ -517,8 +528,7 @@ class TerminologyMapAccumulationTests(SubtitleTestCase):
         """Pre-existing terminology entries are not overwritten (first-seen-wins)"""
         expected = {"星野": "Hoshino", "食事": "meal"}
         data = self._make_data_with_terminology('Translate scene 1 batch 1', expected)
-        originals, translator = self._setup(data)
-        originals.settings['terminology_map'] = {"星野": "Hoseki"}
+        originals, translator = self._setup(data, seed={"星野": "Hoseki"})
 
         scene = originals.GetScene(1)
         self.assertLoggedIsNotNone("Scene 1 exists", scene)
@@ -527,10 +537,7 @@ class TerminologyMapAccumulationTests(SubtitleTestCase):
 
         translator.TranslateScene(originals, scene, batch_numbers=[1])
 
-        terminology_map = originals.settings.get('terminology_map')
-        self.assertLoggedIsInstance("terminology_map is a dict", terminology_map, dict)
-        if not isinstance(terminology_map, dict):
-            return
+        terminology_map = translator.terminology_map
         self.assertLoggedEqual("星野 keeps first translation", "Hoseki", terminology_map.get("星野"))
         self.assertLoggedIn("食事 was added", "食事", terminology_map)
 
@@ -555,8 +562,7 @@ class TerminologyMapAccumulationTests(SubtitleTestCase):
 
         translator.TranslateScene(originals, scene, batch_numbers=[1])
 
-        terminology_map = originals.settings.get('terminology_map')
-        self.assertLoggedTrue("terminology_map not populated", not terminology_map)
+        self.assertLoggedTrue("terminology_map not populated", not translator.terminology_map)
 
     def test_identity_mappings_are_ignored(self):
         """Identity terminology pairs (left == right) are ignored and never stored."""
@@ -575,11 +581,7 @@ class TerminologyMapAccumulationTests(SubtitleTestCase):
 
         translator.TranslateScene(originals, scene, batch_numbers=[1])
 
-        terminology_map = originals.settings.get('terminology_map')
-        self.assertLoggedIsInstance("terminology_map is a dict", terminology_map, dict)
-        if not isinstance(terminology_map, dict):
-            return
-
+        terminology_map = translator.terminology_map
         self.assertLoggedNotIn("source-language identity not stored", "食事", terminology_map)
         self.assertLoggedNotIn("target-language identity not stored", "Hoshino", terminology_map)
         self.assertLoggedIn("non-identity term stored", "星野", terminology_map)
@@ -592,8 +594,7 @@ class TerminologyMapAccumulationTests(SubtitleTestCase):
             "食事": "meal",     # correctly oriented
         }
         data = self._make_data_with_terminology('Translate scene 1 batch 1', terms)
-        originals, translator = self._setup(data)
-        originals.settings['terminology_map'] = {"星野": "Hoshino"}
+        originals, translator = self._setup(data, seed={"星野": "Hoshino"})
 
         scene = originals.GetScene(1)
         self.assertLoggedIsNotNone("Scene 1 exists", scene)
@@ -602,11 +603,7 @@ class TerminologyMapAccumulationTests(SubtitleTestCase):
 
         translator.TranslateScene(originals, scene, batch_numbers=[1])
 
-        terminology_map = originals.settings.get('terminology_map')
-        self.assertLoggedIsInstance("terminology_map is a dict", terminology_map, dict)
-        if not isinstance(terminology_map, dict):
-            return
-
+        terminology_map = translator.terminology_map
         self.assertLoggedEqual("existing mapping preserved", "Hoshino", terminology_map.get("星野"))
         self.assertLoggedNotIn("reversed key not added as new entry", "Hoshino", terminology_map)
         self.assertLoggedIn("correctly oriented term added", "食事", terminology_map)
@@ -659,11 +656,7 @@ class TerminologyMapAccumulationTests(SubtitleTestCase):
             with patch.object(translator.client, 'RequestTranslation', side_effect=request_with_split_terminology):
                 translator.TranslateScene(originals, scene, batch_numbers=[1])
 
-        terminology_map = originals.settings.get('terminology_map')
-        self.assertLoggedIsInstance("terminology_map is a dict", terminology_map, dict)
-        if not isinstance(terminology_map, dict):
-            return
-
+        terminology_map = translator.terminology_map
         self.assertLoggedEqual("split learned 星野 mapping", "Hoshino", terminology_map.get("星野"))
         self.assertLoggedEqual("split learned 食事 mapping", "meal", terminology_map.get("食事"))
 


### PR DESCRIPTION
## Summary

- Promotes `terminology_map` from a value inside `SettingsType`/`Options` to a first-class `dict[str,str]` attribute on `Subtitles`, serialised as a top-level key in `.subtrans` JSON
- `SubtitleTranslator` now accepts `terminology_map` as a constructor seed and owns the working copy; `terminology_updated` events snapshot it back to `subtitles.terminology_map` via the caller
- Terminology context injection is decoupled from `build_terminology_map`: any non-empty seed is always injected into the prompt; the flag only controls whether the model is asked to report and accumulate new terms
- Renames `use_terminology_map` → `build_terminology_map` across all code, docs, CLI flags (`--build-terminology-map`) and env var (`BUILD_TERMINOLOGY_MAP`) to make this distinction clear

## Test plan

- [x] All 308 unit tests pass (`tests/unit_tests.py`)
- [x] Pyright: 0 errors across 189 files
- [ ] Serialisation round-trip: save `.subtrans` with non-empty `terminology_map`, reload, confirm top-level attribute restored and absent from `settings`
- [ ] CLI seed merge: run with `--terminology A::x`, save, re-run with `--terminology A::y B::z`, confirm `{A: y, B: z}`
- [ ] Batch-translate multi-file with `--terminology-file`: terms accumulate across files, file is rewritten correctly
- [ ] GUI: open project with terminology map, edit via ProjectSettings, translate a scene, confirm live-refresh appends new terms and map persists on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)