### PR TITLE
Extend short subtitles on save and preserve subtitle start times

### DIFF
--- a/GuiSubtrans/ProjectDataModel.py
+++ b/GuiSubtrans/ProjectDataModel.py
@@ -10,6 +10,7 @@ from GuiSubtrans.ViewModel.ViewModelUpdate import ModelUpdate
 from PySubtrans.Options import Options, SettingsType
 from PySubtrans.SettingsType import SettingType, SettingsType
 from PySubtrans.SubtitleProject import SubtitleProject
+from PySubtrans.Subtitles import SaveSettings
 from PySubtrans.TranslationProvider import TranslationProvider
 from PySubtrans.Helpers.Localization import _
 
@@ -24,6 +25,7 @@ class ProjectDataModel:
         if project:
             project_settings = project.GetProjectSettings()
             self.project_options.update(project_settings)
+            self._update_save_settings()
 
         self.provider_cache = {}
         self.translation_provider : TranslationProvider|None = None
@@ -99,6 +101,7 @@ class ProjectDataModel:
             # Restore project-specific settings
             project_settings = self.project.GetProjectSettings()
             self.project_options.update(project_settings)
+            self._update_save_settings()
 
         self._update_translation_provider()
 
@@ -109,6 +112,7 @@ class ProjectDataModel:
         if self.project:
             settings = SettingsType(settings)
             self.project_options.update(settings)
+            self._update_save_settings()
             self._update_translation_provider()
 
             self.project.UpdateProjectSettings(settings)
@@ -185,4 +189,7 @@ class ProjectDataModel:
 
         self.CreateTranslationProvider()
 
-
+    def _update_save_settings(self) -> None:
+        """Update settings applied only while writing translated subtitles."""
+        if self.project:
+            self.project.save_settings = SaveSettings(self.project_options)

