### PR TITLE
Add Atlas Cloud translation provider

### DIFF
--- a/PySubtrans/Providers/Clients/AtlasCloudClient.py
+++ b/PySubtrans/Providers/Clients/AtlasCloudClient.py
@@ -1,0 +1,14 @@
+from PySubtrans.Providers.Clients.CustomClient import CustomClient
+from PySubtrans.SettingsType import SettingsType
+
+
+class AtlasCloudClient(CustomClient):
+    """Handles OpenAI-compatible chat requests to Atlas Cloud."""
+
+    def __init__(self, settings : SettingsType):
+        settings['supports_system_messages'] = True
+        settings['supports_conversation'] = True
+        settings['supports_streaming'] = True
+        settings.setdefault('server_address', settings.get_str('api_base', 'https://api.atlascloud.ai'))
+        settings.setdefault('endpoint', '/v1/chat/completions')
+        super().__init__(settings)

--- a/PySubtrans/Providers/Provider_AtlasCloud.py
+++ b/PySubtrans/Providers/Provider_AtlasCloud.py
@@ -1,0 +1,125 @@
+import json
+import logging
+import os
+
+import httpx
+
+from PySubtrans.Helpers.Localization import _
+from PySubtrans.Options import env_float, env_int
+from PySubtrans.Providers.Clients.AtlasCloudClient import AtlasCloudClient
+from PySubtrans.SettingsType import GuiSettingsType, SettingsType
+from PySubtrans.TranslationClient import TranslationClient
+from PySubtrans.TranslationProvider import TranslationProvider
+
+
+class AtlasCloudProvider(TranslationProvider):
+    """Atlas Cloud translation provider using its OpenAI-compatible API."""
+
+    name = "Atlas Cloud"
+    default_model = "openai/gpt-4.1-mini"
+
+    information = """
+    <p>Select an <a href="https://www.atlascloud.ai/models">Atlas Cloud model</a> to use as a translator.</p>
+    <p>Atlas Cloud exposes models through an OpenAI-compatible API. Models are identified as provider/model.</p>
+    """
+
+    information_noapikey = """
+    <p>To use this provider you need an <a href="https://www.atlascloud.ai/console/api-keys">Atlas Cloud API key</a>.</p>
+    <p>Ensure your Atlas Cloud account has sufficient credit before translating.</p>
+    """
+
+    def __init__(self, settings : SettingsType):
+        super().__init__(self.name, SettingsType({
+            'api_key': settings.get_str('api_key', os.getenv('ATLASCLOUD_API_KEY')),
+            'api_base': settings.get_str('api_base', os.getenv('ATLASCLOUD_API_BASE', 'https://api.atlascloud.ai')),
+            'model': settings.get_str('model', os.getenv('ATLASCLOUD_MODEL', self.default_model)),
+            'max_tokens': settings.get_int('max_tokens', env_int('ATLASCLOUD_MAX_TOKENS', 0)),
+            'temperature': settings.get_float('temperature', env_float('ATLASCLOUD_TEMPERATURE', 0.0)),
+            'rate_limit': settings.get_float('rate_limit', env_float('ATLASCLOUD_RATE_LIMIT')),
+            'reuse_client': settings.get_bool('reuse_client', True),
+            'proxy': settings.get_str('proxy') or os.getenv('ATLASCLOUD_PROXY'),
+            'stream_responses': settings.get_bool('stream_responses', True),
+        }))
+        self.refresh_when_changed = ['api_key', 'api_base', 'model']
+
+    @property
+    def api_key(self) -> str|None:
+        return self.settings.get_str('api_key')
+
+    @property
+    def api_base(self) -> str|None:
+        return self.settings.get_str('api_base')
+
+    def GetTranslationClient(self, settings : SettingsType) -> TranslationClient:
+        client_settings = SettingsType(self.settings.copy())
+        client_settings.update(settings)
+        return AtlasCloudClient(client_settings)
+
+    def GetOptions(self, settings : SettingsType) -> GuiSettingsType:
+        options : GuiSettingsType = {
+            'api_key': (str, _("An Atlas Cloud API key is required to use this provider (https://www.atlascloud.ai/console/api-keys)")),
+            'api_base': (str, _("The base URL to use for requests (default is https://api.atlascloud.ai)")),
+        }
+
+        if self.api_key:
+            models = self.available_models
+            if models:
+                options.update({
+                    'model': (models, _("AI model to use as the translator")),
+                    'stream_responses': (bool, _("Enable streaming responses for real-time translation updates")),
+                    'reuse_client': (bool, _("Reuse connection for multiple requests (otherwise a new connection is established for each)")),
+                    'max_tokens': (int, _("Maximum number of output tokens to return in the response.")),
+                    'temperature': (float, _("Amount of random variance to add to translations. Generally speaking, none is best")),
+                    'rate_limit': (float, _("Maximum API requests per minute.")),
+                })
+            else:
+                options['model'] = ([_('Unable to retrieve models')], _("Check API key and base URL and try again"))
+
+        return options
+
+    def GetAvailableModels(self) -> list[str]:
+        """Fetch the current Atlas Cloud model catalog."""
+        if not self.api_key:
+            logging.debug("No Atlas Cloud API key provided")
+            return []
+
+        if not self.api_base:
+            logging.debug("No Atlas Cloud API base URL provided")
+            return []
+
+        try:
+            url = self.api_base.rstrip('/') + '/v1/models'
+            headers = {'Authorization': f"Bearer {self.api_key}"}
+            proxy_url = self.settings.get_str('proxy')
+
+            with httpx.Client(timeout=20, proxy=proxy_url) as client:
+                result = client.get(url, headers=headers)
+                if result.is_error:
+                    logging.error(_("Error fetching models: {status} {text}").format(
+                        status=result.status_code, text=result.text))
+                    return []
+
+                try:
+                    data = result.json()
+                    return sorted(model['id'] for model in data.get('data', []) if model.get('id'))
+                except json.JSONDecodeError:
+                    logging.error(_("Unable to parse server response as JSON: {response_text}").format(
+                        response_text=result.text))
+                    return []
+        except httpx.HTTPError as error:
+            logging.error(_("Unable to retrieve available models: {error}").format(error=str(error)))
+            return []
+
+    def GetInformation(self) -> str:
+        if not self.api_key:
+            return self.information_noapikey
+        return self.information
+
+    def ValidateSettings(self) -> bool:
+        if not self.api_key:
+            self.validation_message = _("API Key is required")
+            return False
+        return True
+
+    def _allow_multithreaded_translation(self) -> bool:
+        return self.settings.get_float('rate_limit', 0.0) == 0.0

