### PR TITLE
Give Project Settings more room

### DIFF
--- a/GuiSubtrans/MainWindow.py
+++ b/GuiSubtrans/MainWindow.py
@@ -7,14 +7,17 @@ from PySide6.QtWidgets import (
     QMainWindow,
     QWidget,
     QVBoxLayout,
+    QHBoxLayout,
     QSplitter,
 )
 from GuiSubtrans.Command import Command
 from GuiSubtrans.GuiInterface import GuiInterface
 from GuiSubtrans.MainToolbar import MainToolbar
 from GuiSubtrans.ProjectDataModel import ProjectDataModel
+from GuiSubtrans.ProjectToolbar import ProjectToolbar
 from GuiSubtrans.Widgets.LogWindow import LogWindow
 from GuiSubtrans.Widgets.ModelView import ModelView
+from GuiSubtrans.Widgets.ProjectSettings import ProjectSettings
 from PySubtrans.Helpers.Resources import GetResourcePath
 from PySubtrans.Options import Options
 from PySubtrans.version import __version__
@@ -45,12 +48,33 @@ class MainWindow(QMainWindow):
         self.toolbar.UpdateToolbar()
         main_layout.addWidget(self.toolbar)
 
-        # Create a splitter widget to divide the remaining vertical space between the project viewer and log window
-        splitter = QSplitter(Qt.Orientation.Vertical)
-        main_layout.addWidget(splitter)
+        # Container for the full bottom body
+        body_container = QWidget()
+        body_layout = QHBoxLayout(body_container)
+        body_layout.setContentsMargins(0, 0, 0, 0)
+        body_layout.setSpacing(0)
+        main_layout.addWidget(body_container)
 
         action_handler = self.gui_interface.GetActionHandler()
-        self.model_viewer = ModelView(action_handler, parent=splitter)
+
+        # Setup full-height project toolbar on the far left
+        self.project_toolbar = ProjectToolbar(action_handler=action_handler, parent=body_container)
+        self.project_toolbar.hide()
+        body_layout.addWidget(self.project_toolbar)
+
+        # Create an outer horizontal splitter to hold ProjectSettings on the left
+        main_h_splitter = QSplitter(Qt.Orientation.Horizontal)
+        body_layout.addWidget(main_h_splitter)
+
+        self.project_settings = ProjectSettings(action_handler=action_handler, parent=main_h_splitter)
+        self.project_settings.hide()
+        main_h_splitter.addWidget(self.project_settings)
+
+        # Create a splitter widget to divide the remaining vertical space between the project viewer and log window
+        splitter = QSplitter(Qt.Orientation.Vertical)
+        main_h_splitter.addWidget(splitter)
+        
+        self.model_viewer = ModelView(action_handler, project_settings=self.project_settings, project_toolbar=self.project_toolbar, parent=splitter)
         self.model_viewer.settingsChanged.connect(self.gui_interface.UpdateProjectSettings)
         splitter.addWidget(self.model_viewer)
 
@@ -58,6 +82,9 @@ class MainWindow(QMainWindow):
         log_window_widget = LogWindow(splitter)
         splitter.addWidget(log_window_widget)
         splitter.setSizes([int(self.height() * 0.8), int(self.height() * 0.2)])
+
+        main_h_splitter.setStretchFactor(0, 0)
+        main_h_splitter.setStretchFactor(1, 1)
 
         # Run startup tasks
         self.gui_interface.Startup(filepath)
@@ -109,6 +136,8 @@ class MainWindow(QMainWindow):
             self.model_viewer.show()
         else:
             self.model_viewer.hide()
+            self.project_settings.hide()
+            self.project_toolbar.hide()
 
     def _load_icon(self, name):
         if not name or name == "default":

--- a/GuiSubtrans/Widgets/ModelView.py
+++ b/GuiSubtrans/Widgets/ModelView.py
@@ -9,11 +9,12 @@ from GuiSubtrans.ProjectToolbar import ProjectToolbar
 from GuiSubtrans.Widgets.ScenesView import ScenesView
 from GuiSubtrans.Widgets.ContentView import ContentView
 from GuiSubtrans.Widgets.ProjectSettings import ProjectSettings
+from GuiSubtrans.ProjectToolbar import ProjectToolbar
 
 class ModelView(QWidget):
     settingsChanged = Signal(dict)
 
-    def __init__(self, action_handler : ProjectActions, parent=None):
+    def __init__(self, action_handler : ProjectActions, project_settings : ProjectSettings|None = None, project_toolbar : ProjectToolbar|None = None, parent=None):
         super().__init__(parent)
 
         if not isinstance(action_handler, ProjectActions):