--- a/GuiSubtrans/SettingsDialog.py
+++ b/GuiSubtrans/SettingsDialog.py
@@ -50,9 +50,13 @@ class SettingsDialog(QDialog):
         'Processing': {
             'preprocess_subtitles': (bool, _("Preprocess subtitles when they are loaded")),
             'postprocess_translation': (bool, _("Postprocess subtitles after translation")),
+            'extend_short_subtitles': (bool, _("Extend short subtitles to a minimum reading duration when saving")),
+            'prevent_overlapping_times': (bool, _("Prevent overlapping subtitle display times")),
             'save_preprocessed_subtitles': (bool, _("Save preprocessed subtitles to a separate file")),
             'max_line_duration': (float, _("Maximum duration of a single line of subtitles")),
             'min_line_duration': (float, _("Minimum duration of a single line of subtitles")),
+            'seconds_per_character': (float, _("Minimum reading time per visible character in seconds")),
+            'min_gap': (float, _("Minimum gap between consecutive subtitles, in seconds, used when preprocess_subtitles, extend_short_subtitles, or prevent_overlapping_times is enabled")),
             'merge_line_duration': (float, _("Merge lines with a duration less than this with the previous line")),
             'min_split_chars': (int, _("Minimum number of characters to split a line at")),
             'break_dialog_on_one_line': (bool, _("Add line breaks to text with dialog markers")),
@@ -90,6 +94,8 @@ class SettingsDialog(QDialog):
 
     _preprocessor_setting = { 'preprocess_subtitles': True }
     _postprocessor_setting = { 'postprocess_translation': True }
+    _duration_setting = { 'extend_short_subtitles': True }
+    _overlap_setting = { 'prevent_overlapping_times': True }
     _prepostprocessor_setting = [ _preprocessor_setting, _postprocessor_setting ]
 
     VISIBILITY_DEPENDENCIES = {
@@ -100,7 +106,9 @@ class SettingsDialog(QDialog):
         # ],
         'save_preprocessed_subtitles': _preprocessor_setting,
         'max_line_duration': _preprocessor_setting,
-        'min_line_duration': _preprocessor_setting,
+        'min_line_duration': [ _preprocessor_setting, _duration_setting ],
+        'seconds_per_character': _duration_setting,
+        'min_gap': [ _preprocessor_setting, _duration_setting, _overlap_setting ],
         'min_split_chars': _preprocessor_setting,
         'whitespaces_to_newline': _preprocessor_setting,
         'break_dialog_on_one_line': _prepostprocessor_setting,
@@ -466,5 +474,4 @@ class SettingsDialog(QDialog):
 
             except Exception as e:
                 logging.error(f"Unable to load instructions from {instruction_file}: {e}")
-
 

--- a/PySubtrans/Options.py
+++ b/PySubtrans/Options.py
@@ -63,6 +63,7 @@ default_settings = {
     'max_single_line_length': env_int('MAX_SINGLE_LINE_LENGTH', 44),
     'min_single_line_length': env_int('MIN_SINGLE_LINE_LENGTH', 8),
     'prevent_overlapping_times': env_bool('PREVENT_OVERLAPPING_TIMES', False),
+    'extend_short_subtitles': env_bool('EXTEND_SHORT_SUBTITLES', False),
     'postprocess_translation': env_bool('POSTPROCESS_TRANSLATION', False),
     'preprocess_subtitles': env_bool('PREPROCESS_SUBTITLES', False),
     'save_preprocessed_subtitles': env_bool('SAVE_PREPROCESSED_SUBTITLES', False),
@@ -70,6 +71,8 @@ default_settings = {
     'break_dialog_on_one_line': env_bool('break_dialog_on_one_line', True),
     'max_line_duration': env_float('MAX_LINE_DURATION', 4.0),
     'min_line_duration': env_float('MIN_LINE_DURATION', 0.8),
+    'seconds_per_character': env_float('SECONDS_PER_CHARACTER', 0.1),
+    'min_gap': env_float('MIN_GAP', 0.05),
     'merge_line_duration': env_float('MERGE_LINE_DURATION', 0.0),
     'min_split_chars': env_int('MIN_SPLIT_CHARS', 3),
     'normalise_dialog_tags': env_bool('NORMALISE_DIALOG_TAGS', True),
@@ -335,5 +338,4 @@ class Options(SettingsType):
         latest_version  : str = str(default_settings['version'])
 
         self['version'] = latest_version
-
 

--- a/PySubtrans/README.md
+++ b/PySubtrans/README.md
@@ -201,6 +201,8 @@ The Options class provides a wide range of options to configure the translation 
 
 `postprocess_translation`: Runs a pass on the translated subtitles to try to resolve some common problems introduced by translation, e.g. breaking long lines with newlines. The post-processor can perform a range of operations, each of which is enabled by another setting, e.g. `break_dialog_on_one_line`, `normalise_dialog_tags`, `whitespaces_to_newline`, `remove_filler_words`.
 
+`extend_short_subtitles`: Extends short subtitles when the translated file is saved, without changing the timestamps stored in the project. The target display time is the greater of `min_line_duration` and the visible character count multiplied by `seconds_per_character`. Extensions are capped at the next subtitle's start time minus `min_gap`.
+
 Example usage:
 
 ```python
@@ -351,7 +353,8 @@ The parameters are:
 `scene_threshold`: A new scene will be introduced after a gap of N seconds.
 `max_batch_size`: If a scene contains too more lines than this it will be subdivided into batches until each batch is no larger than this.
 `min_batch_size`: More of a suggestion than a rule, batches are primarily divided to maximise temporal cohesion of each batch.
-`prevent_overlap`: If the end time of a subtitle overlaps the start time of the next subtitle it will be reduced to ensure that there is no overlap.
+`prevent_overlap`: If the end time of a subtitle overlaps the start time of the next subtitle it will be reduced to preserve `min_gap` where possible.
+`min_gap`: Minimum gap in seconds to preserve when preventing overlaps.
 
 ```python
 from PySubtrans import batch_subtitles, init_subtitles

--- a/PySubtrans/README.md
+++ b/PySubtrans/README.md
@@ -26,7 +26,7 @@ pip install pysubtrans[openai,gemini,claude,mistral,bedrock]
 The quickest way to get started is to use the helper functions exposed at the package root. They wrap the classes used by LLM-Subtrans so that you can execute a full translation pipeline with a few lines of code.
 
 ```python
-from PySubtrans import init_options, init_subtitles, init_translator
+from PySubtrans import SaveSettings, init_options, init_subtitles, init_translator
 
 options = init_options(
     provider="Gemini",
@@ -40,7 +40,7 @@ subtitles = init_subtitles("movie.srt", options=options)
 translator = init_translator(options)
 translator.TranslateSubtitles(subtitles)
 
-subtitles.SaveTranslation("movie-translated.srt")
+subtitles.SaveTranslation("movie-translated.srt", save_settings=SaveSettings(options))
 ```
 
 Subtitle format is auto-detected based on file extension or content.
@@ -201,7 +201,7 @@ The Options class provides a wide range of options to configure the translation 
 
 `postprocess_translation`: Runs a pass on the translated subtitles to try to resolve some common problems introduced by translation, e.g. breaking long lines with newlines. The post-processor can perform a range of operations, each of which is enabled by another setting, e.g. `break_dialog_on_one_line`, `normalise_dialog_tags`, `whitespaces_to_newline`, `remove_filler_words`.
 
-`extend_short_subtitles`: Extends short subtitles when the translated file is saved, without changing the timestamps stored in the project. The target display time is the greater of `min_line_duration` and the visible character count multiplied by `seconds_per_character`. Extensions are capped at the next subtitle's start time minus `min_gap`.
+`extend_short_subtitles`: Extends short subtitles when the translated file is saved, without changing the timestamps stored in the project. The target display time is the greater of `min_line_duration` and the visible character count multiplied by `seconds_per_character`. Extensions are capped at the next subtitle's start time minus `min_gap`. Pass `SaveSettings(options)` when saving translations directly with a `Subtitles` instance.
 
 Example usage:
 

--- a/PySubtrans/SubtitleBatcher.py
+++ b/PySubtrans/SubtitleBatcher.py
@@ -10,6 +10,7 @@ class SubtitleBatcher:
         self.min_batch_size : int = settings.get_int('min_batch_size') or 1
         self.max_batch_size : int = settings.get_int('max_batch_size') or 100
         self.fix_overlaps : bool = settings.get_bool('prevent_overlapping_times', False)
+        self.min_gap : timedelta = settings.get_timedelta('min_gap', timedelta(seconds=0.05))
 
         scene_threshold_seconds : float = settings.get_float('scene_threshold') or 30.0
         self.scene_threshold : timedelta = timedelta(seconds=scene_threshold_seconds)
@@ -20,17 +21,19 @@ class SubtitleBatcher:
 
         scenes : list[SubtitleScene] = []
         current_lines : list[SubtitleLine] = []
-        last_endtime : timedelta|None = None
+        previous_line : SubtitleLine|None = None
 
         for line in lines:
             if line.start is None or line.end is None:
                 raise ValueError(f"Line {line.number} has missing start or end time.")
 
-            # Fix overlapping display times (otherwise gaps can be negative)
-            if self.fix_overlaps and last_endtime and line.start < last_endtime:
-                line.start = last_endtime + timedelta(milliseconds=10)
+            if self.fix_overlaps and previous_line and previous_line.end > line.start:
+                # Preserve the next start time by trimming the previous end, without creating a non-positive duration.
+                latest_end = line.start - self.min_gap
+                if previous_line.end > latest_end and latest_end > previous_line.start:
+                    previous_line.end = latest_end
 
-            gap = line.start - last_endtime if last_endtime is not None else None
+            gap = line.start - previous_line.end if previous_line else None
 
             if gap is not None and gap > self.scene_threshold:
                 if current_lines:
@@ -38,7 +41,7 @@ class SubtitleBatcher:
                     current_lines = []
 
             current_lines.append(line)
-            last_endtime = line.end
+            previous_line = line
 
         # Handle any remaining lines
         if current_lines:
@@ -95,4 +98,3 @@ class SubtitleBatcher:
 
         # Recursively split the batches and concatenate the lists
         return self._split_lines(left) + self._split_lines(right)
-

--- a/PySubtrans/SubtitleProcessor.py
+++ b/PySubtrans/SubtitleProcessor.py
@@ -129,9 +129,6 @@ class SubtitleProcessor:
             if processed_line:
                 processed.append(processed_line)
 
-        # TODO: fix minimum durations
-        # TODO: fix overlapping start/end times (or merge the lines?)
-
         return processed
 
     def _preprocess_line(self, line : SubtitleLine):
@@ -302,5 +299,3 @@ class SubtitleProcessor:
 
     def _compile_break_sequences(self):
         self._compiled_break_sequences = [regex.compile(seq) for seq in self.break_sequences]
-
-

--- a/PySubtrans/SubtitleProject.py
+++ b/PySubtrans/SubtitleProject.py
@@ -12,7 +12,7 @@ from PySubtrans.SettingsType import SettingsType
 from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleError import SubtitleError, TranslationAbortedError
 from PySubtrans.SubtitleFormatRegistry import SubtitleFormatRegistry
-from PySubtrans.Subtitles import Subtitles
+from PySubtrans.Subtitles import SaveSettings, Subtitles
 
 from PySubtrans.SubtitleScene import SubtitleScene
 from PySubtrans.SubtitleSerialisation import SubtitleDecoder, SubtitleEncoder
@@ -60,6 +60,8 @@ class SubtitleProject:
         self.projectfile : str|None = None
         self.existing_project : bool = False
         self.needs_writing : bool = False
+        # Runtime-only settings applied when translated subtitles are written.
+        self.save_settings : SaveSettings|None = None
         self.lock = threading.RLock()
 
         # By default the project is not persistent, i.e. it will not be saved to a file and automatically reloaded next time
@@ -253,7 +255,7 @@ class SubtitleProject:
         """
         try:
             with self.lock:
-                self.subtitles.SaveTranslation(outputpath)
+                self.subtitles.SaveTranslation(outputpath, save_settings=self.save_settings)
 
         except Exception as e:
             logging.error(_("Unable to save translation: {}").format(e))

--- a/PySubtrans/Subtitles.py
+++ b/PySubtrans/Subtitles.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from datetime import timedelta
 import os
 import logging
 import threading
 from typing import Any
+
+import regex
+
 from PySubtrans.Helpers.Localization import _
 from PySubtrans.Options import Options
 
@@ -276,11 +280,15 @@ class Subtitles:
             if self.settings.get('include_original'):
                 translated = self._merge_original_and_translated(originals, translated)
 
+            output_lines = translated
+            if self.settings.get_bool('extend_short_subtitles', False):
+                output_lines = self._extend_short_subtitles(translated)
+
             logging.info(_("Saving translation to {}").format(str(outputpath)))
 
             # Use file handler for format-agnostic saving with metadata preservation
             data = SubtitleData(
-                lines=translated, 
+                lines=output_lines,
                 metadata=self.metadata, 
                 start_line_number=self.start_line_number
             )
@@ -318,6 +326,36 @@ class Subtitles:
             for line_number, line in enumerate(lines, start=1):
                 line.number = line_number
 
+    def _extend_short_subtitles(self, lines : list[SubtitleLine]) -> list[SubtitleLine]:
+        """Extend output subtitle durations without changing the stored lines."""
+        adjusted : list[SubtitleLine] = [line.copy() for line in lines]
+        min_line_duration = self.settings.get_timedelta('min_line_duration', timedelta(seconds=0))
+        min_gap = self.settings.get_timedelta('min_gap', timedelta(seconds=0.05))
+        seconds_per_character = max(self.settings.get_float('seconds_per_character', 0.1) or 0.0, 0.0)
+
+        for index, line in enumerate(adjusted):
+            if not line.text:
+                continue
+
+            visible_text = regex.sub(r'<[^>]*>|\{\\[^}]*\}', '', line.text)
+            character_count = sum(1 for character in regex.findall(r'\X', visible_text) if not character.isspace())
+            reading_duration = timedelta(seconds=character_count * seconds_per_character)
+            target_end = line.start + max(min_line_duration, reading_duration)
+
+            if target_end <= line.end:
+                continue
+
+            if index + 1 < len(adjusted):
+                latest_end = adjusted[index + 1].start - min_gap
+                # Do not shorten existing lines or modify existing overlaps.
+                if latest_end <= line.end:
+                    continue
+                target_end = min(target_end, latest_end)
+
+            line.end = target_end
+
+        return adjusted
+
 
     def _merge_original_and_translated(self, originals: list[SubtitleLine], translated: list[SubtitleLine]) -> list[SubtitleLine]:
         lines = {item.key: SubtitleLine(item) for item in originals if item.key}
@@ -328,4 +366,3 @@ class Subtitles:
                 line.text = f"{line.text}\n{item.text}"
 
         return sorted(lines.values(), key=lambda item: item.key)
-

--- a/PySubtrans/Subtitles.py
+++ b/PySubtrans/Subtitles.py
@@ -22,6 +22,29 @@ from PySubtrans.SubtitleScene import SubtitleScene, UnbatchScenes
 from PySubtrans.SubtitleLine import SubtitleLine
 from PySubtrans.SubtitleData import SubtitleData
 
+FORMATTING_TAG_PATTERN = regex.compile(r'<[^>]*>|\{\\[^}]*\}')
+GRAPHEME_PATTERN = regex.compile(r'\X')
+DURATION_EPSILON = timedelta(milliseconds=50)
+
+class SaveSettings:
+    """Settings applied only while writing translated subtitles."""
+
+    def __init__(self, settings : SettingsType|Options|None = None) -> None:
+        settings = settings or SettingsType()
+        self.extend_short_subtitles : bool = settings.get_bool('extend_short_subtitles', False)
+        self.min_line_duration : timedelta = max(
+            settings.get_timedelta('min_line_duration', timedelta(seconds=0.8)),
+            timedelta(),
+        )
+        self.seconds_per_character : float = max(
+            settings.get_float('seconds_per_character', 0.1) or 0.0,
+            0.0,
+        )
+        self.min_gap : timedelta = max(
+            settings.get_timedelta('min_gap', timedelta(seconds=0.05)),
+            timedelta(),
+        )
+
 class Subtitles:
     """
     High level class for manipulating subtitles
@@ -250,9 +273,12 @@ class Subtitles:
             else:
                 logging.warning(_("No original subtitles to save to {}").format(str(path)))
 
-    def SaveTranslation(self, outputpath: str|None = None) -> None:
+    def SaveTranslation(self, outputpath : str|None = None, save_settings : SaveSettings|None = None) -> None:
         """
-        Write translated subtitles to a file
+        Write translated subtitles to a file.
+
+        :param outputpath: destination path, or the configured output path when omitted
+        :param save_settings: optional settings applied only to the written output
         """
         outputpath = outputpath or self.outputpath
         if not outputpath and self.sourcepath and os.path.exists(self.sourcepath):
@@ -281,8 +307,8 @@ class Subtitles:
                 translated = self._merge_original_and_translated(originals, translated)
 
             output_lines = translated
-            if self.settings.get_bool('extend_short_subtitles', False):
-                output_lines = self._extend_short_subtitles(translated)
+            if save_settings and save_settings.extend_short_subtitles:
+                output_lines = self._extend_short_subtitles(translated, save_settings)
 
             logging.info(_("Saving translation to {}").format(str(outputpath)))
 
@@ -326,33 +352,28 @@ class Subtitles:
             for line_number, line in enumerate(lines, start=1):
                 line.number = line_number
 
-    def _extend_short_subtitles(self, lines : list[SubtitleLine]) -> list[SubtitleLine]:
+    def _extend_short_subtitles(self, lines : list[SubtitleLine], save_settings : SaveSettings) -> list[SubtitleLine]:
         """Extend output subtitle durations without changing the stored lines."""
         adjusted : list[SubtitleLine] = [line.copy() for line in lines]
-        min_line_duration = self.settings.get_timedelta('min_line_duration', timedelta(seconds=0))
-        min_gap = self.settings.get_timedelta('min_gap', timedelta(seconds=0.05))
-        seconds_per_character = max(self.settings.get_float('seconds_per_character', 0.1) or 0.0, 0.0)
 
         for index, line in enumerate(adjusted):
             if not line.text:
                 continue
 
-            visible_text = regex.sub(r'<[^>]*>|\{\\[^}]*\}', '', line.text)
-            character_count = sum(1 for character in regex.findall(r'\X', visible_text) if not character.isspace())
-            reading_duration = timedelta(seconds=character_count * seconds_per_character)
-            target_end = line.start + max(min_line_duration, reading_duration)
-
-            if target_end <= line.end:
-                continue
+            visible_text = FORMATTING_TAG_PATTERN.sub('', line.text)
+            character_count = sum(1 for character in GRAPHEME_PATTERN.findall(visible_text) if not character.isspace())
+            reading_duration = timedelta(seconds=character_count * save_settings.seconds_per_character)
+            target_end = line.start + max(save_settings.min_line_duration, reading_duration)
 
             if index + 1 < len(adjusted):
-                latest_end = adjusted[index + 1].start - min_gap
+                latest_end = adjusted[index + 1].start - save_settings.min_gap
                 # Do not shorten existing lines or modify existing overlaps.
                 if latest_end <= line.end:
                     continue
                 target_end = min(target_end, latest_end)
 
-            line.end = target_end
+            if target_end > line.end + DURATION_EPSILON:
+                line.end = target_end
 
         return adjusted
 

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -22,7 +22,7 @@ translator = init_translator(opts)
 translator.TranslateSubtitles(subs)
 
 # Save translated subtitles
-subs.SaveSubtitles("movie_translated.srt")
+subs.SaveTranslation("movie_translated.srt", save_settings=SaveSettings(opts))
 """
 from __future__ import annotations
 
@@ -39,7 +39,7 @@ from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleError import SubtitleError
 from PySubtrans.SubtitleFormatRegistry import SubtitleFormatRegistry
 from PySubtrans.SubtitleLine import SubtitleLine
-from PySubtrans.Subtitles import Subtitles
+from PySubtrans.Subtitles import SaveSettings, Subtitles
 from PySubtrans.SubtitleProcessor import SubtitleProcessor
 from PySubtrans.SubtitleProject import SubtitleProject
 from PySubtrans.SubtitleScene import SubtitleScene
@@ -393,6 +393,8 @@ def init_project(
                     min_gap=options.get_float('min_gap', 0.05) or 0.0,
                 )
 
+    project.save_settings = SaveSettings(Options(settings))
+
     return project
 
 
@@ -476,6 +478,7 @@ def batch_subtitles(
 __all__ = [
     '__version__',
     'Options',
+    'SaveSettings',
     'SettingsPrecedence',
     'SettingsType',
     'Subtitles',

--- a/PySubtrans/__init__.py
+++ b/PySubtrans/__init__.py
@@ -174,6 +174,7 @@ def init_subtitles(
             min_batch_size=options.get_int('min_batch_size') or 1,
             max_batch_size=options.get_int('max_batch_size') or 100,
             prevent_overlap=options.get_bool('prevent_overlapping_times'),
+            min_gap=options.get_float('min_gap', 0.05) or 0.0,
         )
 
     return subtitles
@@ -389,6 +390,7 @@ def init_project(
                     min_batch_size=options.get_int('min_batch_size') or 1,
                     max_batch_size=options.get_int('max_batch_size') or 100,
                     prevent_overlap=options.get_bool('prevent_overlapping_times'),
+                    min_gap=options.get_float('min_gap', 0.05) or 0.0,
                 )
 
     return project
@@ -426,6 +428,7 @@ def batch_subtitles(
     max_batch_size: int,
     *,
     prevent_overlap: bool = False,
+    min_gap : float = 0.05,
 ) -> list[SubtitleScene]:
     """
     Divide subtitles into scenes and batches using :class:`SubtitleBatcher`.
@@ -442,6 +445,8 @@ def batch_subtitles(
         Maximum number of lines per batch.
     prevent_overlap : bool, optional
         If True, adjust overlapping subtitle times while batching.
+    min_gap : float, optional
+        Minimum gap in seconds to preserve when preventing overlaps.
 
     Returns
     -------
@@ -459,6 +464,7 @@ def batch_subtitles(
         'min_batch_size': min_batch_size,
         'max_batch_size': max_batch_size,
         'prevent_overlapping_times': prevent_overlap,
+        'min_gap': min_gap,
     }))
 
     with SubtitleEditor(subtitles) as editor:

--- a/locales/en/LC_MESSAGES/gui-subtrans.po
+++ b/locales/en/LC_MESSAGES/gui-subtrans.po
@@ -2492,6 +2492,10 @@ msgstr "Enable Thinking"
 msgid "endpoint"
 msgstr "Endpoint"
 
+#: PySubtrans/Options.py:66
+msgid "extend_short_subtitles"
+msgstr "Extend Short Subtitles"
+
 #: PySubtrans/Options.py:79
 msgid "filler_words"
 msgstr "Filler Words"
@@ -2589,6 +2593,10 @@ msgstr "Merge Line Duration"
 #: PySubtrans/Options.py:60
 msgid "min_batch_size"
 msgstr "Min Batch Size"
+
+#: PySubtrans/Options.py:75
+msgid "min_gap"
+msgstr "Min Gap"
 
 #: PySubtrans/Options.py:74
 msgid "min_line_duration"
@@ -2738,6 +2746,10 @@ msgstr "Save Preprocessed Subtitles"
 #: PySubtrans/Options.py:59
 msgid "scene_threshold"
 msgstr "Scene Threshold"
+
+#: PySubtrans/Options.py:74
+msgid "seconds_per_character"
+msgstr "Seconds Per Character"
 
 #: PySubtrans/Providers/Provider_Bedrock.py:0
 msgid "secret_access_key"

--- a/locales/gui-subtrans.pot
+++ b/locales/gui-subtrans.pot
@@ -2317,6 +2317,10 @@ msgstr ""
 msgid "endpoint"
 msgstr ""
 
+#: PySubtrans/Options.py:66
+msgid "extend_short_subtitles"
+msgstr ""
+
 #: PySubtrans/Options.py:79
 msgid "filler_words"
 msgstr ""
@@ -2407,6 +2411,10 @@ msgstr ""
 
 #: PySubtrans/Options.py:60
 msgid "min_batch_size"
+msgstr ""
+
+#: PySubtrans/Options.py:75
+msgid "min_gap"
 msgstr ""
 
 #: PySubtrans/Options.py:74
@@ -2527,6 +2535,10 @@ msgstr ""
 
 #: PySubtrans/Options.py:59
 msgid "scene_threshold"
+msgstr ""
+
+#: PySubtrans/Options.py:74
+msgid "seconds_per_character"
 msgstr ""
 
 #: PySubtrans/Providers/Provider_Bedrock.py:0

--- a/scripts/batch-translate.py
+++ b/scripts/batch-translate.py
@@ -46,7 +46,7 @@ import pathlib
 import sys
 
 from PySubtrans import init_options, init_subtitles, init_translator, init_translation_provider
-from PySubtrans import Options, SettingsType, SubtitleError
+from PySubtrans import Options, SaveSettings, SettingsType, SubtitleError
 from PySubtrans import SubtitleTranslator
 from PySubtrans import TranslationProvider
 from PySubtrans import SubtitleFormatRegistry
@@ -234,7 +234,7 @@ class BatchProcessor:
 
             try:
                 # Save the translated subtitles. Format is deduced from the filename.
-                subtitles.SaveTranslation(str(destination_file))
+                subtitles.SaveTranslation(str(destination_file), save_settings=SaveSettings(self.options))
 
             except (SubtitleError, OSError) as exc:
                 # A failure to write the result should abort the batch

--- a/scripts/subtrans_common.py
+++ b/scripts/subtrans_common.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from PySubtrans.Helpers import GetOutputPath
 from PySubtrans.Helpers.Localization import _
 from PySubtrans.Helpers.Parse import FormatKeyValuePairs, ParseKeyValuePairsOrFiles, ParseNames
-from PySubtrans import batch_subtitles, init_options, init_translator, preprocess_subtitles
+from PySubtrans import SaveSettings, batch_subtitles, init_options, init_translator, preprocess_subtitles
 from PySubtrans.Helpers.Resources import ConfigureConfigDirFromArguments, GetConfigDir
 from PySubtrans.Options import Options
 from PySubtrans.SubtitleTranslator import SubtitleTranslator
@@ -279,6 +279,7 @@ def CreateProject(options : Options, args: Namespace) -> SubtitleProject:
     Initialise a subtitle project with the provided arguments
     """
     project = SubtitleProject(persistent=options.use_project_file)
+    project.save_settings = SaveSettings(options)
 
     project.InitialiseProject(args.input, args.output)
 
@@ -328,6 +329,8 @@ def CreateProject(options : Options, args: Namespace) -> SubtitleProject:
             scene_threshold=scene_threshold,
             min_batch_size=min_batch_size,
             max_batch_size=max_batch_size,
+            prevent_overlap=options.get_bool('prevent_overlapping_times'),
+            min_gap=options.get_float('min_gap', 0.05) or 0.0,
         )
 
     scene_count = subtitles.scenecount

--- a/tests/GuiTests/test_SaveTranslationCommand.py
+++ b/tests/GuiTests/test_SaveTranslationCommand.py
@@ -1,0 +1,46 @@
+import os
+import tempfile
+from datetime import timedelta
+
+from GuiSubtrans.Commands.SaveTranslationFile import SaveTranslationFile
+from GuiSubtrans.ProjectDataModel import ProjectDataModel
+from PySubtrans.Formats.SrtFileHandler import SrtFileHandler
+from PySubtrans.Helpers.TestCases import LoggedTestCase
+from PySubtrans.Options import Options
+from PySubtrans.SubtitleBuilder import SubtitleBuilder
+from PySubtrans.SubtitleEditor import SubtitleEditor
+from PySubtrans.SubtitleProject import SubtitleProject
+
+
+class SaveTranslationCommandTests(LoggedTestCase):
+
+    def test_SaveTranslationFile_uses_current_project_options(self):
+        subtitles = (SubtitleBuilder(max_batch_size=1)
+            .AddLines([
+                (timedelta(seconds=1), timedelta(seconds=1.1), "abcdefghij"),
+            ])
+            .Build())
+        with SubtitleEditor(subtitles) as editor:
+            editor.DuplicateOriginalsAsTranslations()
+
+        project = SubtitleProject()
+        project.subtitles = subtitles
+        datamodel = ProjectDataModel(project, Options())
+        datamodel.UpdateSettings(Options({
+            'extend_short_subtitles': True,
+            'min_line_duration': 0.8,
+            'seconds_per_character': 0.1,
+            'min_gap': 0.05,
+        }))
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".srt") as output_file:
+            output_path = output_file.name
+        self.addCleanup(os.remove, output_path)
+
+        command = SaveTranslationFile(project, output_path)
+        command.SetDataModel(datamodel)
+        command.execute()
+
+        output_data = SrtFileHandler().load_file(output_path)
+        self.assertLoggedEqual("duration extended from GUI options", timedelta(seconds=2), output_data.lines[0].end)
+        self.assertLoggedNotIn("save option not stored in project settings", 'extend_short_subtitles', subtitles.settings)

--- a/tests/PySubtransTests/test_SubtitleProjectFormats.py
+++ b/tests/PySubtransTests/test_SubtitleProjectFormats.py
@@ -18,7 +18,7 @@ from PySubtrans.SubtitleFileHandler import SubtitleFileHandler
 from PySubtrans.SubtitleFormatRegistry import SubtitleFormatRegistry
 from PySubtrans.SubtitleProject import SubtitleProject
 from PySubtrans.SubtitleSerialisation import SubtitleEncoder, SubtitleDecoder
-from PySubtrans.Subtitles import Subtitles
+from PySubtrans.Subtitles import SaveSettings, Subtitles
 from PySubtrans.SettingsType import SettingsType
 from PySubtrans.Helpers.Tests import (
     skip_if_debugger_attached,
@@ -143,12 +143,12 @@ Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello World!
                 (timedelta(seconds=1), timedelta(seconds=1.1), "abcdefghij"),
             ])
             .Build())
-        subtitles.settings = SettingsType({
+        save_settings = SaveSettings(SettingsType({
             'extend_short_subtitles': True,
             'min_line_duration': 0.8,
             'seconds_per_character': 0.1,
             'min_gap': 0.05,
-        })
+        }))
 
         with SubtitleEditor(subtitles) as editor:
             editor.DuplicateOriginalsAsTranslations()
@@ -157,7 +157,7 @@ Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello World!
             output_path = output_file.name
         self.addCleanup(os.remove, output_path)
 
-        subtitles.SaveTranslation(output_path)
+        subtitles.SaveTranslation(output_path, save_settings=save_settings)
         output_data = SrtFileHandler().load_file(output_path)
 
         self.assertLoggedEqual("dynamic output duration", timedelta(seconds=2), output_data.lines[0].end)
@@ -168,7 +168,7 @@ Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello World!
         )
 
         subtitles.scenes[0].batches[0].translated[0].text = "a"
-        subtitles.SaveTranslation(output_path)
+        subtitles.SaveTranslation(output_path, save_settings=save_settings)
         corrected_output = SrtFileHandler().load_file(output_path)
 
         self.assertLoggedEqual(

--- a/tests/PySubtransTests/test_SubtitleProjectFormats.py
+++ b/tests/PySubtransTests/test_SubtitleProjectFormats.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import unittest
+from datetime import timedelta
 from typing import TextIO
 
 from PySubtrans.Formats.SSAFileHandler import SSAFileHandler
@@ -10,12 +11,15 @@ from PySubtrans.Helpers.Color import Color
 from PySubtrans.Helpers.TestCases import LoggedTestCase
 from PySubtrans.Options import Options
 from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SubtitleBuilder import SubtitleBuilder
 from PySubtrans.SubtitleData import SubtitleData
+from PySubtrans.SubtitleEditor import SubtitleEditor
 from PySubtrans.SubtitleFileHandler import SubtitleFileHandler
 from PySubtrans.SubtitleFormatRegistry import SubtitleFormatRegistry
 from PySubtrans.SubtitleProject import SubtitleProject
 from PySubtrans.SubtitleSerialisation import SubtitleEncoder, SubtitleDecoder
 from PySubtrans.Subtitles import Subtitles
+from PySubtrans.SettingsType import SettingsType
 from PySubtrans.Helpers.Tests import (
     skip_if_debugger_attached,
 )
@@ -132,6 +136,46 @@ Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello World!
         self.assertLoggedEqual("line.text", "Hello <b>World</b>!", line.text)
         self.assertLoggedEqual("line.start", 1.0, line.start.total_seconds())
         self.assertLoggedEqual("line.end", 3.0, line.end.total_seconds())
+
+    def test_SaveTranslation_extends_output_duration_without_changing_project(self):
+        subtitles = (SubtitleBuilder(max_batch_size=1)
+            .AddLines([
+                (timedelta(seconds=1), timedelta(seconds=1.1), "abcdefghij"),
+            ])
+            .Build())
+        subtitles.settings = SettingsType({
+            'extend_short_subtitles': True,
+            'min_line_duration': 0.8,
+            'seconds_per_character': 0.1,
+            'min_gap': 0.05,
+        })
+
+        with SubtitleEditor(subtitles) as editor:
+            editor.DuplicateOriginalsAsTranslations()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".srt") as output_file:
+            output_path = output_file.name
+        self.addCleanup(os.remove, output_path)
+
+        subtitles.SaveTranslation(output_path)
+        output_data = SrtFileHandler().load_file(output_path)
+
+        self.assertLoggedEqual("dynamic output duration", timedelta(seconds=2), output_data.lines[0].end)
+        self.assertLoggedEqual(
+            "stored translation unchanged",
+            timedelta(seconds=1.1),
+            subtitles.scenes[0].batches[0].translated[0].end,
+        )
+
+        subtitles.scenes[0].batches[0].translated[0].text = "a"
+        subtitles.SaveTranslation(output_path)
+        corrected_output = SrtFileHandler().load_file(output_path)
+
+        self.assertLoggedEqual(
+            "duration recalculated after correction",
+            timedelta(seconds=1.8),
+            corrected_output.lines[0].end,
+        )
 
     def test_AssHandlerBasicFunctionality(self):
         

--- a/tests/PySubtransTests/test_Subtitles.py
+++ b/tests/PySubtransTests/test_Subtitles.py
@@ -8,6 +8,9 @@ from PySubtrans.Helpers.TestCases import LoggedTestCase
 from PySubtrans.Helpers.Tests import log_info
 from PySubtrans.Helpers.SubtitleHelpers import MergeSubtitles, MergeTranslations, FindSplitPoint, GetProportionalDuration
 from PySubtrans.SubtitleProcessor import SubtitleProcessor
+from PySubtrans.SubtitleBatcher import SubtitleBatcher
+from PySubtrans.SettingsType import SettingsType
+from PySubtrans.Subtitles import Subtitles
 
 
 class TestSubtitles(LoggedTestCase):
@@ -256,6 +259,71 @@ class SubtitleProcessorTests(LoggedTestCase):
 
     def _format_lines(self, expected_result):
         return [f"\"{line}\"".replace('\n', '\\n') for line in expected_result]
+
+
+class SubtitleTimingTests(LoggedTestCase):
+
+    def test_ExtendShortSubtitles(self):
+        source = [
+            SubtitleLine("1\n00:00:01,000 --> 00:00:01,200\nabc"),
+            SubtitleLine("2\n00:00:03,000 --> 00:00:03,200\nabcdefghijkl"),
+            SubtitleLine("3\n00:00:03,900 --> 00:00:04,100\nabcdefghijkl"),
+        ]
+        subtitles = Subtitles(settings=SettingsType({
+            'min_line_duration': 0.8,
+            'seconds_per_character': 0.1,
+            'min_gap': 0.05,
+        }))
+
+        result = subtitles._extend_short_subtitles(source)
+
+        self.assertLoggedEqual("fixed minimum duration", timedelta(seconds=1.8), result[0].end)
+        self.assertLoggedEqual("capped by next subtitle", timedelta(seconds=3.85), result[1].end)
+        self.assertLoggedEqual("dynamic final duration", timedelta(seconds=5.1), result[2].end)
+        self.assertLoggedEqual("source remains unchanged", timedelta(seconds=1.2), source[0].end)
+
+    def test_ExtendShortSubtitles_ignores_formatting_and_whitespace(self):
+        line = SubtitleLine("1\n00:00:01,000 --> 00:00:01,100\nA <i>好</i>\n👨‍👩‍👧‍👦")
+        subtitles = Subtitles(settings=SettingsType({
+            'min_line_duration': 0.0,
+            'seconds_per_character': 0.1,
+        }))
+
+        result = subtitles._extend_short_subtitles([line])
+
+        self.assertLoggedEqual("three visible graphemes", timedelta(seconds=1.3), result[0].end)
+
+    def test_ExtendShortSubtitles_preserves_existing_overlap(self):
+        source = [
+            SubtitleLine("1\n00:00:01,000 --> 00:00:03,000\nA long translated subtitle"),
+            SubtitleLine("2\n00:00:02,500 --> 00:00:04,000\nNext subtitle"),
+        ]
+        subtitles = Subtitles(settings=SettingsType({
+            'min_line_duration': 0.8,
+            'seconds_per_character': 0.1,
+            'min_gap': 0.05,
+        }))
+
+        result = subtitles._extend_short_subtitles(source)
+
+        self.assertLoggedEqual("existing overlap remains unchanged", timedelta(seconds=3), result[0].end)
+
+    def test_BatchSubtitles_prevents_overlap_by_trimming_previous_end(self):
+        source = [
+            SubtitleLine("1\n00:00:01,000 --> 00:00:03,000\nFirst subtitle"),
+            SubtitleLine("2\n00:00:02,500 --> 00:00:02,800\nSecond subtitle"),
+            SubtitleLine("3\n00:00:02,820 --> 00:00:03,200\nThird subtitle"),
+        ]
+        batcher = SubtitleBatcher(SettingsType({
+            'prevent_overlapping_times': True,
+            'min_gap': 0.05,
+        }))
+
+        batcher.BatchSubtitles(source)
+
+        self.assertLoggedEqual("previous end trimmed", timedelta(seconds=2.45), source[0].end)
+        self.assertLoggedEqual("next start unchanged", timedelta(seconds=2.5), source[1].start)
+        self.assertLoggedEqual("non-overlapping end unchanged", timedelta(seconds=2.8), source[1].end)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/PySubtransTests/test_Subtitles.py
+++ b/tests/PySubtransTests/test_Subtitles.py
@@ -10,7 +10,7 @@ from PySubtrans.Helpers.SubtitleHelpers import MergeSubtitles, MergeTranslations
 from PySubtrans.SubtitleProcessor import SubtitleProcessor
 from PySubtrans.SubtitleBatcher import SubtitleBatcher
 from PySubtrans.SettingsType import SettingsType
-from PySubtrans.Subtitles import Subtitles
+from PySubtrans.Subtitles import SaveSettings, Subtitles
 
 
 class TestSubtitles(LoggedTestCase):
@@ -269,13 +269,14 @@ class SubtitleTimingTests(LoggedTestCase):
             SubtitleLine("2\n00:00:03,000 --> 00:00:03,200\nabcdefghijkl"),
             SubtitleLine("3\n00:00:03,900 --> 00:00:04,100\nabcdefghijkl"),
         ]
-        subtitles = Subtitles(settings=SettingsType({
+        subtitles = Subtitles()
+        save_settings = SaveSettings(SettingsType({
             'min_line_duration': 0.8,
             'seconds_per_character': 0.1,
             'min_gap': 0.05,
         }))
 
-        result = subtitles._extend_short_subtitles(source)
+        result = subtitles._extend_short_subtitles(source, save_settings)
 
         self.assertLoggedEqual("fixed minimum duration", timedelta(seconds=1.8), result[0].end)
         self.assertLoggedEqual("capped by next subtitle", timedelta(seconds=3.85), result[1].end)
@@ -284,12 +285,13 @@ class SubtitleTimingTests(LoggedTestCase):
 
     def test_ExtendShortSubtitles_ignores_formatting_and_whitespace(self):
         line = SubtitleLine("1\n00:00:01,000 --> 00:00:01,100\nA <i>好</i>\n👨‍👩‍👧‍👦")
-        subtitles = Subtitles(settings=SettingsType({
+        subtitles = Subtitles()
+        save_settings = SaveSettings(SettingsType({
             'min_line_duration': 0.0,
             'seconds_per_character': 0.1,
         }))
 
-        result = subtitles._extend_short_subtitles([line])
+        result = subtitles._extend_short_subtitles([line], save_settings)
 
         self.assertLoggedEqual("three visible graphemes", timedelta(seconds=1.3), result[0].end)
 
@@ -298,15 +300,31 @@ class SubtitleTimingTests(LoggedTestCase):
             SubtitleLine("1\n00:00:01,000 --> 00:00:03,000\nA long translated subtitle"),
             SubtitleLine("2\n00:00:02,500 --> 00:00:04,000\nNext subtitle"),
         ]
-        subtitles = Subtitles(settings=SettingsType({
+        subtitles = Subtitles()
+        save_settings = SaveSettings(SettingsType({
             'min_line_duration': 0.8,
             'seconds_per_character': 0.1,
             'min_gap': 0.05,
         }))
 
-        result = subtitles._extend_short_subtitles(source)
+        result = subtitles._extend_short_subtitles(source, save_settings)
 
         self.assertLoggedEqual("existing overlap remains unchanged", timedelta(seconds=3), result[0].end)
+
+    def test_ExtendShortSubtitles_ignores_frame_sized_adjustments(self):
+        source = [
+            SubtitleLine("1\n00:00:01,000 --> 00:00:01,900\nabcdefghij"),
+            SubtitleLine("2\n00:00:02,000 --> 00:00:03,000\nNext subtitle"),
+        ]
+        save_settings = SaveSettings(SettingsType({
+            'min_line_duration': 1.0,
+            'seconds_per_character': 0.1,
+            'min_gap': 0.05,
+        }))
+
+        result = Subtitles()._extend_short_subtitles(source, save_settings)
+
+        self.assertLoggedEqual("50ms capped extension ignored", timedelta(seconds=1.9), result[0].end)
 
     def test_BatchSubtitles_prevents_overlap_by_trimming_previous_end(self):
         source = [


### PR DESCRIPTION

## Summary

- Add an opt-in `extend_short_subtitles` setting that extends short translated subtitles when the output file is saved.
- Calculate the target duration using the greater of:
  - `min_line_duration`
  - visible character count multiplied by `seconds_per_character`
- Handle CJK characters and emoji grapheme clusters as visible characters while excluding whitespace and HTML/ASS styling tags from reading-duration calculations.
- Cap extensions at the next subtitle's start time minus `min_gap`.
- Apply duration changes only to output copies, leaving timestamps stored in the project unchanged.
- Update overlap prevention to shorten the previous subtitle's end time instead of shifting the next subtitle's start time.
- Expose the new duration and overlap settings in the GUI and PySubtrans API documentation.

## Motivation

Translated text can require more reading time than the source subtitle provides. Extending short subtitles improves readability, but storing those derived timestamps in the project could retain an excessive duration produced by a bad translation after the text is retranslated or manually corrected.

Applying the adjustment only while saving keeps the project timestamps unchanged and recalculates the required duration from the latest translation each time.

For overlapping subtitles, preserving the next subtitle's start time avoids the more noticeable synchronization error caused by shifting dialogue starts. When an actual overlap is detected, the previous subtitle's end time is shortened to preserve `min_gap` where possible.

## Processing stages

extend_short_subtitles and prevent_overlapping_times are independent options applied at different stages of the workflow:

extend_short_subtitles is applied only when SaveTranslation creates the output file. It adjusts copies of the translated lines and does not change timestamps stored in the project.

prevent_overlapping_times is applied earlier, when subtitles are batched. It corrects actual overlaps in the internal subtitle timeline and is not reapplied when the translation is saved.

Enabling either option does not enable the other. They share the min_gap setting, but otherwise operate independently.

## Behavior

- The new duration adjustment is disabled by default.
- Existing subtitle durations are never shortened by `extend_short_subtitles`.
- CJK characters and emoji grapheme clusters are counted correctly when estimating reading time.
- Whitespace and HTML/ASS styling tags do not increase the estimated reading duration.
- Extensions are capped at the following subtitle's start time minus `min_gap`.
- Existing overlaps are left unchanged unless `prevent_overlapping_times` is enabled.
- Non-overlapping subtitles are not shortened solely because their existing gap is smaller than `min_gap`.
- If preserving `min_gap` while fixing an overlap would create a non-positive duration, the previous subtitle is left unchanged.
- No subtitles are automatically merged by this feature.

## Testing

- Added unit coverage for fixed and character-based minimum durations.
- Added coverage for whitespace, CJK characters, Unicode grapheme clusters, and HTML/ASS styling tags.
- Added coverage for capping extensions at the next subtitle while preserving existing overlaps.
- Added coverage confirming that overlap prevention trims the previous end time without changing the next start time.
- Added coverage confirming that non-overlapping subtitles with a gap smaller than `min_gap` are not modified.
- Added an end-to-end save test confirming that derived durations are not stored in the project and are recalculated after manual text correction.