--- a/PySubtrans/Providers/__init__.py
+++ b/PySubtrans/Providers/__init__.py
@@ -9,6 +9,7 @@ all providers are available regardless of installation method.
 
 # Explicitly import all provider modules to ensure they're registered
 # This is required for pip-installed packages where dynamic discovery may fail
+from . import Provider_AtlasCloud
 from . import Provider_Azure
 from . import Provider_Bedrock
 from . import Provider_Claude
@@ -20,4 +21,3 @@ from . import Provider_OpenAI
 from . import Provider_OpenRouter
 from . import Provider_Requesty
 from . import Provider_LiteLLM
-

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,13 @@ The Gemini-powered LLM-Subtrans Web has been retired as it was costing me money.
 
 ## Translation Providers
 
+### Atlas Cloud
+https://www.atlascloud.ai/privacy
+
+[Atlas Cloud](https://www.atlascloud.ai/) provides an OpenAI-compatible API for models from multiple providers. You will need an [Atlas Cloud API key](https://www.atlascloud.ai/console/api-keys) and sufficient account credit to use the service.
+
+The model list is loaded from the Atlas Cloud API. Models use `provider/model` identifiers, and `openai/gpt-4.1-mini` is selected by default.
+
 ### OpenRouter
 https://openrouter.ai/privacy
 
@@ -340,6 +347,13 @@ Default values for many settings can be set in the .env file, using a NAME_IN_CA
 
 ### Provider-specific arguments
 Some additional arguments are available for specific providers.
+
+#### Atlas Cloud
+- `-k`, `--apikey`:
+  Your [Atlas Cloud API key](https://www.atlascloud.ai/console/api-keys) (the app will look for `ATLASCLOUD_API_KEY` in the environment if this is not provided)
+
+- `-m`, `--model`:
+  Specify the Atlas Cloud model ID to use for translation, for example `openai/gpt-4.1-mini`.
 
 #### OpenRouter
 - `-k`, `--apikey`:

--- a/tests/PySubtransTests/test_AtlasCloudProvider.py
+++ b/tests/PySubtransTests/test_AtlasCloudProvider.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from PySubtrans.Helpers.TestCases import LoggedTestCase
+from PySubtrans.Providers.Clients.AtlasCloudClient import AtlasCloudClient
+from PySubtrans.Providers.Provider_AtlasCloud import AtlasCloudProvider
+from PySubtrans.SettingsType import SettingsType
+from PySubtrans.TranslationProvider import TranslationProvider
+
+
+class TestAtlasCloudProvider(LoggedTestCase):
+    """Tests for the Atlas Cloud provider and client."""
+
+    def test_provider_registered(self):
+        providers = TranslationProvider.get_providers()
+        self.assertLoggedIn("Atlas Cloud in providers", "Atlas Cloud", providers)
+
+    def test_provider_creates_chat_client(self):
+        settings = SettingsType({
+            'api_key': 'test-key',
+            'model': 'openai/gpt-4.1-mini',
+        })
+        provider = AtlasCloudProvider(settings)
+        client = provider.GetTranslationClient(SettingsType({'instructions': 'Translate the subtitles.'}))
+
+        self.assertLoggedIsInstance("client type", client, AtlasCloudClient)
+        self.assertLoggedEqual("API server", 'https://api.atlascloud.ai', client.server_address)
+        self.assertLoggedEqual("chat completions endpoint", '/v1/chat/completions', client.endpoint)
+        self.assertLoggedEqual("selected model", 'openai/gpt-4.1-mini', client.model)
+
+    @patch('PySubtrans.Providers.Provider_AtlasCloud.httpx.Client')
+    def test_available_models_uses_atlas_catalog(self, mock_client_class : MagicMock):
+        response = MagicMock()
+        response.is_error = False
+        response.json.return_value = {
+            'data': [
+                {'id': 'openai/gpt-4.1-mini'},
+                {'id': 'anthropic/claude-sonnet-4'},
+            ]
+        }
+        mock_client_class.return_value.__enter__.return_value.get.return_value = response
+        provider = AtlasCloudProvider(SettingsType({'api_key': 'test-key'}))
+
+        models = provider.GetAvailableModels()
+
+        self.assertLoggedEqual(
+            "sorted Atlas model catalog",
+            ['anthropic/claude-sonnet-4', 'openai/gpt-4.1-mini'],
+            models,
+        )
+        mock_client_class.return_value.__enter__.return_value.get.assert_called_once_with(
+            'https://api.atlascloud.ai/v1/models',
+            headers={'Authorization': 'Bearer test-key'},
+        )
+
+    def test_missing_api_key_fails_validation(self):
+        with patch.dict('os.environ', {}, clear=True):
+            provider = AtlasCloudProvider(SettingsType())
+
+        self.assertLoggedEqual("settings are invalid without API key", False, provider.ValidateSettings())
+        self.assertLoggedEqual("validation message", "API Key is required", provider.validation_message)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- add Atlas Cloud as an optional OpenAI-compatible translation provider
- load the current model catalog from the Atlas Cloud models endpoint
- route translations through Chat Completions without changing the default provider
- document API key and model configuration

## Tests

- `python -m unittest tests.PySubtransTests.test_AtlasCloudProvider` (4 passed)
- `python tests/unit_tests.py` (345 run; 2 pre-existing `test_Resources` portable-path failures reproduced on unmodified `origin/main`, 28 skipped)
- `git diff --check`
- live Atlas Cloud model catalog check and one Chat Completions smoke request using `openai/gpt-4.1-mini`

Type checking could not be run because fetching `pyright` from PyPI failed during TLS negotiation.