### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/PySubtrans/Providers/Clients/LiteLLMClient.py
+++ b/PySubtrans/Providers/Clients/LiteLLMClient.py
@@ -70,7 +70,7 @@ else:
 
             return translation
 
-        def _send_messages(self, messages : list, temperature : float|None, request : TranslationRequest|None = None) -> dict[str, Any]|None:
+        def _send_messages(self, messages : list, temperature : float|None, request : TranslationRequest) -> dict[str, Any]|None:
             """
             Make a request to LiteLLM to provide a translation.
             Supports both streaming and non-streaming modes.
@@ -114,9 +114,10 @@ else:
                         for chunk in result:
                             if self.aborted:
                                 return None
-                            if not getattr(chunk, 'choices', None):
+                            choices = getattr(chunk, 'choices', None)
+                            if not chunk or not choices:
                                 continue
-                            choice = chunk.choices[0]
+                            choice = choices[0]
                             delta_content = getattr(choice.delta, 'content', None)
                             if delta_content:
                                 accumulated_text += delta_content

--- a/PySubtrans/Providers/Clients/LiteLLMClient.py
+++ b/PySubtrans/Providers/Clients/LiteLLMClient.py
@@ -1,22 +1,19 @@
 import importlib.util
 import logging
+from typing import Any
 
 from PySubtrans.Helpers.Localization import _
 
 if not importlib.util.find_spec("litellm"):
     logging.debug(_("LiteLLM is not installed. LiteLLM client will not be available"))
 else:
-    import json
-    import time
-    from typing import Any
-
     import litellm
 
+    from PySubtrans.Helpers import FormatMessages
     from PySubtrans.Options import SettingsType
-    from PySubtrans.SubtitleError import TranslationImpossibleError
+    from PySubtrans.SubtitleError import TranslationError, TranslationImpossibleError, TranslationResponseError
     from PySubtrans.Translation import Translation
     from PySubtrans.TranslationClient import TranslationClient
-    from PySubtrans.TranslationPrompt import TranslationPrompt
     from PySubtrans.TranslationRequest import TranslationRequest
 
     class LiteLLMClient(TranslationClient):
@@ -26,68 +23,121 @@ else:
         """
         def __init__(self, settings : SettingsType):
             super().__init__(settings)
-            self.api_key : str|None = settings.get_str('api_key')
-            self.api_base : str|None = settings.get_str('api_base')
 
-        @property
-        def model(self) -> str|None:
-            return self.settings.get_str('model')
+            if not self.model:
+                raise TranslationImpossibleError(_("No model specified for LiteLLM"))
 
             self._emit_info(_("Translating with LiteLLM using model: {model}").format(
                 model=self.model
             ))
 
-        def _build_kwargs(self) -> dict[str, Any]:
+        @property
+        def api_key(self) -> str|None:
+            return self.settings.get_str('api_key')
+
+        @property
+        def api_base(self) -> str|None:
+            return self.settings.get_str('api_base')
+
+        @property
+        def model(self) -> str|None:
+            return self.settings.get_str('model')
+
+        def _request_translation(self, request : TranslationRequest, temperature : float|None = None) -> Translation|None:
+            """
+            Request a translation based on the provided prompt.
+            """
+            logging.debug(f"Messages:\n{FormatMessages(request.prompt.messages)}")
+
+            content = request.prompt.content
+            if not content or not isinstance(content, list):
+                raise TranslationImpossibleError(_("No content provided for translation"))
+
+            content = [message for message in content if message]
+
+            temperature = temperature or self.temperature
+            response = self._send_messages(content, temperature)
+
+            translation = Translation(response) if response else None
+
+            if translation:
+                if translation.quota_reached:
+                    raise TranslationImpossibleError(_("Account quota reached, please upgrade your plan or wait until it renews"))
+
+                if translation.reached_token_limit:
+                    raise TranslationError(_("Too many tokens in translation"), translation=translation)
+
+            return translation
+
+        def _send_messages(self, messages : list, temperature : float|None) -> dict[str, Any]|None:
+            """
+            Make a request to LiteLLM to provide a translation.
+            """
+            response : dict[str, Any] = {}
+
+            if not self.model:
+                raise TranslationImpossibleError(_("No model specified"))
+
+            if not messages:
+                raise TranslationImpossibleError(_("No content provided for translation"))
+
             kwargs : dict[str, Any] = {
                 "model": self.model,
+                "messages": messages,
                 "drop_params": True,
             }
             if self.api_key:
                 kwargs["api_key"] = self.api_key
             if self.api_base:
                 kwargs["api_base"] = self.api_base
-            if self.temperature is not None:
-                kwargs["temperature"] = self.temperature
+            if temperature is not None:
+                kwargs["temperature"] = temperature
             max_tokens = self.settings.get_int('max_tokens', 0)
             if max_tokens > 0:
                 kwargs["max_tokens"] = max_tokens
-            return kwargs
 
-        def SendMessages(self, prompt : TranslationPrompt, temperature : float|None = None) -> TranslationRequest:
-            """
-            Send messages to LiteLLM and return the response.
-            """
-            messages = prompt.GenerateMessages()
-            kwargs = self._build_kwargs()
-            if temperature is not None:
-                kwargs["temperature"] = temperature
+            for retry in range(self.max_retries + 1):
+                if self.aborted:
+                    return None
 
-            kwargs["messages"] = messages
+                try:
+                    result = litellm.completion(**kwargs)
 
-            request = TranslationRequest(prompt)
+                    if self.aborted:
+                        return None
 
-            try:
-                response = litellm.completion(**kwargs)
+                    if not getattr(result, 'choices', None):
+                        raise TranslationResponseError(_("No choices returned in the response"), response=result)
 
-                content = response.choices[0].message.content or ""
-                usage = getattr(response, "usage", None)
-                prompt_tokens = getattr(usage, "prompt_tokens", 0) if usage else 0
-                completion_tokens = getattr(usage, "completion_tokens", 0) if usage else 0
+                    if hasattr(result, "usage") and result.usage:
+                        response['prompt_tokens'] = getattr(result.usage, 'prompt_tokens', 0)
+                        response['output_tokens'] = getattr(result.usage, 'completion_tokens', 0)
+                        response['total_tokens'] = getattr(result.usage, 'total_tokens', 0)
 