@@ -24,9 +25,11 @@ class ModelView(QWidget):
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        self._toolbar = ProjectToolbar(parent=self, action_handler=action_handler)
+        self._toolbar = project_toolbar if project_toolbar else ProjectToolbar(parent=self, action_handler=action_handler)
         self._toolbar.setVisible(False)
-        layout.addWidget(self._toolbar)
+        
+        if not project_toolbar:
+            layout.addWidget(self._toolbar)
 
         # Scenes & Batches Panel
         self.scenes_view = ScenesView(parent=self)
@@ -35,18 +38,25 @@ class ModelView(QWidget):
         self.content_view = ContentView(action_handler=action_handler, parent=self)
 
         # Project Settings
-        self.project_settings = ProjectSettings(action_handler=action_handler, parent=self)
-        self.project_settings.hide()
+        self.project_settings = project_settings if project_settings else ProjectSettings(action_handler=action_handler, parent=self)
+        if not project_settings:
+            self.project_settings.hide()
         self.project_settings.settingsChanged.connect(self._on_project_settings_changed, Qt.ConnectionType.QueuedConnection)
 
         # Splitter
         splitter = QSplitter(Qt.Orientation.Horizontal)
-        splitter.addWidget(self.project_settings)
+        if not project_settings:
+            splitter.addWidget(self.project_settings)
         splitter.addWidget(self.scenes_view)
         splitter.addWidget(self.content_view)
-        splitter.setStretchFactor(0, 2)
-        splitter.setStretchFactor(1, 1)
-        splitter.setStretchFactor(2, 3)
+        
+        if not project_settings:
+            splitter.setStretchFactor(0, 2)
+            splitter.setStretchFactor(1, 1)
+            splitter.setStretchFactor(2, 3)
+        else:
+            splitter.setStretchFactor(0, 1)
+            splitter.setStretchFactor(1, 3)
 
         layout.addWidget(splitter)
         self.setLayout(layout)

--- a/GuiSubtrans/Widgets/ModelView.py
+++ b/GuiSubtrans/Widgets/ModelView.py
@@ -9,7 +9,6 @@ from GuiSubtrans.ProjectToolbar import ProjectToolbar
 from GuiSubtrans.Widgets.ScenesView import ScenesView
 from GuiSubtrans.Widgets.ContentView import ContentView
 from GuiSubtrans.Widgets.ProjectSettings import ProjectSettings
-from GuiSubtrans.ProjectToolbar import ProjectToolbar
 
 class ModelView(QWidget):
     settingsChanged = Signal(dict)

--- a/GuiSubtrans/Widgets/ModelView.py
+++ b/GuiSubtrans/Widgets/ModelView.py
@@ -24,10 +24,10 @@ class ModelView(QWidget):
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        self._toolbar = project_toolbar if project_toolbar else ProjectToolbar(parent=self, action_handler=action_handler)
+        self._toolbar = project_toolbar if project_toolbar is not None else ProjectToolbar(parent=self, action_handler=action_handler)
         self._toolbar.setVisible(False)
         
-        if not project_toolbar:
+        if project_toolbar is None:
             layout.addWidget(self._toolbar)
 
         # Scenes & Batches Panel
@@ -37,19 +37,19 @@ class ModelView(QWidget):
         self.content_view = ContentView(action_handler=action_handler, parent=self)
 
         # Project Settings
-        self.project_settings = project_settings if project_settings else ProjectSettings(action_handler=action_handler, parent=self)
-        if not project_settings:
+        self.project_settings = project_settings if project_settings is not None else ProjectSettings(action_handler=action_handler, parent=self)
+        if project_settings is None:
             self.project_settings.hide()
         self.project_settings.settingsChanged.connect(self._on_project_settings_changed, Qt.ConnectionType.QueuedConnection)
 
         # Splitter
         splitter = QSplitter(Qt.Orientation.Horizontal)
-        if not project_settings:
+        if project_settings is None:
             splitter.addWidget(self.project_settings)
         splitter.addWidget(self.scenes_view)
         splitter.addWidget(self.content_view)
         
-        if not project_settings:
+        if project_settings is None:
             splitter.setStretchFactor(0, 2)
             splitter.setStretchFactor(1, 1)
             splitter.setStretchFactor(2, 3)


### PR DESCRIPTION
Pull ProjectSettings and ProjectToolbar up to the MainWindow so that they can share space with LogWindow and have a bit more room to breathe.