### PR TITLE
Fix temperature deprecation error for Claude Sonnet 5 (#426)

### DIFF
--- a/PySubtrans/Providers/Clients/AnthropicClient.py
+++ b/PySubtrans/Providers/Clients/AnthropicClient.py
@@ -51,16 +51,21 @@ class AnthropicClient(TranslationClient):
     
     @property
     def thinking(self) -> ThinkingConfigParam|anthropic.Omit:
-        if self.allow_thinking:
-            if not self._supports_temperature_parameter():
-                return ThinkingConfigAdaptiveParam(type='adaptive')
+        if not self.allow_thinking:
+            return anthropic.omit
 
-            return ThinkingConfigEnabledParam(
-                type='enabled',
-                budget_tokens=self.settings.get_int('max_thinking_tokens', 1024) or 1024
-            )
-        
-        return anthropic.omit
+        use_adaptive = self._use_adaptive_thinking()
+        if use_adaptive is None:
+            # The model does not support thinking at all
+            return anthropic.omit
+
+        if use_adaptive:
+            return ThinkingConfigAdaptiveParam(type='adaptive')
+
+        return ThinkingConfigEnabledParam(
+            type='enabled',
+            budget_tokens=self.settings.get_int('max_thinking_tokens', 1024) or 1024
+        )
 
     def _request_translation(self, request: TranslationRequest, temperature: float|None = None) -> Translation|None:
         """
@@ -287,16 +292,54 @@ class AnthropicClient(TranslationClient):
 
         return messages
 
-    def _supports_temperature_parameter(self) -> bool:
-        """Return True when the selected model accepts the temperature parameter."""
+    def _parse_claude_version(self) -> tuple[int, int]|None:
+        """Parse (major, minor) version numbers from the model name, or None if indeterminable."""
         if self.model is None:
-            return True
+            return None
 
         match = regex.search(r'claude[-\s]+[a-zA-Z]+[-\s]+(\d+)(?:[.-](\d{1,3})(?!\d))?', self.model, flags=regex.IGNORECASE)
         if match is None:
-            return True
+            return None
 
         major = int(match.group(1))
         minor = int(match.group(2)) if match.group(2) is not None else 0
 
+        return major, minor
+
+    def _supports_temperature_parameter(self) -> bool:
+        """
+        Return True when the selected model accepts the temperature parameter.
+
+        Claude models from 4.7 onward reject temperature. Models we cannot identify are
+        assumed not to support it, as Anthropic has removed it going forward.
+        """
+        version = self._parse_claude_version()
+        if version is None:
+            return False
+
+        major, minor = version
         return major < 4 or (major == 4 and minor < 7)
+
+    def _use_adaptive_thinking(self) -> bool|None:
+        """
+        Decide the thinking configuration for the selected model.
+
+        Returns True for adaptive thinking, False for enabled thinking with a token budget,
+        or None if the model does not support thinking at all.
+
+        Prefers the model's reported capabilities (supplied by the provider); falls back to
+        the version heuristic when capabilities are unavailable, e.g. the model was typed
+        manually or is not in the fetched model list.
+        """
+        adaptive = self.settings.get('thinking_supports_adaptive')
+        enabled = self.settings.get('thinking_supports_enabled')
+
+        if adaptive is None and enabled is None:
+            # No capability information - models from 4.7 onward use adaptive thinking
+            version = self._parse_claude_version()
+            return version is None or version >= (4, 7)
+
+        if not adaptive and not enabled:
+            return None
+
+        return bool(adaptive) and not bool(enabled)

--- a/PySubtrans/Providers/Clients/AnthropicClient.py
+++ b/PySubtrans/Providers/Clients/AnthropicClient.py
@@ -297,9 +297,6 @@ class AnthropicClient(TranslationClient):
             return True
 
         major = int(match.group(1))
-        minor_str = match.group(2)
+        minor = int(match.group(2)) if match.group(2) is not None else 0
 
-        if minor_str is None:
-            return True
-
-        return major < 4 or (major == 4 and int(minor_str) < 7)
+        return major < 4 or (major == 4 and minor < 7)

--- a/PySubtrans/Providers/Clients/AnthropicClient.py
+++ b/PySubtrans/Providers/Clients/AnthropicClient.py
@@ -201,20 +201,21 @@ class AnthropicClient(TranslationClient):
 
     def _stream_client_response(self, prompt : TranslationPrompt, request : TranslationRequest, temperature : float):
         """Stream an Anthropic response with model-specific parameters."""
+        thinking = self.thinking
         if self._supports_temperature_parameter():
             with self._get_client().messages.stream(
                 model=self._get_model_param(),
-                thinking=self.thinking,
+                thinking=thinking,
                 messages=self._get_message_params(prompt),
                 system=self._get_system_prompt(prompt),
-                temperature=temperature if not self.allow_thinking else 1,
+                temperature=self._resolve_temperature(temperature, thinking),
                 max_tokens=self.max_tokens
             ) as stream:
                 return self._consume_stream(stream, request)
 
         with self._get_client().messages.stream(
             model=self._get_model_param(),
-            thinking=self.thinking,
+            thinking=thinking,
             messages=self._get_message_params(prompt),
             system=self._get_system_prompt(prompt),
             max_tokens=self.max_tokens
@@ -223,19 +224,20 @@ class AnthropicClient(TranslationClient):
 
     def _create_client_response(self, prompt : TranslationPrompt, temperature : float):
         """Create an Anthropic response with model-specific parameters."""
+        thinking = self.thinking
         if self._supports_temperature_parameter():
             return self._get_client().messages.create(
                 model=self._get_model_param(),
-                thinking=self.thinking,
+                thinking=thinking,
                 messages=self._get_message_params(prompt),
                 system=self._get_system_prompt(prompt),
-                temperature=temperature if not self.allow_thinking else 1,
+                temperature=self._resolve_temperature(temperature, thinking),
                 max_tokens=self.max_tokens
             )
 
         return self._get_client().messages.create(
             model=self._get_model_param(),
-            thinking=self.thinking,
+            thinking=thinking,
             messages=self._get_message_params(prompt),
             system=self._get_system_prompt(prompt),
             max_tokens=self.max_tokens
@@ -343,3 +345,15 @@ class AnthropicClient(TranslationClient):
             return None
 
         return bool(adaptive) and not bool(enabled)
+
+    @staticmethod
+    def _resolve_temperature(temperature : float, thinking : ThinkingConfigParam|anthropic.Omit) -> float:
+        """
+        Enabled (budget) thinking requires temperature to be 1; otherwise use the requested
+        value. Keyed on the thinking config actually being sent, not the raw thinking setting,
+        so a model that omits thinking still honours the configured temperature.
+        """
+        if isinstance(thinking, dict) and thinking.get('type') == 'enabled':
+            return 1
+
+        return temperature

--- a/PySubtrans/Providers/Provider_Claude.py
+++ b/PySubtrans/Providers/Provider_Claude.py
@@ -78,6 +78,13 @@ else:
                     'supports_system_messages': False,
                     'supports_system_prompt': True
                     })
+
+                model_id = client_settings.get('model')
+                if isinstance(model_id, str):
+                    thinking_capabilities = self._get_thinking_capabilities(model_id)
+                    if thinking_capabilities is not None:
+                        client_settings.update(thinking_capabilities)
+
                 return AnthropicClient(client_settings)
 
             def GetAvailableModels(self) -> list[str]:
@@ -149,6 +156,29 @@ else:
                         error=str(e)
                     ))
                     return []
+
+            def _get_thinking_capabilities(self, model_id : str) -> SettingsType|None:
+                """
+                Return the model's reported thinking capabilities as client settings, or None
+                when they are unavailable (e.g. the model is not in the fetched model list or
+                the API did not report capabilities). The client falls back to a version
+                heuristic in that case.
+                """
+                for model in self.claude_models:
+                    if model.id != model_id:
+                        continue
+
+                    capabilities = getattr(model, 'capabilities', None)
+                    thinking = getattr(capabilities, 'thinking', None) if capabilities else None
+                    if thinking is None:
+                        return None
+
+                    return SettingsType({
+                        'thinking_supports_adaptive': thinking.types.adaptive.supported,
+                        'thinking_supports_enabled': thinking.types.enabled.supported,
+                    })
+
+                return None
 
             def _get_model_id(self, name : str) -> str:
                 if not self.claude_models:

--- a/PySubtrans/Providers/Provider_Claude.py
+++ b/PySubtrans/Providers/Provider_Claude.py
@@ -170,12 +170,16 @@ else:
 
                     capabilities = getattr(model, 'capabilities', None)
                     thinking = getattr(capabilities, 'thinking', None) if capabilities else None
-                    if thinking is None:
+                    types = getattr(thinking, 'types', None) if thinking else None
+                    adaptive = getattr(types, 'adaptive', None) if types else None
+                    enabled = getattr(types, 'enabled', None) if types else None
+
+                    if adaptive is None or enabled is None:
                         return None
 
                     return SettingsType({
-                        'thinking_supports_adaptive': thinking.types.adaptive.supported,
-                        'thinking_supports_enabled': thinking.types.enabled.supported,
+                        'thinking_supports_adaptive': getattr(adaptive, 'supported', False),
+                        'thinking_supports_enabled': getattr(enabled, 'supported', False),
                     })
 
                 return None

--- a/PySubtrans/pyproject.toml
+++ b/PySubtrans/pyproject.toml
@@ -35,7 +35,7 @@ gemini = [
     "google-api-core"
 ]
 claude = [
-    "anthropic"
+    "anthropic>=0.105.0"
 ]
 mistral = [
     "mistralai"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ gui = [
 openai = ["openai"]
 azure = ["openai"]
 gemini = ["google-genai", "google-api-core"]
-claude = ["anthropic>=0.78.0"]
+claude = ["anthropic>=0.105.0"]
 mistral = ["mistralai"]
 bedrock = ["boto3"]
 litellm = ["litellm>=1.84.0,<1.87.0"]

--- a/tests/PySubtransTests/test_AnthropicClient.py
+++ b/tests/PySubtransTests/test_AnthropicClient.py
@@ -185,3 +185,29 @@ class TestAnthropicClientRequestParameters(LoggedTestCase):
         thinking = client.client.messages.create.call_args.kwargs.get('thinking')
 
         self.assertLoggedIsInstance("thinking omitted", thinking, anthropic.Omit)
+
+    def test_budget_thinking_forces_temperature_one(self) -> None:
+        """Enabled (budget) thinking overrides temperature to 1 on temperature-capable models."""
+        client = AnthropicClient(_create_test_settings('claude-opus-4-6', thinking=True))
+        client.client = MagicMock()
+
+        client._create_client_response(_create_test_request().prompt, 0.3)
+        kwargs = client.client.messages.create.call_args.kwargs
+
+        self.assertLoggedEqual("thinking type", 'enabled', kwargs.get('thinking', {}).get('type'))
+        self.assertLoggedEqual("temperature", 1, kwargs.get('temperature'))
+
+    def test_no_thinking_capability_preserves_temperature(self) -> None:
+        """A temperature-capable model that omits thinking keeps the configured temperature."""
+        # thinking is left enabled, but the model reports no thinking support, so no thinking
+        # config is sent - the temperature override must not fire.
+        client = AnthropicClient(_create_test_settings(
+            'claude-opus-4-6', thinking=True,
+            thinking_supports_adaptive=False, thinking_supports_enabled=False))
+        client.client = MagicMock()
+
+        client._create_client_response(_create_test_request().prompt, 0.3)
+        kwargs = client.client.messages.create.call_args.kwargs
+
+        self.assertLoggedIsInstance("thinking omitted", kwargs.get('thinking'), anthropic.Omit)
+        self.assertLoggedEqual("temperature", 0.3, kwargs.get('temperature'))

--- a/tests/PySubtransTests/test_AnthropicClient.py
+++ b/tests/PySubtransTests/test_AnthropicClient.py
@@ -10,18 +10,22 @@ from PySubtrans.TranslationRequest import TranslationRequest
 HAS_ANTHROPIC = importlib.util.find_spec("anthropic") is not None
 
 if HAS_ANTHROPIC:
+    import anthropic
+
     from PySubtrans.Providers.Clients.AnthropicClient import AnthropicClient
 
 
-def _create_test_settings(model : str, thinking : bool = False) -> SettingsType:
+def _create_test_settings(model : str, thinking : bool = False, **extra) -> SettingsType:
     """Create minimal Anthropic client settings for testing."""
-    return SettingsType({
+    settings : dict = {
         'api_key': 'test-key',
         'instructions': 'Translate the subtitles.',
         'model': model,
         'max_tokens': 512,
         'thinking': thinking
-    })
+    }
+    settings.update(extra)
+    return SettingsType(settings)
 
 
 def _create_test_request() -> TranslationRequest:
@@ -119,3 +123,65 @@ class TestAnthropicClientRequestParameters(LoggedTestCase):
 
         self.assertLoggedEqual("thinking type", 'adaptive', thinking.get('type'))
         self.assertLoggedNotIn("budget tokens omitted", 'budget_tokens', thinking)
+
+    def test_unrecognized_model_omits_temperature(self) -> None:
+        """Unidentifiable model names default to omitting temperature (assume it is gone)."""
+        client = AnthropicClient(_create_test_settings('some-future-model'))
+        client.client = MagicMock()
+
+        client._create_client_response(_create_test_request().prompt, 0.3)
+        kwargs = client.client.messages.create.call_args.kwargs
+
+        self.assertLoggedNotIn("temperature omitted", 'temperature', kwargs)
+
+    def test_capabilities_adaptive_only_uses_adaptive_mode(self) -> None:
+        """Reported adaptive-only thinking capability selects adaptive mode."""
+        client = AnthropicClient(_create_test_settings(
+            'claude-sonnet-5', thinking=True,
+            thinking_supports_adaptive=True, thinking_supports_enabled=False))
+        client.client = MagicMock()
+
+        client._create_client_response(_create_test_request().prompt, 0.3)
+        thinking = client.client.messages.create.call_args.kwargs.get('thinking', {})
+
+        self.assertLoggedEqual("thinking type", 'adaptive', thinking.get('type'))
+        self.assertLoggedNotIn("budget tokens omitted", 'budget_tokens', thinking)
+
+    def test_capabilities_override_version_heuristic(self) -> None:
+        """Reported capabilities take precedence over the model-name version heuristic."""
+        # An older model name that the heuristic would map to enabled thinking, but the
+        # reported capabilities say adaptive-only - capabilities must win.
+        client = AnthropicClient(_create_test_settings(
+            'claude-opus-4-6', thinking=True,
+            thinking_supports_adaptive=True, thinking_supports_enabled=False))
+        client.client = MagicMock()
+
+        client._create_client_response(_create_test_request().prompt, 0.3)
+        thinking = client.client.messages.create.call_args.kwargs.get('thinking', {})
+
+        self.assertLoggedEqual("thinking type", 'adaptive', thinking.get('type'))
+
+    def test_capabilities_enabled_uses_budget_thinking(self) -> None:
+        """A model reporting enabled thinking uses a token budget."""
+        client = AnthropicClient(_create_test_settings(
+            'claude-sonnet-4-6', thinking=True,
+            thinking_supports_adaptive=True, thinking_supports_enabled=True))
+        client.client = MagicMock()
+
+        client._create_client_response(_create_test_request().prompt, 0.3)
+        thinking = client.client.messages.create.call_args.kwargs.get('thinking', {})
+
+        self.assertLoggedEqual("thinking type", 'enabled', thinking.get('type'))
+        self.assertLoggedIn("budget tokens present", 'budget_tokens', thinking)
+
+    def test_capabilities_no_thinking_omits_thinking(self) -> None:
+        """A model that reports no thinking support omits the thinking parameter."""
+        client = AnthropicClient(_create_test_settings(
+            'claude-haiku-4-5', thinking=True,
+            thinking_supports_adaptive=False, thinking_supports_enabled=False))
+        client.client = MagicMock()
+
+        client._create_client_response(_create_test_request().prompt, 0.3)
+        thinking = client.client.messages.create.call_args.kwargs.get('thinking')
+
+        self.assertLoggedIsInstance("thinking omitted", thinking, anthropic.Omit)

--- a/tests/PySubtransTests/test_AnthropicClient.py
+++ b/tests/PySubtransTests/test_AnthropicClient.py
@@ -76,6 +76,38 @@ class TestAnthropicClientRequestParameters(LoggedTestCase):
 
         self.assertLoggedNotIn("temperature omitted", 'temperature', kwargs)
 
+    def test_sonnet_5_omits_temperature(self) -> None:
+        """Sonnet 5 request payloads omit deprecated temperature."""
+        client = AnthropicClient(_create_test_settings('claude-sonnet-5'))
+        client.client = MagicMock()
+
+        client._create_client_response(_create_test_request().prompt, 0.3)
+        kwargs = client.client.messages.create.call_args.kwargs
+
+        self.assertLoggedNotIn("temperature omitted", 'temperature', kwargs)
+
+    def test_fable_5_omits_temperature(self) -> None:
+        """Fable 5 request payloads omit deprecated temperature."""
+        client = AnthropicClient(_create_test_settings('claude-fable-5'))
+        client.client = MagicMock()
+
+        client._create_client_response(_create_test_request().prompt, 0.3)
+        kwargs = client.client.messages.create.call_args.kwargs
+
+        self.assertLoggedNotIn("temperature omitted", 'temperature', kwargs)
+
+    def test_sonnet_5_thinking_uses_adaptive_mode(self) -> None:
+        """Sonnet 5 thinking mode uses adaptive thinking without a budget."""
+        client = AnthropicClient(_create_test_settings('claude-sonnet-5', thinking=True))
+        client.client = MagicMock()
+
+        client._create_client_response(_create_test_request().prompt, 0.3)
+        kwargs = client.client.messages.create.call_args.kwargs
+        thinking = kwargs.get('thinking', {})
+
+        self.assertLoggedEqual("thinking type", 'adaptive', thinking.get('type'))
+        self.assertLoggedNotIn("budget tokens omitted", 'budget_tokens', thinking)
+
     def test_opus_4_7_thinking_uses_adaptive_mode(self) -> None:
         """Opus 4.7 thinking mode uses adaptive thinking without a budget."""
         client = AnthropicClient(_create_test_settings('Claude Opus 4.7', thinking=True))


### PR DESCRIPTION
## Summary

Fixes #426 — translating with **Claude Sonnet 5** failed with HTTP 400 `"temperature" is deprecated for this model.` Same bug class as #422 (Opus 4.7), now hitting the Sonnet 5 / Fable 5 generation. Tested live against Sonnet 5 and Haiku 4.5.

### Root cause
`AnthropicClient._supports_temperature_parameter()` short-circuited to `True` whenever the model string had no parseable minor version. That branch existed to keep `temperature` for dated Opus-4 snapshots (e.g. `claude-opus-4-20250514`), but it also matched `claude-sonnet-5` / `claude-fable-5` (major 5, no minor), so the client sent `temperature` — and `budget_tokens` in thinking mode — which these models reject with a 400.

## Changes

**Core fix** (`AnthropicClient`)
- Treat a missing minor version as `0` and let the existing "< 4.7" threshold decide. Dated Opus-4 snapshots still keep temperature; major ≥ 5 correctly omits it and switches to adaptive thinking. Forward-safe for future models.

**Review-driven hardening**
- Thinking config (adaptive vs `budget_tokens`) is now driven by the model's reported `capabilities.thinking.types` when available, falling back to the version heuristic otherwise. A model reporting no thinking support omits the `thinking` parameter entirely instead of sending `budget_tokens` it would reject.
- Temperature and thinking are decoupled — they share `_parse_claude_version()`, but neither depends on the other.
- Unidentifiable model names now default to omitting temperature (Anthropic has removed it going forward; err on the safe side).

**Housekeeping**
- Bump the `anthropic` SDK floor to `>=0.105.0` (verified to expose the adaptive-thinking types and `anthropic.omit` the client uses).

## Tests
- 13 tests in `test_AnthropicClient.py` (was 8): Sonnet 5 / Fable 5 temperature omission, the flipped default, and capability-driven adaptive/enabled/no-thinking paths (including capabilities overriding the version heuristic).
- Full unit suite green (328 tests); pyright clean.

## Notes
- Behavior is unchanged for every currently-supported model classified via the version heuristic (Opus 4.6 → temperature + budget thinking, Opus 4.7+ → omit + adaptive, etc.).
- The capability path degrades safely to the version heuristic when the API returns `capabilities = None` for a model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)