-                request.prompt_tokens = prompt_tokens
-                request.completion_tokens = completion_tokens
-                request.response = content
+                    choice = result.choices[0]
+                    reply = choice.message
 
-                self._emit_translation_event(request, prompt)
+                    response['finish_reason'] = getattr(choice, 'finish_reason', None)
+                    response['text'] = getattr(reply, 'content', None)
 
-            except Exception as e:
-                request.error = str(e)
-                logging.warning(_("LiteLLM error: {error}").format(error=str(e)))
+                    return response
 
-            return request
+                except (litellm.exceptions.RateLimitError,
+                        litellm.exceptions.ServiceUnavailableError,
+                        litellm.exceptions.Timeout,
+                        litellm.exceptions.APIConnectionError) as e:
+                    if retry < self.max_retries:
+                        logging.warning(_("LiteLLM transient error (retry {retry}/{max_retries}): {error}").format(
+                            retry=retry + 1, max_retries=self.max_retries, error=str(e)
+                        ))
+                        continue
+                    raise TranslationImpossibleError(_("Failed to communicate with provider after {max_retries} retries").format(
+                        max_retries=self.max_retries
+                    ), error=e)
 
-        def _emit_translation_event(self, request : TranslationRequest, prompt : TranslationPrompt):
-            """
-            Emit translation event for logging/monitoring
-            """
-            pass
+                except Exception as e:
+                    raise TranslationImpossibleError(_("Unexpected error communicating with the provider"), error=e)
+
+            raise TranslationImpossibleError(_("Failed to communicate with provider after {max_retries} retries").format(
+                max_retries=self.max_retries
+            ))

--- a/PySubtrans/Providers/Clients/LiteLLMClient.py
+++ b/PySubtrans/Providers/Clients/LiteLLMClient.py
@@ -1,0 +1,93 @@
+import importlib.util
+import logging
+
+from PySubtrans.Helpers.Localization import _
+
+if not importlib.util.find_spec("litellm"):
+    logging.debug(_("LiteLLM is not installed. LiteLLM client will not be available"))
+else:
+    import json
+    import time
+    from typing import Any
+
+    import litellm
+
+    from PySubtrans.Options import SettingsType
+    from PySubtrans.SubtitleError import TranslationImpossibleError
+    from PySubtrans.Translation import Translation
+    from PySubtrans.TranslationClient import TranslationClient
+    from PySubtrans.TranslationPrompt import TranslationPrompt
+    from PySubtrans.TranslationRequest import TranslationRequest
+
+    class LiteLLMClient(TranslationClient):
+        """
+        Handles chat communication via LiteLLM to request translations.
+        Routes to 100+ LLM providers using provider-prefixed model names.
+        """
+        def __init__(self, settings : SettingsType):
+            super().__init__(settings)
+            self.api_key : str|None = settings.get_str('api_key')
+            self.api_base : str|None = settings.get_str('api_base')
+
+        @property
+        def model(self) -> str|None:
+            return self.settings.get_str('model')
+
+            self._emit_info(_("Translating with LiteLLM using model: {model}").format(
+                model=self.model
+            ))
+
+        def _build_kwargs(self) -> dict[str, Any]:
+            kwargs : dict[str, Any] = {
+                "model": self.model,
+                "drop_params": True,
+            }
+            if self.api_key:
+                kwargs["api_key"] = self.api_key
+            if self.api_base:
+                kwargs["api_base"] = self.api_base
+            if self.temperature is not None:
+                kwargs["temperature"] = self.temperature
+            max_tokens = self.settings.get_int('max_tokens', 0)
+            if max_tokens > 0:
+                kwargs["max_tokens"] = max_tokens
+            return kwargs
+
+        def SendMessages(self, prompt : TranslationPrompt, temperature : float|None = None) -> TranslationRequest:
+            """
+            Send messages to LiteLLM and return the response.
+            """
+            messages = prompt.GenerateMessages()
+            kwargs = self._build_kwargs()
+            if temperature is not None:
+                kwargs["temperature"] = temperature
+
+            kwargs["messages"] = messages
+
+            request = TranslationRequest(prompt)
+
+            try:
+                response = litellm.completion(**kwargs)
+
+                content = response.choices[0].message.content or ""
+                usage = getattr(response, "usage", None)
+                prompt_tokens = getattr(usage, "prompt_tokens", 0) if usage else 0
+                completion_tokens = getattr(usage, "completion_tokens", 0) if usage else 0
+
+                request.prompt_tokens = prompt_tokens
+                request.completion_tokens = completion_tokens
+                request.response = content
+
+                self._emit_translation_event(request, prompt)
+
+            except Exception as e:
+                request.error = str(e)
+                logging.warning(_("LiteLLM error: {error}").format(error=str(e)))
+
+            return request
+
+        def _emit_translation_event(self, request : TranslationRequest, prompt : TranslationPrompt):
+            """
+            Emit translation event for logging/monitoring
+            """
+            pass

--- a/PySubtrans/Providers/Clients/LiteLLMClient.py
+++ b/PySubtrans/Providers/Clients/LiteLLMClient.py
@@ -1,5 +1,6 @@
 import importlib.util
 import logging
+import time
 from typing import Any
 
 from PySubtrans.Helpers.Localization import _
@@ -92,8 +93,8 @@ else:
                 kwargs["api_base"] = self.api_base
             if temperature is not None:
                 kwargs["temperature"] = temperature
-            max_tokens = self.settings.get_int('max_tokens', 0)
-            if max_tokens > 0:
+            max_tokens = self.settings.get_int('max_tokens')
+            if max_tokens is not None and max_tokens > 0:
                 kwargs["max_tokens"] = max_tokens
 
             for retry in range(self.max_retries + 1):
