### PR TITLE
Add portable and configurable application paths

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,32 +2,20 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [ready_for_review]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # Reviews are not run on every push by default - add `opened` and `synchronize` for that
+    types: [ready_for_review, reopened]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # Required to post inline review comments
       id-token: write
-    
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -36,19 +24,44 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Post a live progress checklist, and reuse one comment across re-runs
+          track_progress: true
+          use_sticky_comment: true
+
           prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-          
+            Review this pull request. Read CLAUDE.md for the project's coding
+            standards and docs/architecture.md for how the components fit
+            together before assessing the changes.
+
+            Look for:
+            - Correctness: bugs, unhandled edge cases, thread-safety problems in
+              code that touches shared state (the project uses RLock/QRecursiveMutex)
+            - Design: does the change fit the existing architecture, or duplicate
+              something that already exists elsewhere in the codebase?
+            - Test coverage: unit tests extend LoggedTestCase and use the
+              assertLogged* helpers rather than bare assertions
+            - Security concerns and performance regressions
+
+            Also check these project-specific rules, which are easy to miss:
+            - Imports must be at the top of the file, never inside a function or method
+            - No deprecated typing members (List, Union, Iterator) - use builtins and `|`
+            - Type hint style is `param : str` and `str|None` (space before the colon,
+              no spaces around the pipe)
+            - `# type: ignore` is only acceptable for missing third-party stubs
+            - Prefer SettingsType typed getters (get_str/get_bool/get_int/get_dict)
+              over raw .get()
+            - The `regex` module is used instead of `re`
+            - No Unicode symbols in print/log output - they break the Windows console
+            - PySide6 enums must use the scoped form
+            - User-facing error messages should be localizable via _()
+
+            Leave specific findings as inline comments on the relevant lines, and
+            post one top-level comment summarising the review. Be constructive and
+            concrete, and say so plainly if the change looks good.
+
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(gh search:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,14 +19,14 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -35,16 +35,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
-          # This is an optional setting that allows Claude to read CI results on PRs
+
+          # Allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
-
+          claude_args: '--model claude-opus-4-8'

--- a/PySubtrans/Helpers/InstructionsHelpers.py
+++ b/PySubtrans/Helpers/InstructionsHelpers.py
@@ -3,7 +3,7 @@ import os
 
 from PySubtrans.Instructions import Instructions, DEFAULT_TASK_TYPE, default_instructions, default_retry_instructions, default_terminology_instructions
 from PySubtrans.Helpers.Localization import _
-from PySubtrans.Helpers.Resources import GetResourcePath, config_dir
+from PySubtrans.Helpers.Resources import GetConfigDir, GetResourcePath
 
 linesep = '\n'
 
@@ -150,7 +150,7 @@ def GetInstructionsUserPath(instructions_file : str|None = None) -> str:
     """
     Get the path for an instructions file (or the directory that contains them).
     """
-    instructions_dir = os.path.join(config_dir, "instructions")
+    instructions_dir = os.path.join(GetConfigDir(), "instructions")
     return os.path.join(instructions_dir, instructions_file) if instructions_file else instructions_dir
 
 

--- a/PySubtrans/Helpers/Resources.py
+++ b/PySubtrans/Helpers/Resources.py
@@ -51,6 +51,9 @@ def ConfigureConfigDirFromArguments(arguments : Sequence[str]|None = None) -> st
         elif argument.startswith("--configpath="):
             config_path = argument.split("=", 1)[1]
 
+    if config_path is None and not portable:
+        config_path = os.getenv("LLM_SUBTRANS_CONFIG_DIR") or None
+
     return ConfigureConfigDir(config_path=config_path, portable=portable)
 
 def GetResourcePath(relative_path : str, *parts : str) -> str:

--- a/PySubtrans/Helpers/Resources.py
+++ b/PySubtrans/Helpers/Resources.py
@@ -1,10 +1,57 @@
 
+from collections.abc import Sequence
 import os
 import sys
 import appdirs # type: ignore
 
-old_config_dir : str = appdirs.user_config_dir("GPTSubtrans", "MachineWrapped", roaming=True)
-config_dir : str = appdirs.user_config_dir("LLMSubtrans", "MachineWrapped", roaming=True)
+default_config_dir : str = appdirs.user_config_dir("LLMSubtrans", "MachineWrapped", roaming=True)
+config_dir : str = default_config_dir
+
+
+def GetConfigDir() -> str:
+    """Return the active application configuration directory."""
+    return config_dir
+
+
+def GetSettingsPath() -> str:
+    """Return the path to the active application settings file."""
+    return os.path.join(config_dir, "settings.json")
+
+
+def _get_portable_config_dir() -> str:
+    """Return the configuration directory used by portable installations."""
+    return os.path.abspath(os.path.join(os.getcwd(), ".settings"))
+
+
+def ConfigureConfigDir(config_path : str|None = None, portable : bool = False) -> str:
+    """Configure the application directory used for persistent settings and logs."""
+    global config_dir
+
+    if config_path:
+        config_dir = os.path.abspath(os.path.expanduser(config_path))
+    elif portable or os.path.isdir(_get_portable_config_dir()):
+        config_dir = _get_portable_config_dir()
+    else:
+        config_dir = default_config_dir
+
+    return config_dir
+
+
+def ConfigureConfigDirFromArguments(arguments : Sequence[str]|None = None) -> str:
+    """Configure the application directory from early command-line arguments."""
+    arguments = list(arguments if arguments is not None else sys.argv[1:])
+    config_path : str|None = None
+    portable = False
+
+    for index, argument in enumerate(arguments):
+        if argument == "--portable":
+            portable = True
+        elif argument == "--configpath" and index + 1 < len(arguments):
+            config_path = arguments[index + 1]
+        elif argument.startswith("--configpath="):
+            config_path = argument.split("=", 1)[1]
+
+    return ConfigureConfigDir(config_path=config_path, portable=portable)
 
 def GetResourcePath(relative_path : str, *parts : str) -> str:
     """

--- a/PySubtrans/Helpers/Resources.py
+++ b/PySubtrans/Helpers/Resources.py
@@ -52,7 +52,7 @@ def ConfigureConfigDirFromArguments(arguments : Sequence[str]|None = None) -> st
             config_path = argument.split("=", 1)[1]
 
     if config_path is None and not portable:
-        config_path = os.getenv("LLM_SUBTRANS_CONFIG_DIR") or None
+        config_path = os.getenv("LLM_SUBTRANS_CONFIG_PATH") or None
 
     return ConfigureConfigDir(config_path=config_path, portable=portable)
 

--- a/PySubtrans/Options.py
+++ b/PySubtrans/Options.py
@@ -10,15 +10,13 @@ import dotenv
 from PySubtrans.Helpers.Version import VersionNumberLessThan
 from PySubtrans.Instructions import Instructions, default_user_prompt
 from PySubtrans.Helpers.Localization import _
-from PySubtrans.Helpers.Resources import config_dir, old_config_dir
+from PySubtrans.Helpers.Resources import GetConfigDir, GetSettingsPath
 from PySubtrans.Helpers.Text import standard_filler_words
 from PySubtrans.ProviderSettingsView import ProviderSettingsView
 from PySubtrans.SettingsType import SettingType, SettingsType
 from PySubtrans.version import __version__
 
 MULTILINE_OPTION = 'multiline'
-
-settings_path = os.path.join(config_dir, 'settings.json')
 
 # Load environment variables from .env file
 dotenv.load_dotenv()
@@ -207,6 +205,7 @@ class Options(SettingsType):
         """
         Load the settings from a JSON file
         """
+        settings_path = GetSettingsPath()
         if not os.path.exists(settings_path):
             return False
 
@@ -238,6 +237,8 @@ class Options(SettingsType):
         """
         Save the settings to a JSON file
         """
+        config_dir = GetConfigDir()
+        settings_path = GetSettingsPath()
         try:
             settings : SettingsType = self.GetSettings()
 
@@ -261,40 +262,6 @@ class Options(SettingsType):
             logging.error(_("Error saving settings to {}").format(settings_path))
             return False
         
-    def MigrateSettings(self) -> bool:
-        """
-        Migrate settings from the old config directory to the new one
-        """
-        if os.path.exists(settings_path):
-            return False
-        
-        old_settings_path = os.path.join(old_config_dir, 'settings.json')
-        if not os.path.exists(old_settings_path):
-            return False
-
-        try:
-            if not os.path.exists(config_dir):
-                # Rename the old config directory to the new one
-                os.rename(old_config_dir, config_dir)
-                logging.info("Settings migrated to new location")
-            else:
-                os.rename(old_settings_path, settings_path)
-                logging.info("Settings file migrated to new location")
-
-                old_custom_instructions_path = os.path.join(old_config_dir, 'instructions')
-                if os.path.exists(old_custom_instructions_path):
-                    new_custom_instructions_path = os.path.join(config_dir, 'instructions')
-                    if not os.path.exists(new_custom_instructions_path):
-                        os.rename(old_custom_instructions_path, new_custom_instructions_path)
-                        logging.info("Custom instructions migrated to new location")                
-                
-            return True
-
-        except Exception as e:
-            logging.debug(f"Error migrating settings from {old_config_dir} to {config_dir}: {e}")
-            logging.error(_("Error migrating settings from {} to {}. You can copy the files manually and restart the application.").format(old_config_dir, config_dir))
-            return False
-
     def BuildUserPrompt(self) -> str:
         """
         Generate the user prompt to use for requesting translations

--- a/PySubtrans/VersionCheck.py
+++ b/PySubtrans/VersionCheck.py
@@ -4,14 +4,17 @@ import logging
 import requests
 
 from PySubtrans.version import __version__
-from PySubtrans.Helpers.Resources import config_dir
+from PySubtrans.Helpers.Resources import GetConfigDir
 
 repo_name = "llm-subtrans"
 repo_owner = "machinewrapped"
 
-last_check_file = os.path.join(config_dir, 'last_check.txt')
+def _get_last_check_file() -> str:
+    """Return the path to the update check marker for the active config directory."""
+    return os.path.join(GetConfigDir(), 'last_check.txt')
 
 def CheckIfUpdateAvailable():
+    last_check_file = _get_last_check_file()
     try:
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases/latest"
         response = requests.get(url)
@@ -37,6 +40,7 @@ def CheckIfUpdateAvailable():
     return False
 
 def CheckIfUpdateCheckIsRequired():
+    last_check_file = _get_last_check_file()
     if not os.path.exists(last_check_file):
         return True
 

--- a/install.bat
+++ b/install.bat
@@ -23,6 +23,20 @@ if /i "%~1"=="--portable" (
     exit /b 1
 )
 
+if defined PORTABLE_INSTALL (
+    echo.
+    echo ========================================
+    echo Portable configuration mode enabled
+    echo Settings and logs will be stored in .settings
+    echo ========================================
+) else if defined CONFIG_PATH (
+    echo.
+    echo ========================================
+    echo Custom configuration mode enabled
+    echo Settings and logs will be stored in "!CONFIG_PATH!"
+    echo ========================================
+)
+
 REM Check if we're in the correct directory
 if not exist "scripts" (
     echo Please run this script from the root directory of the project.

--- a/install.bat
+++ b/install.bat
@@ -1,6 +1,28 @@
 @echo off
 setlocal enabledelayedexpansion
 
+set "PORTABLE_INSTALL="
+set "CONFIG_DIR="
+if /i "%~1"=="--portable" (
+    set "PORTABLE_INSTALL=1"
+) else if /i "%~1"=="--configdir" (
+    if "%~2"=="" (
+        echo Usage: install.bat [--portable ^| --configdir PATH]
+        pause
+        exit /b 1
+    )
+    if not "%~3"=="" (
+        echo Usage: install.bat [--portable ^| --configdir PATH]
+        pause
+        exit /b 1
+    )
+    set "CONFIG_DIR=%~2"
+) else if not "%~1"=="" (
+    echo Usage: install.bat [--portable ^| --configdir PATH]
+    pause
+    exit /b 1
+)
+
 REM Check if we're in the correct directory
 if not exist "scripts" (
     echo Please run this script from the root directory of the project.
@@ -68,6 +90,26 @@ if "%install_choice%"=="2" (
     echo Including GUI modules...
     if "!EXTRAS!"=="" (set "EXTRAS=gui") else (set "EXTRAS=!EXTRAS!,gui")
     set "SCRIPTS=!SCRIPTS! gui-subtrans"
+)
+
+echo.
+if defined CONFIG_DIR (
+    if not exist "!CONFIG_DIR!" mkdir "!CONFIG_DIR!"
+) else if defined PORTABLE_INSTALL (
+    if not exist .settings mkdir .settings
+)
+
+if defined PORTABLE_INSTALL if exist .env (
+    (findstr /v /b /c:"LLM_SUBTRANS_CONFIG_DIR=" .env) > .env.tmp
+    move .env.tmp .env >nul 2>&1
+)
+
+if defined CONFIG_DIR (
+    if exist .env (
+        (findstr /v /b /c:"LLM_SUBTRANS_CONFIG_DIR=" .env) > .env.tmp
+        move .env.tmp .env >nul 2>&1
+    )
+    echo LLM_SUBTRANS_CONFIG_DIR=!CONFIG_DIR!>> .env
 )
 
 REM Optional: configure OpenRouter API key

--- a/install.bat
+++ b/install.bat
@@ -2,23 +2,23 @@
 setlocal enabledelayedexpansion
 
 set "PORTABLE_INSTALL="
-set "CONFIG_DIR="
+set "CONFIG_PATH="
 if /i "%~1"=="--portable" (
     set "PORTABLE_INSTALL=1"
-) else if /i "%~1"=="--configdir" (
+) else if /i "%~1"=="--configpath" (
     if "%~2"=="" (
-        echo Usage: install.bat [--portable ^| --configdir PATH]
+        echo Usage: install.bat [--portable ^| --configpath PATH]
         pause
         exit /b 1
     )
     if not "%~3"=="" (
-        echo Usage: install.bat [--portable ^| --configdir PATH]
+        echo Usage: install.bat [--portable ^| --configpath PATH]
         pause
         exit /b 1
     )
-    set "CONFIG_DIR=%~2"
+    set "CONFIG_PATH=%~2"
 ) else if not "%~1"=="" (
-    echo Usage: install.bat [--portable ^| --configdir PATH]
+    echo Usage: install.bat [--portable ^| --configpath PATH]
     pause
     exit /b 1
 )
@@ -93,23 +93,23 @@ if "%install_choice%"=="2" (
 )
 
 echo.
-if defined CONFIG_DIR (
-    if not exist "!CONFIG_DIR!" mkdir "!CONFIG_DIR!"
+if defined CONFIG_PATH (
+    if not exist "!CONFIG_PATH!" mkdir "!CONFIG_PATH!"
 ) else if defined PORTABLE_INSTALL (
     if not exist .settings mkdir .settings
 )
 
 if defined PORTABLE_INSTALL if exist .env (
-    (findstr /v /b /c:"LLM_SUBTRANS_CONFIG_DIR=" .env) > .env.tmp
+    (findstr /v /b /c:"LLM_SUBTRANS_CONFIG_PATH=" .env) > .env.tmp
     move .env.tmp .env >nul 2>&1
 )
 
-if defined CONFIG_DIR (
+if defined CONFIG_PATH (
     if exist .env (
-        (findstr /v /b /c:"LLM_SUBTRANS_CONFIG_DIR=" .env) > .env.tmp
+        (findstr /v /b /c:"LLM_SUBTRANS_CONFIG_PATH=" .env) > .env.tmp
         move .env.tmp .env >nul 2>&1
     )
-    echo LLM_SUBTRANS_CONFIG_DIR=!CONFIG_DIR!>> .env
+    echo LLM_SUBTRANS_CONFIG_PATH=!CONFIG_PATH!>> .env
 )
 
 REM Optional: configure OpenRouter API key

--- a/install.sh
+++ b/install.sh
@@ -3,19 +3,19 @@
 set -e
 
 portable_install=false
-config_dir=""
+config_path=""
 if [ "$#" -gt 0 ]; then
     case "$1" in
         --portable)
-            [ "$#" -eq 1 ] || { echo "Usage: ./install.sh [--portable | --configdir PATH]"; exit 1; }
+            [ "$#" -eq 1 ] || { echo "Usage: ./install.sh [--portable | --configpath PATH]"; exit 1; }
             portable_install=true
             ;;
-        --configdir)
-            [ "$#" -eq 2 ] || { echo "Usage: ./install.sh [--portable | --configdir PATH]"; exit 1; }
-            config_dir=$2
+        --configpath)
+            [ "$#" -eq 2 ] || { echo "Usage: ./install.sh [--portable | --configpath PATH]"; exit 1; }
+            config_path=$2
             ;;
         *)
-            echo "Usage: ./install.sh [--portable | --configdir PATH]"
+            echo "Usage: ./install.sh [--portable | --configpath PATH]"
             exit 1
             ;;
     esac
@@ -138,23 +138,23 @@ else
     scripts_to_generate+=("gui-subtrans")
 fi
 
-if [ -n "$config_dir" ]; then
-    mkdir -p "$config_dir"
+if [ -n "$config_path" ]; then
+    mkdir -p "$config_path"
 elif [ "$portable_install" = true ]; then
     mkdir -p .settings
 fi
 
 if [ "$portable_install" = true ] && [ -f ".env" ]; then
-    sed -i.bak '/^LLM_SUBTRANS_CONFIG_DIR=/d' .env
+    sed -i.bak '/^LLM_SUBTRANS_CONFIG_PATH=/d' .env
     rm -f .env.bak
 fi
 
-if [ -n "$config_dir" ]; then
+if [ -n "$config_path" ]; then
     if [ -f ".env" ]; then
-        sed -i.bak '/^LLM_SUBTRANS_CONFIG_DIR=/d' .env
+        sed -i.bak '/^LLM_SUBTRANS_CONFIG_PATH=/d' .env
         rm -f .env.bak
     fi
-    printf 'LLM_SUBTRANS_CONFIG_DIR=%s\n' "$config_dir" >> .env
+    printf 'LLM_SUBTRANS_CONFIG_PATH=%s\n' "$config_path" >> .env
 fi
 
 # Optional: configure OpenRouter API key

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,20 @@ if [ "$#" -gt 0 ]; then
     esac
 fi
 
+if [ "$portable_install" = true ]; then
+    echo
+    echo "========================================"
+    echo "Portable configuration mode enabled"
+    echo "Settings and logs will be stored in .settings"
+    echo "========================================"
+elif [ -n "$config_path" ]; then
+    echo
+    echo "========================================"
+    echo "Custom configuration mode enabled"
+    echo "Settings and logs will be stored in: $config_path"
+    echo "========================================"
+fi
+
 function install_provider() {
     local provider=$1
     local api_key_var_name=$2

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,25 @@
 # Enable error handling
 set -e
 
+portable_install=false
+config_dir=""
+if [ "$#" -gt 0 ]; then
+    case "$1" in
+        --portable)
+            [ "$#" -eq 1 ] || { echo "Usage: ./install.sh [--portable | --configdir PATH]"; exit 1; }
+            portable_install=true
+            ;;
+        --configdir)
+            [ "$#" -eq 2 ] || { echo "Usage: ./install.sh [--portable | --configdir PATH]"; exit 1; }
+            config_dir=$2
+            ;;
+        *)
+            echo "Usage: ./install.sh [--portable | --configdir PATH]"
+            exit 1
+            ;;
+    esac
+fi
+
 function install_provider() {
     local provider=$1
     local api_key_var_name=$2
@@ -117,6 +136,25 @@ else
     echo "Including GUI modules..."
     extras+=("gui")
     scripts_to_generate+=("gui-subtrans")
+fi
+
+if [ -n "$config_dir" ]; then
+    mkdir -p "$config_dir"
+elif [ "$portable_install" = true ]; then
+    mkdir -p .settings
+fi
+
+if [ "$portable_install" = true ] && [ -f ".env" ]; then
+    sed -i.bak '/^LLM_SUBTRANS_CONFIG_DIR=/d' .env
+    rm -f .env.bak
+fi
+
+if [ -n "$config_dir" ]; then
+    if [ -f ".env" ]; then
+        sed -i.bak '/^LLM_SUBTRANS_CONFIG_DIR=/d' .env
+        rm -f .env.bak
+    fi
+    printf 'LLM_SUBTRANS_CONFIG_DIR=%s\n' "$config_dir" >> .env
 fi
 
 # Optional: configure OpenRouter API key

--- a/readme.md
+++ b/readme.md
@@ -235,6 +235,10 @@ llm-subtrans --project --auto -l <language> <path_to_subtrans_file>
 llm-subtrans --project --auto -l <language> <path_to_subtitle_file>  # Project file will be detected automatically if it is in the same folder
 ```
 
+## Configuration directory
+
+The GUI and command-line tools use the platform's standard application-data directory for settings and logs. Use `--portable` to store them in a `.settings` folder in the current directory, or `--configpath <directory>` to set a specific location. An existing `.settings` directory will automatically activate portable mode.
+
 ## Format Conversion
 LLM-Subtrans is primarily a translation application, and format conversion is probably best handled by dedicated tools, but the option exists to read one format and write another.
 

--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ The easiest setup method is to run the unified installation script:
 
 These scripts will create a virtual environment and offer **install with GUI** or **install command line only** options, with additional options to add support for specific providers. The script will guide you through the setup and generate command scripts to launch the application.
 
-Pass `--portable` to `install.bat` or `install.sh` to create the local `.settings` directory without prompting. Use `--configdir <directory>` to configure a different settings and log directory; the installer saves that path in `.env`.
+Pass `--portable` to `install.bat` or `install.sh` to create the local `.settings` directory without prompting. Use `--configpath <directory>` to configure a different settings and log directory; the installer saves that path in `.env`.
 
 During the installing process, you can choose to input an API key for each selected provider when prompted, which will be saved in a .env file so that you don't need to provide it every time you run the program. This is largely redundant if you only plan to use the GUI, as keys can be saved in the app settings.
 

--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,8 @@ The easiest setup method is to run the unified installation script:
 
 These scripts will create a virtual environment and offer **install with GUI** or **install command line only** options, with additional options to add support for specific providers. The script will guide you through the setup and generate command scripts to launch the application.
 
+Pass `--portable` to `install.bat` or `install.sh` to create the local `.settings` directory without prompting. Use `--configdir <directory>` to configure a different settings and log directory; the installer saves that path in `.env`.
+
 During the installing process, you can choose to input an API key for each selected provider when prompted, which will be saved in a .env file so that you don't need to provide it every time you run the program. This is largely redundant if you only plan to use the GUI, as keys can be saved in the app settings.
 
 ### Manual configuration

--- a/scripts/gui-subtrans.py
+++ b/scripts/gui-subtrans.py
@@ -22,12 +22,14 @@ from PySide6.QtWidgets import QApplication
 if sys.platform == 'win32':
     signal.signal(signal.SIGINT, _prev_sigint)
     del _prev_sigint
-from PySubtrans.Options import Options, settings_path, config_dir
+from PySubtrans.Helpers.Resources import ConfigureConfigDirFromArguments, GetConfigDir, GetSettingsPath
+from PySubtrans.Options import Options
 from PySubtrans.Helpers.Localization import initialize_localization, _
 from GuiSubtrans.MainWindow import MainWindow
 
 def parse_arguments():
     # Parse command line arguments
+    ConfigureConfigDirFromArguments()
     parser = argparse.ArgumentParser(description='Translates subtitles using an AI service')
     parser.add_argument('filepath', nargs='?', help="Optional file to load on startup")
     parser.add_argument('-l', '--target-language', type=str, default=None, help="The target language for the translation")
@@ -47,6 +49,8 @@ def parse_arguments():
     parser.add_argument('--ratelimit', type=int, default=None, help="Maximum number of batches per minute to process")
     parser.add_argument('--scenethreshold', type=float, default=None, help="Number of seconds between lines to consider a new scene")
     parser.add_argument('--theme', type=str, default=None, help="Stylesheet to load")
+    parser.add_argument('--portable', action='store_true', help="Store settings and logs in the .settings directory in the current directory")
+    parser.add_argument('--configpath', type=str, default=None, help="Store settings and logs in the specified directory")
 
     try:
         args = parser.parse_args()
@@ -84,7 +88,7 @@ def run_with_profiler(app):
 
     profiler.disable()
 
-    profile_path = os.path.join(config_dir, 'profile_guisubtrans.txt')
+    profile_path = os.path.join(GetConfigDir(), 'profile_guisubtrans.txt')
     with open(profile_path, 'w') as stream:
         stats = Stats(profiler, stream=stream)
         stats.sort_stats('tottime')
@@ -105,9 +109,8 @@ if __name__ == "__main__":
     options = Options()
 
     if not arguments.get('firstrun'):
-        options.MigrateSettings()
         if options.LoadSettings():
-            logging.info(f"Loaded settings from {settings_path}")
+            logging.info(f"Loaded settings from {GetSettingsPath()}")
 
     options.update(arguments)
 

--- a/scripts/subtrans_common.py
+++ b/scripts/subtrans_common.py
@@ -10,7 +10,8 @@ from PySubtrans.Helpers import GetOutputPath
 from PySubtrans.Helpers.Localization import _
 from PySubtrans.Helpers.Parse import FormatKeyValuePairs, ParseKeyValuePairsOrFiles, ParseNames
 from PySubtrans import batch_subtitles, init_options, init_translator, preprocess_subtitles
-from PySubtrans.Options import Options, config_dir
+from PySubtrans.Helpers.Resources import ConfigureConfigDirFromArguments, GetConfigDir
+from PySubtrans.Options import Options
 from PySubtrans.SubtitleTranslator import SubtitleTranslator
 from PySubtrans.Substitutions import Substitutions
 from PySubtrans.SubtitleFormatRegistry import SubtitleFormatRegistry
@@ -101,6 +102,7 @@ class TranslationProgressLogger():
 
 def InitLogger(logfilename: str, debug: bool = False) -> LoggerOptions:
     """ Initialise the logger with a file handler and return the path to the log file """
+    config_dir = GetConfigDir()
     log_path = os.path.join(config_dir, f"{logfilename}.log")
     file_handler = None
 
@@ -165,6 +167,7 @@ def CreateArgParser(description : str) -> ArgumentParser:
     """
     Create new arg parser and parse shared command line arguments between models
     """
+    ConfigureConfigDirFromArguments()
     _warn_renamed_args()
     pre_parser = ArgumentParser(add_help=False)
     pre_parser.add_argument('--list-formats', action='store_true')
@@ -212,6 +215,8 @@ def CreateArgParser(description : str) -> ArgumentParser:
     parser.add_argument('--terminology', action='append', type=str, default=None, help="Seed entry for the terminology map as SOURCE::TRANSLATION, or a path to a file of such pairs.")
     parser.add_argument('--terminology-file', dest='terminology_file', type=str, default=None, help="Path to a key::value file to seed from and save the terminology map to after translation")
     parser.add_argument('--writebackup', action='store_true', help="Write a backup of the project file when it is loaded (if it exists)")
+    parser.add_argument('--portable', action='store_true', help="Store settings and logs in the .settings directory in the current directory")
+    parser.add_argument('--configpath', type=str, default=None, help="Store settings and logs in the specified directory")
     return parser
 
 def HandleFormatListing(args: Namespace) -> None:

--- a/tests/PySubtransTests/test_Resources.py
+++ b/tests/PySubtransTests/test_Resources.py
@@ -1,0 +1,65 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from PySubtrans.Helpers.Resources import (
+    ConfigureConfigDir,
+    ConfigureConfigDirFromArguments,
+    default_config_dir,
+)
+from PySubtrans.Helpers.TestCases import LoggedTestCase
+
+
+class TestResources(LoggedTestCase):
+    """Test application resource path selection."""
+
+    def tearDown(self) -> None:
+        """Restore the normal configuration directory after each test."""
+        ConfigureConfigDir(config_path=default_config_dir)
+        super().tearDown()
+
+    @patch('PySubtrans.Helpers.Resources.os.path.isdir', return_value=False)
+    @patch('PySubtrans.Helpers.Resources.os.getcwd', return_value=os.path.abspath('portable-app'))
+    def test_portable_mode_uses_local_settings_directory(self, mock_getcwd, mock_isdir):
+        """Portable mode stores settings below the current directory."""
+        expected_path = os.path.abspath(os.path.join(os.path.abspath('portable-app'), '.settings'))
+
+        result = ConfigureConfigDirFromArguments(['--portable'])
+
+        self.assertLoggedEqual('portable configuration directory', expected_path, result)
+        mock_getcwd.assert_called()
+        mock_isdir.assert_not_called()
+
+    @patch('PySubtrans.Helpers.Resources.os.path.isdir', return_value=True)
+    @patch('PySubtrans.Helpers.Resources.os.getcwd', return_value=os.path.abspath('portable-app'))
+    def test_existing_settings_directory_enables_portable_mode(self, mock_getcwd, mock_isdir):
+        """An existing .settings directory enables portable mode automatically."""
+        expected_path = os.path.abspath(os.path.join(os.path.abspath('portable-app'), '.settings'))
+
+        result = ConfigureConfigDirFromArguments([])
+
+        self.assertLoggedEqual('automatic portable configuration directory', expected_path, result)
+        mock_getcwd.assert_called()
+        mock_isdir.assert_called()
+
+    @patch('PySubtrans.Helpers.Resources.os.path.isdir', return_value=True)
+    def test_configpath_overrides_portable_mode(self, mock_isdir):
+        """An explicit config path takes precedence over portable mode detection."""
+        config_path = os.path.abspath(os.path.join('custom', 'settings'))
+
+        result = ConfigureConfigDirFromArguments(['--portable', '--configpath', config_path])
+
+        self.assertLoggedEqual('explicit configuration directory', config_path, result)
+        mock_isdir.assert_not_called()
+
+    def test_configpath_equals_syntax_is_supported(self):
+        """The equals form of --configpath is accepted before full argument parsing."""
+        config_path = os.path.abspath(os.path.join('custom', 'settings'))
+
+        result = ConfigureConfigDirFromArguments([f'--configpath={config_path}'])
+
+        self.assertLoggedEqual('equals-form configuration directory', config_path, result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/PySubtransTests/test_Resources.py
+++ b/tests/PySubtransTests/test_Resources.py
@@ -60,7 +60,7 @@ class TestResources(LoggedTestCase):
 
         self.assertLoggedEqual('equals-form configuration directory', config_path, result)
 
-    @patch.dict('os.environ', {'LLM_SUBTRANS_CONFIG_DIR': os.path.abspath(os.path.join('environment', 'settings'))})
+    @patch.dict('os.environ', {'LLM_SUBTRANS_CONFIG_PATH': os.path.abspath(os.path.join('environment', 'settings'))})
     @patch('PySubtrans.Helpers.Resources.os.path.isdir', return_value=False)
     def test_environment_config_dir_is_used_when_no_argument_is_set(self, mock_isdir):
         """Use the installer-provided environment path when no CLI override is present."""

--- a/tests/PySubtransTests/test_Resources.py
+++ b/tests/PySubtransTests/test_Resources.py
@@ -60,6 +60,17 @@ class TestResources(LoggedTestCase):
 
         self.assertLoggedEqual('equals-form configuration directory', config_path, result)
 
+    @patch.dict('os.environ', {'LLM_SUBTRANS_CONFIG_DIR': os.path.abspath(os.path.join('environment', 'settings'))})
+    @patch('PySubtrans.Helpers.Resources.os.path.isdir', return_value=False)
+    def test_environment_config_dir_is_used_when_no_argument_is_set(self, mock_isdir):
+        """Use the installer-provided environment path when no CLI override is present."""
+        expected_path = os.path.abspath(os.path.join('environment', 'settings'))
+
+        result = ConfigureConfigDirFromArguments([])
+
+        self.assertLoggedEqual('environment configuration directory', expected_path, result)
+        mock_isdir.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Adds portable and custom configuration-directory support to the GUI and provider-specific CLI tools, plus installer support.

## What changed

- Add `--portable` and `--configpath` command-line options, with automatic detection of a local `.settings` directory.
- Centralize CLI configuration initialization in the shared argument parser and GUI argument parsing, keeping the resources helper free of import-time argument handling.
- Resolve settings, logs, custom instructions, update-check markers, and profiling paths dynamically from the active configuration directory.
- Remove the obsolete GPT-Subtrans to LLM-Subtrans settings migration.
- Add `--portable` and `--configpath PATH` support to `install.bat` and `install.sh`.
- Make installer-selected custom paths persistent through `LLM_SUBTRANS_CONFIG_PATH` in `.env`; portable installs create `.settings` and clear any saved custom-path override.
- Preserve `.settings` during clean installs, and add prominent installer mode banners plus invalid-argument handling.
- Update the README with concise GUI guidance and a separate configuration-directory section.
- Add resource/configuration-path tests, including option precedence and environment-variable behavior.
- Keep `batch-translate.py` out of persistent config/log initialization because it uses in-memory options and its own `--log-file` handling.

## Why

Users can keep settings and logs alongside a portable installation or select a separate configuration directory without relying on the platform default. Installer choices persist across launches while the default install remains unchanged.

## Validation

- `python tests/unit_tests.py`: 369 tests passed, 3 skipped.
- Pyright: 199 files analyzed, 0 errors.
- `git diff --check`.
- Safe Windows installer invalid-argument handling was checked in a fresh worktree; a full install was not run because it would create an environment, modify `.env`, and download dependencies.