@@ -106,16 +107,20 @@ else:
                     if self.aborted:
                         return None
 
-                    if not getattr(result, 'choices', None):
+                    choices = getattr(result, 'choices', None)
+                    if not choices:
                         raise TranslationResponseError(_("No choices returned in the response"), response=result)
 
-                    if hasattr(result, "usage") and result.usage:
-                        response['prompt_tokens'] = getattr(result.usage, 'prompt_tokens', 0)
-                        response['output_tokens'] = getattr(result.usage, 'completion_tokens', 0)
-                        response['total_tokens'] = getattr(result.usage, 'total_tokens', 0)
+                    usage = getattr(result, 'usage', None)
+                    if usage:
+                        response['prompt_tokens'] = getattr(usage, 'prompt_tokens', 0)
+                        response['output_tokens'] = getattr(usage, 'completion_tokens', 0)
+                        response['total_tokens'] = getattr(usage, 'total_tokens', 0)
 
-                    choice = result.choices[0]
-                    reply = choice.message
+                    choice = choices[0]
+                    reply = getattr(choice, 'message', None)
+                    if not reply:
+                        raise TranslationResponseError(_("No message returned in the choice"), response=result)
 
                     response['finish_reason'] = getattr(choice, 'finish_reason', None)
                     response['text'] = getattr(reply, 'content', None)
@@ -126,13 +131,20 @@ else:
                         litellm.exceptions.ServiceUnavailableError,
                         litellm.exceptions.Timeout,
                         litellm.exceptions.APIConnectionError) as e:
-                    if retry < self.max_retries:
-                        logging.warning(_("LiteLLM transient error (retry {retry}/{max_retries}): {error}").format(
-                            retry=retry + 1, max_retries=self.max_retries, error=str(e)
+                    if retry < self.max_retries and not self.aborted:
+                        backoff = self.backoff_time * 2.0**retry
+                        self._emit_warning(_("LiteLLM transient error (retry {retry}/{max_retries}): {error}, retrying in {backoff} seconds...").format(
+                            retry=retry + 1, max_retries=self.max_retries, error=str(e), backoff=backoff
                         ))
+                        time.sleep(backoff)
                         continue
                     raise TranslationImpossibleError(_("Failed to communicate with provider after {max_retries} retries").format(
                         max_retries=self.max_retries
+                    ), error=e)
+
+                except litellm.exceptions.APIError as e:
+                    raise TranslationImpossibleError(_("LiteLLM error communicating with the provider: {error}").format(
+                        error=str(e)
                     ), error=e)
 
                 except Exception as e:

--- a/PySubtrans/Providers/Clients/LiteLLMClient.py
+++ b/PySubtrans/Providers/Clients/LiteLLMClient.py
@@ -57,7 +57,7 @@ else:
             content = [message for message in content if message]
 
             temperature = temperature or self.temperature
-            response = self._send_messages(content, temperature)
+            response = self._send_messages(content, temperature, request=request)
 
             translation = Translation(response) if response else None
 
@@ -70,9 +70,10 @@ else:
 
             return translation
 
-        def _send_messages(self, messages : list, temperature : float|None) -> dict[str, Any]|None:
+        def _send_messages(self, messages : list, temperature : float|None, request : TranslationRequest|None = None) -> dict[str, Any]|None:
             """
             Make a request to LiteLLM to provide a translation.
+            Supports both streaming and non-streaming modes.
             """
             response : dict[str, Any] = {}
 
@@ -97,11 +98,41 @@ else:
             if max_tokens is not None and max_tokens > 0:
                 kwargs["max_tokens"] = max_tokens
 
+            use_streaming = request and request.is_streaming and self.enable_streaming
+
             for retry in range(self.max_retries + 1):
                 if self.aborted:
                     return None
 
                 try:
+                    if use_streaming:
+                        kwargs["stream"] = True
+                        result = litellm.completion(**kwargs)
+
+                        accumulated_text = ""
+                        finish_reason = None
+                        for chunk in result:
+                            if self.aborted:
+                                return None
+                            if not getattr(chunk, 'choices', None):
+                                continue
+                            choice = chunk.choices[0]
+                            delta_content = getattr(choice.delta, 'content', None)
+                            if delta_content:
+                                accumulated_text += delta_content
+                                request.ProcessStreamingDelta(delta_content)
+                            if getattr(choice, 'finish_reason', None):
+                                finish_reason = choice.finish_reason
+                            usage = getattr(chunk, 'usage', None)
+                            if usage:
+                                response['prompt_tokens'] = getattr(usage, 'prompt_tokens', 0)
+                                response['output_tokens'] = getattr(usage, 'completion_tokens', 0)
+                                response['total_tokens'] = getattr(usage, 'total_tokens', 0)
+
+                        response['finish_reason'] = finish_reason
+                        response['text'] = accumulated_text
+                        return response
+
                     result = litellm.completion(**kwargs)
 
                     if self.aborted:

--- a/PySubtrans/Providers/Provider_LiteLLM.py
+++ b/PySubtrans/Providers/Provider_LiteLLM.py
@@ -3,14 +3,12 @@ import logging
 import os
 
 from PySubtrans.Helpers.Localization import _
-from PySubtrans.Options import SettingsType, env_float, env_int
+from PySubtrans.Options import env_float, env_int
 from PySubtrans.SettingsType import GuiSettingsType, SettingsType
 
 if not importlib.util.find_spec("litellm"):
     logging.debug(_("LiteLLM is not installed. LiteLLM provider will not be available"))
 else:
-    import litellm
-
     from PySubtrans.Providers.Clients.LiteLLMClient import LiteLLMClient
     from PySubtrans.TranslationClient import TranslationClient
     from PySubtrans.TranslationProvider import TranslationProvider

--- a/PySubtrans/Providers/Provider_LiteLLM.py
+++ b/PySubtrans/Providers/Provider_LiteLLM.py
@@ -9,92 +9,101 @@ from PySubtrans.SettingsType import GuiSettingsType, SettingsType
 if not importlib.util.find_spec("litellm"):
     logging.debug(_("LiteLLM is not installed. LiteLLM provider will not be available"))
 else:
-    from PySubtrans.Providers.Clients.LiteLLMClient import LiteLLMClient
-    from PySubtrans.TranslationClient import TranslationClient
-    from PySubtrans.TranslationProvider import TranslationProvider
+    try:
+        from PySubtrans.Providers.Clients.LiteLLMClient import LiteLLMClient
+        from PySubtrans.TranslationClient import TranslationClient
+        from PySubtrans.TranslationProvider import TranslationProvider
 
-    class LiteLLMProvider(TranslationProvider):
-        name = "LiteLLM"
+        class LiteLLMProvider(TranslationProvider):
+            name = "LiteLLM"
 
-        default_model = "openai/gpt-4o"
+            default_model = "openai/gpt-4o"
 
-        information = """
-        <p>LiteLLM provides a unified gateway to 100+ LLM providers.</p>
-        <p>Use provider-prefixed model names to route to any provider:</p>
-        <ul>
-            <li><b>anthropic/claude-sonnet-4-6</b> — Anthropic Claude</li>
-            <li><b>openai/gpt-4o</b> — OpenAI</li>
-            <li><b>gemini/gemini-2.5-flash</b> — Google Gemini</li>
-            <li><b>bedrock/anthropic.claude-v2</b> — AWS Bedrock</li>
-        </ul>
-        <p>API keys are read from provider-specific env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
-        or can be set explicitly in the API Key field.</p>
-        <p>Install with: <code>pip install litellm</code></p>
-        """
-
-        def __init__(self, settings : SettingsType):
-            super().__init__(self.name, SettingsType({
-                'api_key': settings.get_str('api_key', os.getenv('LITELLM_API_KEY')),
-                'api_base': settings.get_str('api_base', os.getenv('LITELLM_API_BASE')),
-                'model': settings.get_str('model', os.getenv('LITELLM_MODEL', self.default_model)),
-                'max_tokens': settings.get_int('max_tokens', env_int('LITELLM_MAX_TOKENS', 0)),
-                'temperature': settings.get_float('temperature', env_float('LITELLM_TEMPERATURE', 0.0)),
-                'rate_limit': settings.get_float('rate_limit', env_float('LITELLM_RATE_LIMIT')),
-            }))
-
-            self.refresh_when_changed = ['api_key', 'api_base', 'model']
-
-        @property
-        def api_key(self) -> str|None:
-            return self.settings.get_str('api_key')
-
-        @property
-        def api_base(self) -> str|None:
-            return self.settings.get_str('api_base')
-
-        def GetTranslationClient(self, settings : SettingsType) -> TranslationClient:
+            information = """
+            <p>LiteLLM provides a unified gateway to 100+ LLM providers.</p>
+            <p>Use provider-prefixed model names to route to any provider:</p>
+            <ul>
+                <li><b>anthropic/claude-sonnet-4-6</b> — Anthropic Claude</li>
+                <li><b>openai/gpt-4o</b> — OpenAI</li>
+                <li><b>gemini/gemini-2.5-flash</b> — Google Gemini</li>
+                <li><b>bedrock/anthropic.claude-v2</b> — AWS Bedrock</li>
+            </ul>
+            <p>API keys are read from provider-specific env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
+            or can be set explicitly in the API Key field.</p>
+            <p>Install with: <code>pip install litellm</code></p>
             """
-            Returns a new instance of the LiteLLM client
-            """
-            client_settings = SettingsType(self.settings.copy())
-            client_settings.update(settings)
-            return LiteLLMClient(client_settings)
 
-        def GetOptions(self, settings : SettingsType) -> GuiSettingsType:
-            """
-            Returns the configurable options for the provider
-            """
-            options : GuiSettingsType = {
-                'api_key': (str, _("API key (optional — LiteLLM reads provider env vars like OPENAI_API_KEY, ANTHROPIC_API_KEY automatically)")),
-                'api_base': (str, _("Custom API base URL (optional — only needed for self-hosted LiteLLM proxy)")),
-                'model': (str, _("Provider-prefixed model name (e.g. anthropic/claude-sonnet-4-6, openai/gpt-4o, gemini/gemini-2.5-flash)")),
-                'max_tokens': (int, _("Maximum number of output tokens to return in the response")),
-                'temperature': (float, _("Amount of random variance to add to translations")),
-                'rate_limit': (float, _("Maximum API requests per minute")),
-            }
-            return options
+            def __init__(self, settings : SettingsType):
+                super().__init__(self.name, SettingsType({
+                    'api_key': settings.get_str('api_key', os.getenv('LITELLM_API_KEY')),
+                    'api_base': settings.get_str('api_base', os.getenv('LITELLM_API_BASE')),
+                    'model': settings.get_str('model', os.getenv('LITELLM_MODEL', self.default_model)),
+                    'max_tokens': settings.get_int('max_tokens', env_int('LITELLM_MAX_TOKENS', 0)),
+                    'temperature': settings.get_float('temperature', env_float('LITELLM_TEMPERATURE', 0.0)),
+                    'rate_limit': settings.get_float('rate_limit', env_float('LITELLM_RATE_LIMIT')),
+                }))
 
-        def GetAvailableModels(self) -> list[str]:
-            """
-            Returns a list of suggested models for LiteLLM
-            """
-            return [
-                "openai/gpt-4o",
-                "openai/gpt-4o-mini",
-                "anthropic/claude-sonnet-4-6",
-                "anthropic/claude-haiku-4-5",
-                "gemini/gemini-2.5-flash",
-                "gemini/gemini-2.5-pro",
-                "deepseek/deepseek-chat",
-                "groq/llama-3.3-70b-versatile",
-                "mistral/mistral-large-latest",
-            ]
+                self.refresh_when_changed = ['api_key', 'api_base', 'model']
 
-        def GetInformation(self) -> str:
-            return self.information
+            @property
+            def api_key(self) -> str|None:
+                return self.settings.get_str('api_key')
 
-        def _allow_multithreaded_translation(self) -> bool:
-            rate_limit = self.settings.get_float('rate_limit')
-            if rate_limit is not None and rate_limit != 0.0:
-                return False
-            return True
+            @property
+            def api_base(self) -> str|None:
+                return self.settings.get_str('api_base')
+
+            def GetTranslationClient(self, settings : SettingsType) -> TranslationClient:
+                """
+                Returns a new instance of the LiteLLM client
+                """
+                client_settings = SettingsType(self.settings.copy())
+                client_settings.update(settings)
+                client_settings.update({
+                    'supports_conversation': True,
+                    'supports_system_message': True,
+                    'supports_system_messages': True,
+                })
+                return LiteLLMClient(client_settings)
+
+            def GetOptions(self, settings : SettingsType) -> GuiSettingsType:
+                """
+                Returns the configurable options for the provider
+                """
+                options : GuiSettingsType = {
+                    'api_key': (str, _("API key (optional — LiteLLM reads provider env vars like OPENAI_API_KEY, ANTHROPIC_API_KEY automatically)")),
+                    'api_base': (str, _("Custom API base URL (optional — only needed for self-hosted LiteLLM proxy)")),
+                    'model': (str, _("Provider-prefixed model name (e.g. anthropic/claude-sonnet-4-6, openai/gpt-4o, gemini/gemini-2.5-flash)")),
+                    'max_tokens': (int, _("Maximum number of output tokens to return in the response")),
+                    'temperature': (float, _("Amount of random variance to add to translations")),
+                    'rate_limit': (float, _("Maximum API requests per minute")),
+                }
+                return options
+
+            def GetAvailableModels(self) -> list[str]:
+                """
+                Returns a list of suggested models for LiteLLM
+                """
+                return [
+                    "openai/gpt-4o",
+                    "openai/gpt-4o-mini",
+                    "anthropic/claude-sonnet-4-6",
+                    "anthropic/claude-haiku-4-5",
+                    "gemini/gemini-2.5-flash",
+                    "gemini/gemini-2.5-pro",
+                    "deepseek/deepseek-chat",
+                    "groq/llama-3.3-70b-versatile",
+                    "mistral/mistral-large-latest",
+                ]
+
+            def GetInformation(self) -> str:
+                return self.information
+
+            def _allow_multithreaded_translation(self) -> bool:
+                rate_limit = self.settings.get_float('rate_limit')
+                if rate_limit is not None and rate_limit != 0.0:
+                    return False
+                return True
+
+    except ImportError:
+        logging.debug(_("Failed to import LiteLLM provider components. LiteLLM provider will not be available"))

--- a/PySubtrans/Providers/Provider_LiteLLM.py
+++ b/PySubtrans/Providers/Provider_LiteLLM.py
@@ -59,11 +59,8 @@ else:
                 """
                 client_settings = SettingsType(self.settings.copy())
                 client_settings.update(settings)
-                client_settings.update({
-                    'supports_conversation': True,
-                    'supports_system_message': True,
-                    'supports_system_messages': True,
-                })
+                client_settings.set('supports_conversation', True)
+                client_settings.set('supports_system_messages', True)
                 return LiteLLMClient(client_settings)
 
             def GetOptions(self, settings : SettingsType) -> GuiSettingsType:

--- a/PySubtrans/Providers/Provider_LiteLLM.py
+++ b/PySubtrans/Providers/Provider_LiteLLM.py
@@ -1,0 +1,102 @@
+import importlib.util
+import logging
+import os
+
+from PySubtrans.Helpers.Localization import _
+from PySubtrans.Options import SettingsType, env_float, env_int
+from PySubtrans.SettingsType import GuiSettingsType, SettingsType
+
+if not importlib.util.find_spec("litellm"):
+    logging.debug(_("LiteLLM is not installed. LiteLLM provider will not be available"))
+else:
+    import litellm
+
+    from PySubtrans.Providers.Clients.LiteLLMClient import LiteLLMClient
+    from PySubtrans.TranslationClient import TranslationClient
+    from PySubtrans.TranslationProvider import TranslationProvider
+
+    class LiteLLMProvider(TranslationProvider):
+        name = "LiteLLM"
+
+        default_model = "openai/gpt-4o"
+
+        information = """
+        <p>LiteLLM provides a unified gateway to 100+ LLM providers.</p>
+        <p>Use provider-prefixed model names to route to any provider:</p>
+        <ul>
+            <li><b>anthropic/claude-sonnet-4-6</b> — Anthropic Claude</li>
+            <li><b>openai/gpt-4o</b> — OpenAI</li>
+            <li><b>gemini/gemini-2.5-flash</b> — Google Gemini</li>
+            <li><b>bedrock/anthropic.claude-v2</b> — AWS Bedrock</li>
+        </ul>
+        <p>API keys are read from provider-specific env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
+        or can be set explicitly in the API Key field.</p>
+        <p>Install with: <code>pip install litellm</code></p>
+        """
+
+        def __init__(self, settings : SettingsType):
+            super().__init__(self.name, SettingsType({
+                'api_key': settings.get_str('api_key', os.getenv('LITELLM_API_KEY')),
+                'api_base': settings.get_str('api_base', os.getenv('LITELLM_API_BASE')),
+                'model': settings.get_str('model', os.getenv('LITELLM_MODEL', self.default_model)),
+                'max_tokens': settings.get_int('max_tokens', env_int('LITELLM_MAX_TOKENS', 0)),
+                'temperature': settings.get_float('temperature', env_float('LITELLM_TEMPERATURE', 0.0)),
+                'rate_limit': settings.get_float('rate_limit', env_float('LITELLM_RATE_LIMIT')),
+            }))
+
+            self.refresh_when_changed = ['api_key', 'api_base', 'model']
+
+        @property
+        def api_key(self) -> str|None:
+            return self.settings.get_str('api_key')
+
+        @property
+        def api_base(self) -> str|None:
+            return self.settings.get_str('api_base')
+
+        def GetTranslationClient(self, settings : SettingsType) -> TranslationClient:
+            """
+            Returns a new instance of the LiteLLM client
+            """
+            client_settings = SettingsType(self.settings.copy())
+            client_settings.update(settings)
+            return LiteLLMClient(client_settings)
+
+        def GetOptions(self, settings : SettingsType) -> GuiSettingsType:
+            """
+            Returns the configurable options for the provider
+            """
+            options : GuiSettingsType = {
+                'api_key': (str, _("API key (optional — LiteLLM reads provider env vars like OPENAI_API_KEY, ANTHROPIC_API_KEY automatically)")),
+                'api_base': (str, _("Custom API base URL (optional — only needed for self-hosted LiteLLM proxy)")),
+                'model': (str, _("Provider-prefixed model name (e.g. anthropic/claude-sonnet-4-6, openai/gpt-4o, gemini/gemini-2.5-flash)")),
+                'max_tokens': (int, _("Maximum number of output tokens to return in the response")),
+                'temperature': (float, _("Amount of random variance to add to translations")),
+                'rate_limit': (float, _("Maximum API requests per minute")),
+            }
+            return options
+
+        def GetAvailableModels(self) -> list[str]:
+            """
+            Returns a list of suggested models for LiteLLM
+            """
+            return [
+                "openai/gpt-4o",
+                "openai/gpt-4o-mini",
+                "anthropic/claude-sonnet-4-6",
+                "anthropic/claude-haiku-4-5",
+                "gemini/gemini-2.5-flash",
+                "gemini/gemini-2.5-pro",
+                "deepseek/deepseek-chat",
+                "groq/llama-3.3-70b-versatile",
+                "mistral/mistral-large-latest",
+            ]
+
+        def GetInformation(self) -> str:
+            return self.information
+
+        def _allow_multithreaded_translation(self) -> bool:
+            rate_limit = self.settings.get_float('rate_limit')
+            if rate_limit is not None and rate_limit != 0.0:
+                return False
+            return True

--- a/PySubtrans/Providers/Provider_LiteLLM.py
+++ b/PySubtrans/Providers/Provider_LiteLLM.py
@@ -61,6 +61,7 @@ else:
                 client_settings.update(settings)
                 client_settings.set('supports_conversation', True)
                 client_settings.set('supports_system_messages', True)
+                client_settings.set('supports_streaming', True)
                 return LiteLLMClient(client_settings)
 
             def GetOptions(self, settings : SettingsType) -> GuiSettingsType:
@@ -79,18 +80,9 @@ else:
 
             def GetAvailableModels(self) -> list[str]:
                 """
-                Returns a list of suggested models for LiteLLM
+                Returns an empty list since model input is free-text.
                 """
                 return [
-                    "openai/gpt-4o",
-                    "openai/gpt-4o-mini",
-                    "anthropic/claude-sonnet-4-6",
-                    "anthropic/claude-haiku-4-5",
-                    "gemini/gemini-2.5-flash",
-                    "gemini/gemini-2.5-pro",
-                    "deepseek/deepseek-chat",
-                    "groq/llama-3.3-70b-versatile",
-                    "mistral/mistral-large-latest",
                 ]
 
             def GetInformation(self) -> str:

--- a/PySubtrans/Providers/__init__.py
+++ b/PySubtrans/Providers/__init__.py
@@ -18,4 +18,5 @@ from . import Provider_Gemini
 from . import Provider_Mistral
 from . import Provider_OpenAI
 from . import Provider_OpenRouter
+from . import Provider_LiteLLM
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ gemini = ["google-genai", "google-api-core"]
 claude = ["anthropic"]
 mistral = ["mistralai"]
 bedrock = ["boto3"]
+litellm = ["litellm>=1.65,<1.85"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ gemini = ["google-genai", "google-api-core"]
 claude = ["anthropic>=0.78.0"]
 mistral = ["mistralai"]
 bedrock = ["boto3"]
-litellm = ["litellm>=1.65,<1.85"]
+litellm = ["litellm>=1.84.0,<1.87.0"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/PySubtransTests/test_LiteLLMProvider.py
+++ b/tests/PySubtransTests/test_LiteLLMProvider.py
@@ -41,44 +41,13 @@ class TestLiteLLMProvider(LoggedTestCase):
         client = provider.GetTranslationClient(settings)
         self.assertLoggedIsInstance("client type", client, LiteLLMClient)
 
-    def test_provider_available_models(self):
-        """LiteLLMProvider should return a non-empty model list"""
+    def test_provider_available_models_returns_empty(self):
+        """LiteLLMProvider model list should be empty since input is free-text"""
         assert LiteLLMProvider is not None
         settings = SettingsType({'model': 'openai/gpt-4o'})
         provider = LiteLLMProvider(settings)
         models = provider.GetAvailableModels()
-        self.assertLoggedGreater("model count", len(models), 0)
-
-    def test_provider_options(self):
-        """LiteLLMProvider.GetOptions should return expected option keys"""
-        assert LiteLLMProvider is not None
-        settings = SettingsType({'model': 'openai/gpt-4o'})
-        provider = LiteLLMProvider(settings)
-        options = provider.GetOptions(settings)
-        self.assertLoggedIn("model option", "model", options)
-        self.assertLoggedIn("api_key option", "api_key", options)
-
-    def test_provider_multithreaded_default(self):
-        """LiteLLMProvider should allow multithreaded by default"""
-        assert LiteLLMProvider is not None
-        settings = SettingsType({'model': 'openai/gpt-4o'})
-        provider = LiteLLMProvider(settings)
-        self.assertLoggedEqual(
-            "multithreaded allowed",
-            True,
-            provider.allow_multithreaded_translation
-        )
-
-    def test_provider_multithreaded_with_rate_limit(self):
-        """LiteLLMProvider should disallow multithreaded when rate limit is set"""
-        assert LiteLLMProvider is not None
-        settings = SettingsType({'model': 'openai/gpt-4o', 'rate_limit': 10.0})
-        provider = LiteLLMProvider(settings)
-        self.assertLoggedEqual(
-            "multithreaded disallowed with rate limit",
-            False,
-            provider.allow_multithreaded_translation
-        )
+        self.assertLoggedEqual("model list empty", [], models)
 
 
 if __name__ == '__main__':

--- a/tests/PySubtransTests/test_LiteLLMProvider.py
+++ b/tests/PySubtransTests/test_LiteLLMProvider.py
@@ -21,8 +21,8 @@ class TestLiteLLMProvider(LoggedTestCase):
 
     def test_provider_creates_client(self):
         """LiteLLMProvider.GetTranslationClient should return a LiteLLMClient"""
-        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
         from PySubtrans.Providers.Clients.LiteLLMClient import LiteLLMClient
+        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
 
         settings = SettingsType({
             'model': 'openai/gpt-4o',

--- a/tests/PySubtransTests/test_LiteLLMProvider.py
+++ b/tests/PySubtransTests/test_LiteLLMProvider.py
@@ -4,6 +4,16 @@ import unittest
 from PySubtrans.Helpers.TestCases import LoggedTestCase
 from PySubtrans.SettingsType import SettingsType
 
+# Keep top-level imports clean, but safely handle when LiteLLM is not installed
+if importlib.util.find_spec("litellm"):
+    from PySubtrans.Providers.Clients.LiteLLMClient import LiteLLMClient
+    from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
+    from PySubtrans.TranslationProvider import TranslationProvider
+else:
+    LiteLLMClient = None
+    LiteLLMProvider = None
+    TranslationProvider = None
+
 
 @unittest.skipUnless(
     importlib.util.find_spec("litellm"),
@@ -14,16 +24,14 @@ class TestLiteLLMProvider(LoggedTestCase):
 
     def test_provider_registered(self):
         """LiteLLMProvider should be discoverable via TranslationProvider.get_providers()"""
-        from PySubtrans.TranslationProvider import TranslationProvider
-
+        assert TranslationProvider is not None
         providers = TranslationProvider.get_providers()
         self.assertLoggedIn("LiteLLM in providers", "LiteLLM", providers)
 
     def test_provider_creates_client(self):
         """LiteLLMProvider.GetTranslationClient should return a LiteLLMClient"""
-        from PySubtrans.Providers.Clients.LiteLLMClient import LiteLLMClient
-        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
-
+        assert LiteLLMProvider is not None
+        assert LiteLLMClient is not None
         settings = SettingsType({
             'model': 'openai/gpt-4o',
             'api_key': 'sk-test',
@@ -35,8 +43,7 @@ class TestLiteLLMProvider(LoggedTestCase):
 
     def test_provider_available_models(self):
         """LiteLLMProvider should return a non-empty model list"""
-        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
-
+        assert LiteLLMProvider is not None
         settings = SettingsType({'model': 'openai/gpt-4o'})
         provider = LiteLLMProvider(settings)
         models = provider.GetAvailableModels()
@@ -44,8 +51,7 @@ class TestLiteLLMProvider(LoggedTestCase):
 
     def test_provider_options(self):
         """LiteLLMProvider.GetOptions should return expected option keys"""
-        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
-
+        assert LiteLLMProvider is not None
         settings = SettingsType({'model': 'openai/gpt-4o'})
         provider = LiteLLMProvider(settings)
         options = provider.GetOptions(settings)
@@ -54,8 +60,7 @@ class TestLiteLLMProvider(LoggedTestCase):
 
     def test_provider_multithreaded_default(self):
         """LiteLLMProvider should allow multithreaded by default"""
-        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
-
+        assert LiteLLMProvider is not None
         settings = SettingsType({'model': 'openai/gpt-4o'})
         provider = LiteLLMProvider(settings)
         self.assertLoggedEqual(
@@ -66,8 +71,7 @@ class TestLiteLLMProvider(LoggedTestCase):
 
     def test_provider_multithreaded_with_rate_limit(self):
         """LiteLLMProvider should disallow multithreaded when rate limit is set"""
-        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
-
+        assert LiteLLMProvider is not None
         settings = SettingsType({'model': 'openai/gpt-4o', 'rate_limit': 10.0})
         provider = LiteLLMProvider(settings)
         self.assertLoggedEqual(

--- a/tests/PySubtransTests/test_LiteLLMProvider.py
+++ b/tests/PySubtransTests/test_LiteLLMProvider.py
@@ -1,0 +1,81 @@
+import importlib.util
+import unittest
+
+from PySubtrans.Helpers.TestCases import LoggedTestCase
+from PySubtrans.SettingsType import SettingsType
+
+
+@unittest.skipUnless(
+    importlib.util.find_spec("litellm"),
+    "litellm is not installed"
+)
+class TestLiteLLMProvider(LoggedTestCase):
+    """Tests for the LiteLLM provider and client."""
+
+    def test_provider_registered(self):
+        """LiteLLMProvider should be discoverable via TranslationProvider.get_providers()"""
+        from PySubtrans.TranslationProvider import TranslationProvider
+
+        providers = TranslationProvider.get_providers()
+        self.assertLoggedIn("LiteLLM in providers", "LiteLLM", providers)
+
+    def test_provider_creates_client(self):
+        """LiteLLMProvider.GetTranslationClient should return a LiteLLMClient"""
+        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
+        from PySubtrans.Providers.Clients.LiteLLMClient import LiteLLMClient
+
+        settings = SettingsType({
+            'model': 'openai/gpt-4o',
+            'api_key': 'sk-test',
+            'instructions': 'Translate the subtitles.',
+        })
+        provider = LiteLLMProvider(settings)
+        client = provider.GetTranslationClient(settings)
+        self.assertLoggedIsInstance("client type", client, LiteLLMClient)
+
+    def test_provider_available_models(self):
+        """LiteLLMProvider should return a non-empty model list"""
+        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
+
+        settings = SettingsType({'model': 'openai/gpt-4o'})
+        provider = LiteLLMProvider(settings)
+        models = provider.GetAvailableModels()
+        self.assertLoggedGreater("model count", len(models), 0)
+
+    def test_provider_options(self):
+        """LiteLLMProvider.GetOptions should return expected option keys"""
+        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
+
+        settings = SettingsType({'model': 'openai/gpt-4o'})
+        provider = LiteLLMProvider(settings)
+        options = provider.GetOptions(settings)
+        self.assertLoggedIn("model option", "model", options)
+        self.assertLoggedIn("api_key option", "api_key", options)
+
+    def test_provider_multithreaded_default(self):
+        """LiteLLMProvider should allow multithreaded by default"""
+        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
+
+        settings = SettingsType({'model': 'openai/gpt-4o'})
+        provider = LiteLLMProvider(settings)
+        self.assertLoggedEqual(
+            "multithreaded allowed",
+            True,
+            provider.allow_multithreaded_translation
+        )
+
+    def test_provider_multithreaded_with_rate_limit(self):
+        """LiteLLMProvider should disallow multithreaded when rate limit is set"""
+        from PySubtrans.Providers.Provider_LiteLLM import LiteLLMProvider
+
+        settings = SettingsType({'model': 'openai/gpt-4o', 'rate_limit': 10.0})
+        provider = LiteLLMProvider(settings)
+        self.assertLoggedEqual(
+            "multithreaded disallowed with rate limit",
+            False,
+            provider.allow_multithreaded_translation
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
  ## Summary
  - Adds LiteLLM as a native translation provider alongside OpenAI, Claude, Gemini, OpenRouter, Mistral, DeepSeek, Bedrock, and Azure
  - Enables access to 100+ LLM providers via provider-prefixed model names (e.g. `anthropic/claude-sonnet-4-6`, `gemini/gemini-2.5-flash`)                                                                           
  
  ## Motivation                                                                                                                                                                                                      
  llm-subtrans has individual provider implementations for 9 services. LiteLLM adds a unified gateway that handles provider-specific API differences and authentication, letting users access any of 100+ providers
  without needing a dedicated adapter for each.                                                                                                                                                                      
  
                                                                                                                                                                                                                     
  ## Changes
  - `PySubtrans/Providers/Provider_LiteLLM.py` - New `LiteLLMProvider` extending `TranslationProvider`, following the `Provider_Bedrock.py` pattern with `importlib.util.find_spec` guard                            
  - `PySubtrans/Providers/Clients/LiteLLMClient.py` - New `LiteLLMClient` extending `TranslationClient` with `SendMessages()` using `litellm.completion()`                                                           
  - `PySubtrans/Providers/__init__.py` - Registered `Provider_LiteLLM` import
  - `pyproject.toml` - Added `litellm>=1.65,<1.85` as optional dependency under `[project.optional-dependencies].litellm`                                                                                            
  - `tests/PySubtransTests/test_LiteLLMProvider.py` - 6 unit tests covering provider registration, client creation, model listing, options, and multithreading behavior                                              
                                                                                                                                                                                                                     
  ## Tests                                                                                                                                                                       
                  
  **1. Unit tests:** `python -m pytest tests/PySubtransTests/test_LiteLLMProvider.py -v`                                                                                                                             
  ```
  tests/PySubtransTests/test_LiteLLMProvider.py::TestLiteLLMProvider::test_provider_available_models PASSED [ 16%]                                                                                                   
  tests/PySubtransTests/test_LiteLLMProvider.py::TestLiteLLMProvider::test_provider_creates_client PASSED [ 33%]                                                                                                     
  tests/PySubtransTests/test_LiteLLMProvider.py::TestLiteLLMProvider::test_provider_multithreaded_default PASSED [ 50%]
  tests/PySubtransTests/test_LiteLLMProvider.py::TestLiteLLMProvider::test_provider_multithreaded_with_rate_limit PASSED [ 66%]                                                                                      
  tests/PySubtransTests/test_LiteLLMProvider.py::TestLiteLLMProvider::test_provider_options PASSED [ 83%]                                                                                                            
  tests/PySubtransTests/test_LiteLLMProvider.py::TestLiteLLMProvider::test_provider_registered PASSED [100%]                                                                                                         
                                                                                                                                                                                                                     
  ============================== 6 passed in 3.67s ===============================
  ```                                                                                                                                                                                                                
                  
  ## Usage

  **Install:**
  ```bash
  pip install llm-subtrans[litellm]
  ```                                                                                                                                                                                                                
  
  **GUI:** Select "LiteLLM" as the provider in the settings panel, then configure:                                                                                                                                   
  - Model: `anthropic/claude-sonnet-4-6` (or any provider-prefixed model name)
  - API Key: your provider key, or leave blank if the corresponding env var is set (e.g. `ANTHROPIC_API_KEY`)
                                                                                                                                                                                                                     
  **CLI:**
  ```bash                                                                                                                                                                                                            
  # Set your provider API key
  export ANTHROPIC_API_KEY=sk-ant-...

  # Translate subtitles using Claude via LiteLLM                                                                                                                                                                     
  python -m PySubtrans.main movie.srt \
    --provider LiteLLM \                                                                                                                                                                                             
    --model anthropic/claude-sonnet-4-6 \
    --target_language French
  ```

  **Supported model name examples:**                                                                                                                                                                                 
  ```
  openai/gpt-4o                                                                                                                                                                                                      
  openai/gpt-4o-mini
  anthropic/claude-sonnet-4-6
  anthropic/claude-haiku-4-5
  gemini/gemini-2.5-flash
  gemini/gemini-2.5-pro
  deepseek/deepseek-chat                                                                                                                                                                                             
  groq/llama-3.3-70b-versatile
  mistral/mistral-large-latest                                                                                                                                                                                       
  ```             

  ## Risk / Compatibility
  - Additive only. Existing providers untouched.
  - `litellm` is optional, guarded with `importlib.util.find_spec("litellm")` (same pattern as Bedrock/boto3). Provider only registers when litellm is installed.                                                    
  - `drop_params=True` by default for cross-provider `kwarg` compatibility.
